### PR TITLE
Ajout d'une commande CLI pour importer les images

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -6,14 +6,26 @@ require __DIR__."/../vendor/autoload.php";
 
 use Biblys\Database\Connection;
 use Biblys\Service\Config;
+use Biblys\Service\CurrentSite;
+use Biblys\Service\Images\ImagesService;
 use Command\CreateSeedsCommand;
+use Command\ImportImagesCommand;
 use Command\ResetDatabaseCommand;
 use Symfony\Component\Console\Application;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Finder\Finder;
 
 $config = Config::load();
 Connection::initPropel($config);
 
+$config = Config::load();
+$finder = new Finder();
+$currentSite = CurrentSite::buildFromConfig($config);
+$filesystem = new Filesystem();
+$imagesServices = new ImagesService($config, $currentSite, $filesystem);
+
 $application = new Application();
+$application->add(new ImportImagesCommand($config, $finder, $filesystem, $imagesServices));
 $application->add(new ResetDatabaseCommand());
 $application->add(new CreateSeedsCommand());
 $application->run();

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
     "propel:migrate": "vendor/bin/propel migrate",
     "db:reset": "bin/console db:reset",
     "db:seed": "bin/console db:seed",
-    "db:prepare": ["@db:reset", "@db:seed"]
+    "db:prepare": ["@db:reset", "@db:seed"],
+    "images:import": "bin/console images:import"
   },
   "require": {
     "php": "~8.1",

--- a/src/Biblys/Service/Images/ImagesService.php
+++ b/src/Biblys/Service/Images/ImagesService.php
@@ -110,25 +110,35 @@ class ImagesService
             return null;
         }
 
-        $baseUrl = rtrim($this->baseUrl, "/");
-        $filePath = trim($image->getFilepath(), "/");
-        $filename = trim($image->getFilename(), "/");
+        $url = "$this->baseUrl/{$image->getFilepath()}/{$image->getFilename()}";
+        $normalizedUrl = $this->_removeDuplicateSlashes($url);
         $version = $image->getVersion() > 1 ? "?v={$image->getVersion()}" : "";
+        return $normalizedUrl . $version;
+    }
 
-        return "$baseUrl/$filePath/$filename$version";
+    public function getCoverPathForArticle(Article $article): ?string
+    {
+        $image = $this->_getCoverImageForArticle($article);
+        if (!$image) {
+            return null;
+        }
+
+        return $this->_buildArticleCoverImagePath($image);
     }
 
     private function _buildArticleCoverImagePath(Image $image): ?string
     {
-        return "$this->basePath/{$image->getFilepath()}/{$image->getFilename()}";
+        $path = "$this->basePath/{$image->getFilepath()}/{$image->getFilename()}";
+        return $this->_removeDuplicateSlashes($path);
     }
 
-    /**
-     * @param Article $article
-     * @return Image|null
-     */
     private function _getCoverImageForArticle(Article $article): ?Image
     {
         return ImageQuery::create()->findOneByArticleId($article->getId());
+    }
+
+    private function _removeDuplicateSlashes(string $string): string|array
+    {
+        return str_replace("//", "/", $string);
     }
 }

--- a/src/Command/ImportImagesCommand.php
+++ b/src/Command/ImportImagesCommand.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Command;
+
+use Biblys\Service\Config;
+use Biblys\Service\Images\ImagesService;
+use Biblys\Service\LoggerService;
+use Exception;
+use Model\ArticleQuery;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Finder\Finder;
+
+class ImportImagesCommand extends Command
+{
+    protected static $defaultName = 'images:import';
+
+    public function __construct(
+        private readonly Config $config,
+        private readonly Finder $finder,
+        private readonly Filesystem $filesystem,
+        private readonly ImagesService $imagesService,
+        string $name = null,
+    )
+    {
+        parent::__construct($name);
+    }
+
+    protected function configure(): void
+    {
+        $this->setDescription('Clears database and execute migrations');
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $loggerService = new LoggerService();
+
+        $coversDirectory = $this->config->get("media_path") . "/book";
+        $output->writeln(["Listing in files {$coversDirectory}…"]);
+        $loggerService->log("images-import", "info", "Listing files {$coversDirectory}…");
+
+        $coversDirectoryFullPath = __DIR__ . "/../.." . $coversDirectory;
+        $coverFiles = $this->finder
+            ->in($coversDirectoryFullPath)
+            ->files()
+            ->depth(1);
+
+        $fileCount = $coverFiles->count();
+        $output->writeln(["$fileCount files to process"]);
+        $loggerService->log("images-import", "info", "$fileCount files to process");
+
+        $progress = new ProgressBar($output, $fileCount);
+        $progress->setFormat("%current%/%max% [%bar%] %percent:3s%% (%remaining:6s%) %message%");
+        $progress->setMessage("");
+        $progress->start();
+
+        $deletedFilesCount = 0;
+        $skippedFilesCount = 0;
+        $loadedImagesCount = 0;
+        foreach ($coverFiles as $coverFile) {
+            $filePath = $coverFile->getRealPath();
+            preg_match_all('/book\/\d{2}\/(\d+)\.jpg/m', $filePath, $matches);
+            $articleId = $matches[1][0];
+            $article = ArticleQuery::create()->findPk($articleId);
+
+            if (!$article) {
+                $this->filesystem->remove($filePath);
+                $progress->setMessage("Deleted cover for inexistant article $articleId");
+                $loggerService->log("images-import", "info", "Deleted cover for inexistant article $articleId");
+                $progress->advance();
+                $deletedFilesCount++;
+                continue;
+            }
+
+            if ($this->imagesService->articleHasCoverImage($article)) {
+                $progress->setMessage("Skipped already imported cover for article $articleId ({$article->getTitle()})");
+                $loggerService->log("images-import", "info", "Ignored already imported cover for article $articleId  ({$article->getTitle()})");
+                $progress->advance();
+                $skippedFilesCount++;
+                continue;
+            }
+
+            $this->imagesService->addArticleCoverImage($article, $filePath);
+
+            $progress->setMessage("Imported cover for article $articleId ({$article->getTitle()})");
+            $loggerService->log("images-import", "info", "Imported cover for article $articleId ({$article->getTitle()})");
+            $loadedImagesCount++;
+            $progress->advance();
+        }
+
+        $progress->finish();
+
+        $output->writeln(["Loaded $loadedImagesCount images, skilled $skippedFilesCount files and deleted $deletedFilesCount files."]);
+        return 0;
+    }
+}

--- a/tests/Biblys/Service/Images/ImagesServiceTest.php
+++ b/tests/Biblys/Service/Images/ImagesServiceTest.php
@@ -247,6 +247,58 @@ class ImagesServiceTest extends TestCase
         $this->assertEquals("images/book/covers/book-cover-updated.jpeg?v=2", $coverUrl);
     }
 
+    /** ImagesService->getCoverPathForArticle */
+
+    /**
+     * @throws PropelException
+     * @throws Exception
+     */
+    public function testGetCoverPathForArticleIfItDoesNotExist(): void
+    {
+        // given
+        $site = ModelFactory::createSite();
+        $article = ModelFactory::createArticle();
+
+        $config = new Config(["media_url" => "/images/"]);
+        $currentSite = new CurrentSite($site);
+        $filesystem = Mockery::mock(Filesystem::class);
+        $service = new ImagesService($config, $currentSite, $filesystem);
+
+        // when
+        $coverUrl = $service->getCoverPathForArticle($article);
+
+        // then
+        $this->assertNull($coverUrl);
+    }
+
+    /**
+     * @throws PropelException
+     * @throws Exception
+     */
+    public function testGetCoverPathForArticleIfItExists(): void
+    {
+        // given
+        $site = ModelFactory::createSite();
+
+        $config = new Config(["media_path" => "/images/"]);
+        $currentSite = new CurrentSite($site);
+        $filesystem = Mockery::mock(Filesystem::class);
+        $service = new ImagesService($config, $currentSite, $filesystem);
+
+        $article = ModelFactory::createArticle();
+        ModelFactory::createImage(
+            article: $article,
+            filePath: "book/covers/",
+            fileName: "book-cover.jpeg",
+        );
+
+        // when
+        $coverPath = $service->getCoverPathForArticle($article);
+
+        // then
+        $this->assertStringEndsWith("/images/book/covers/book-cover.jpeg", $coverPath);
+    }
+
     /** ImagesService->deleteArticleCoverImage */
 
     /**


### PR DESCRIPTION
## Problème

Une entrée en base de données est maintenant créé lorsqu'une nouvelle image de couverture est uploadé. Mais pour les fichiers d'images déjà présent, il n'existe pas d'entrée en base, si bien qu'elles sont invisible pour le site.

## Solution

Ajouter une commande CLI `composer run images:import` pour lire les fichiers sur le disque et créer l'entrée correspondante en base.
