### PR TITLE
Afficher toutes les images de couverture à l'aide du service ImagesService

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,31 @@ Améliorations
 
 Déploiement
 
-Jouer les migrations
+1. Jouer les migrations
 
 ```shell
 composer db:migrate
+```
+
+2. Mettre à jour la configuration, en remplaçant
+
+```yaml
+media_path: public/images
+media_url: /images/
+```
+
+par
+
+```yaml
+images:
+  path: public/images
+  base_url: /images/
+```
+
+3. Importer en base les images de couverture des articles
+
+```shell
+composer images:import
 ```
 
 ## 2.82.0 (5 juin 2024)

--- a/config.example.yml
+++ b/config.example.yml
@@ -34,7 +34,7 @@ site: 1
 #  secret: abcdefghijklmnopqrstuvxyz12345678
 
 #axys:
-#    client_id: abcd1234
+#  client_id: abcd1234
 #  client_secret: efgh5678
 #  redirect_uri: http://paronymie.fr/openid/callback
 #  base_uri: https://axys.me/
@@ -51,6 +51,10 @@ site: 1
 
 ## Set HTTP Strict Transport Security to 6 months
 #hsts: true
+
+#images:
+#  path: public/images/
+#  base_url: /images/
 
 ## Path to composer home folder must be defined
 ## to allow auto-updates

--- a/controllers/common/php/article_edit.php
+++ b/controllers/common/php/article_edit.php
@@ -519,7 +519,7 @@ return function (
 
     // Couverture
     $article_cover_upload = '<input type="file" id="article_cover_upload" name="article_cover_upload" accept="image/jpeg" />';
-    if ($articleEntity->hasCover()) {
+    if ($imagesService->articleHasCoverImage($article)) {
         $article_cover_upload = '<input type="file" id="article_cover_upload" name="article_cover_upload" accept="image/jpeg" hidden /> <label class="after btn btn-default" for="article_cover_upload">Remplacer</label> <input type="checkbox" id="article_cover_delete" name="article_cover_delete" value="1" /> <label for="article_cover_delete" class="after">Supprimer</label>';
     }
 

--- a/controllers/common/php/log_myebooks.php
+++ b/controllers/common/php/log_myebooks.php
@@ -72,11 +72,6 @@ return function (
             ';
         }
 
-        $articleCoverUrl = null;
-        if ($articleEntity->hasCover()) {
-            $articleCoverUrl = $articleEntity->getCoverUrl(["size" => "h60"]);
-        }
-
         // Liens de téléchargement
         if ($articleEntity->get('pubdate') > date("Y-m-d") && !$copy->getAllowPredownload()) {
             $dl_links = 'A para&icirc;tre<br />le ' . _date($articleEntity->get('pubdate'), 'd/m');
@@ -113,7 +108,6 @@ return function (
         $ebooks[] = [
             "article" => $article,
             "updated" => $copy->isFileUpdated(),
-            "articleCoverUrl" => $articleCoverUrl,
             "dlLinks" => $dl_links,
         ];
     }

--- a/inc/Article.class.php
+++ b/inc/Article.class.php
@@ -93,6 +93,17 @@ class Article extends Entity
     }
 
     /**
+     * @throws Exception
+     */
+    public function getModel(): \Model\Article
+    {
+        $model = new \Model\Article();
+        $model->setId($this->get("id"));
+
+        return $model;
+    }
+
+    /**
      * @throws InvalidEntityFetchedException
      */
     public function validateOnFetch(): void

--- a/inc/Article.class.php
+++ b/inc/Article.class.php
@@ -269,11 +269,18 @@ class Article extends Entity
     /**
      * Get article cover
      * @throws Exception
+     * @deprecated Article->getCover is deprecated. Use ImagesService instead.
      */
     public function getCover($size = null): Media|string|null
     {
+        trigger_deprecation(
+            "biblys/biblys",
+            "2.83.0",
+            "Article->getCover is deprecated, use ImagesService instead."
+        );
+
         if (!isset($this->cover)) {
-            $this->cover = new Media('article', $this->get('id'));
+            $this->cover = new Media("article", $this->get("id"));
         }
 
         if ($size === null) {
@@ -281,28 +288,13 @@ class Article extends Entity
         }
 
         if ($size === "object") {
-            trigger_deprecation(
-                "biblys/biblys",
-                "2.53.1",
-                "Article->getCover(\"object\") is deprecated, use Article->getCover() instead."
-            );
             return $this->cover;
         }
 
         if ($size === "url") {
-            trigger_deprecation(
-                "biblys/biblys",
-                "2.53.1",
-                "Article->getCover(\"url\") is depreciated, use Article->getCoverUrl() instead."
-            );
             return $this->getCoverUrl();
         }
 
-        trigger_deprecation(
-            "biblys/biblys",
-            "2.53.1",
-            "Article->getCover(\$size) is depreciated, use Article->getCoverTag() instead."
-        );
         return $this->getCoverTag(["size" => $size]);
     }
 
@@ -310,9 +302,16 @@ class Article extends Entity
      * Returns true if article has a cover
      * @return bool
      * @throws Exception
+     * @deprecated Article->getCover is deprecated, use ImagesService instead.
      */
     public function hasCover(): bool
     {
+        trigger_deprecation(
+            "biblys/biblys",
+            "2.83.0",
+            "Article->getCover is deprecated, use ImagesService instead."
+        );
+
         $cover = $this->getCover();
         return $cover->exists();
     }
@@ -373,9 +372,16 @@ class Article extends Entity
     /**
      * Return article's cover url
      * @throws Exception
+     * @deprecated
      */
     public function getCoverUrl(array $options = []): ?string
     {
+        trigger_deprecation(
+            "biblys/biblys",
+            "2.83.0",
+            "Article->getCoverUrl is deprecated, use ImagesService instead."
+        );
+
         if (!$this->hasCover()) {
             return null;
         }

--- a/inc/Media.class.php
+++ b/inc/Media.class.php
@@ -18,6 +18,15 @@ class Media
      */
     public function __construct($type, $id)
     {
+        if ($type === "article") {
+            trigger_deprecation(
+                "biblys",
+                "2.83.0",
+                "Using Media with 'article' type is deprecated." .
+                        "Use ImagesService->getCoverUrlForArticle instead"
+            );
+        }
+
         $this->setDomain('media'); // domaine par défaut
 
         $this->setId($id);

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -72,10 +72,6 @@ function biblysPath(): string
     return __DIR__."/../";
 }
 
-// Media path
-$media_path = __DIR__."/../".$config->get("media_path");
-define('MEDIA_PATH', $media_path);
-
 // Get request
 $request = Request::createFromGlobals();
 
@@ -331,31 +327,8 @@ function media_url($type, $id, $size = '0'): string
  */
 function media_exists($type, $id): bool
 {
-    if ('article' == $type) {
-        $type = 'book';
-    }
-    if ('extrait' == $type) {
-        $ext = 'pdf';
-    } elseif ('publisher' == $type) {
-        $ext = 'png';
-    } else {
-        $ext = 'jpg';
-    }
-    $path = MEDIA_PATH . '//' . $type . '/' . file_dir($id) . '/' . $id . '.' . $ext;
-    if ('ebook-pdf' == $type) {
-        $path = __DIR__ . '/../dl/pdf/' . file_dir($id) . '/' . $id . '.pdf';
-    }
-    if ('ebook-epub' == $type) {
-        $path = __DIR__ . '/../dl/epub/' . file_dir($id) . '/' . $id . '.epub';
-    }
-    if ('ebook-azw' == $type) {
-        $path = __DIR__ . '/../dl/azw/' . file_dir($id) . '/' . $id . '.azw';
-    }
-    if (file_exists($path)) {
-        return true;
-    } else {
-        return false;
-    }
+    $media = new Media($type, $id);
+    return $media->exists();
 }
 
 function numero($x, $b = ' n&deg;&nbsp;'): string

--- a/public/common/js/common.js
+++ b/public/common/js/common.js
@@ -935,7 +935,7 @@ function reloadEvents(scope) {
     .click(function() {
       const button = $(this);
       button
-        .find('i.fa')
+        .find('.fa')
         .removeClass('fa-heart-o fa-heart red')
         .addClass('fa-spin fa-spinner');
 
@@ -954,18 +954,18 @@ function reloadEvents(scope) {
           if (data.error) {
             _alert(data.error);
             button
-              .find('i.fa')
+              .find('.fa')
               .removeClass('fa-spin fa-spinner')
               .addClass('fa-heart-o');
           } else if (data.created) {
             button
-              .find('i.fa')
+              .find('.fa')
               .removeClass('fa-spin fa-spinner')
               .addClass('fa-heart red');
             new Biblys.Notification(data.message, { type: 'success' });
           } else if (data.deleted) {
             button
-              .find('i.fa')
+              .find('.fa')
               .removeClass('fa-spin fa-spinner')
               .addClass('fa-heart-o');
             new Biblys.Notification(data.message, { type: 'success' });

--- a/src/AppBundle/Resources/views/Article/_cover.html.twig
+++ b/src/AppBundle/Resources/views/Article/_cover.html.twig
@@ -10,7 +10,12 @@
    style="cursor: {{ cursor }};"
 >
   <img
-    src="{{ article|coverUrl }}"
+    src="{{ article|coverUrl(
+      width|default(null),
+      height|default(null),
+    ) }}"
+    width="{{ width|default(null) }}"
+    height="{{ height|default(null) }}"
     {% if class is defined %} class="{{ class }}" {% endif %}
     alt="{{ article.title }}"
   >

--- a/src/AppBundle/Resources/views/Legacy/user_ebooks.html.twig
+++ b/src/AppBundle/Resources/views/Legacy/user_ebooks.html.twig
@@ -30,9 +30,9 @@
       {% for ebook in ebooks %}
         <tr class="{{ ebook.updated ? "alert alert-info" : "" }}">
           <td class="center">
-            {% if ebook.articleCoverUrl %}
+            {% if ebook.article|hasCover %}
               <a href="{{ path("article_show", { slug: ebook.article.url }) }}">
-                <img src="{{ ebook.articleCoverUrl }}" alt="{{ ebook.article.title }}" />
+                <img src="{{ ebook.article|coverUrl }}" height="100" alt="{{ ebook.article.title }}" />
               </a>
             {% endif %}
           </td>

--- a/src/Biblys/Service/Config.php
+++ b/src/Biblys/Service/Config.php
@@ -133,4 +133,14 @@ class Config
 
         return false;
     }
+
+    public function getImagesPath(): string
+    {
+        return $this->get("images.path") ?? "public/images/";
+    }
+
+    public function getImagesBaseUrl(): string
+    {
+        return $this->get("images.base_url") ?? "/images/";
+    }
 }

--- a/src/Biblys/Service/Config.php
+++ b/src/Biblys/Service/Config.php
@@ -73,10 +73,6 @@ class Config
             return 1;
         }
 
-        if ($path === "media_path") {
-            return "/public/media";
-        }
-
         if ($path === "composer_home") {
             return "~/.composer";
         }

--- a/src/Biblys/Service/Images/ImagesService.php
+++ b/src/Biblys/Service/Images/ImagesService.php
@@ -103,7 +103,12 @@ class ImagesService
         return ImageQuery::create()->filterByArticle($article)->exists();
     }
 
-    public function getCoverUrlForArticle(Article $article): ?string
+    public function getCoverUrlForArticle(
+        Article $article,
+        int $width = null,
+        int $height = null
+    ):
+    ?string
     {
         $image = $this->_getCoverImageForArticle($article);
         if (!$image) {

--- a/src/Biblys/Service/Images/ImagesService.php
+++ b/src/Biblys/Service/Images/ImagesService.php
@@ -115,10 +115,12 @@ class ImagesService
             return null;
         }
 
-        $url = "$this->baseUrl/{$image->getFilepath()}/{$image->getFilename()}";
-        $normalizedUrl = $this->_removeDuplicateSlashes($url);
+        $baseUrl = rtrim($this->baseUrl, "/");
+        $filePath = trim($image->getFilepath(), "/");
+        $fileName = trim($image->getFilename(), "/");
+        $url = "$baseUrl/$filePath/$fileName";
         $version = $image->getVersion() > 1 ? "?v={$image->getVersion()}" : "";
-        return $normalizedUrl . $version;
+        return $url . $version;
     }
 
     public function getCoverPathForArticle(Article $article): ?string

--- a/src/Biblys/Service/Images/ImagesService.php
+++ b/src/Biblys/Service/Images/ImagesService.php
@@ -24,9 +24,9 @@ class ImagesService
         private readonly Filesystem  $filesystem,
     )
     {
-        $basePathFromRoot = $this->config->get("media_path") ?: "public/images";
+        $basePathFromRoot = $this->config->getImagesPath();
         $this->basePath = __DIR__ . "/../../../../$basePathFromRoot";
-        $this->baseUrl = $this->config->get("media_url") ?: "/images/";
+        $this->baseUrl = $this->config->getImagesBaseUrl();
     }
 
     /**

--- a/src/Biblys/Service/TemplateService.php
+++ b/src/Biblys/Service/TemplateService.php
@@ -277,9 +277,14 @@ class TemplateService
             return $imagesService->articleHasCoverImage($article);
         });
 
-        $filters[] = new TwigFilter('coverUrl', function (Article $article) use($imagesService) {
-            return $imagesService->getCoverUrlForArticle($article);
-        });
+        $filters[] = new TwigFilter('coverUrl',
+            function (Article $article, array $options = []) use ($imagesService) {
+                $width = $options["width"] ?? null;
+                $height = $options["height"] ?? null;
+                return $imagesService->getCoverUrlForArticle($article, width: $width, height: $height);
+            },
+            ['is_variadic' => true]
+        );
 
         $filters[] = new TwigFilter('currency', function ($amount, $cents = false) {
             return currency($amount, $cents);

--- a/src/Command/ImportImagesCommand.php
+++ b/src/Command/ImportImagesCommand.php
@@ -41,7 +41,7 @@ class ImportImagesCommand extends Command
     {
         $loggerService = new LoggerService();
 
-        $coversDirectory = $this->config->get("media_path") . "/book";
+        $coversDirectory = $this->config->getImagesPath() . "/book";
         $output->writeln(["Listing in files {$coversDirectory}…"]);
         $loggerService->log("images-import", "info", "Listing files {$coversDirectory}…");
 

--- a/tests/AppBundle/Controller/Legacy/CartTest.php
+++ b/tests/AppBundle/Controller/Legacy/CartTest.php
@@ -2,15 +2,14 @@
 
 namespace AppBundle\Controller\Legacy;
 
-use Biblys\Legacy\LegacyCodeHelper;
 use Biblys\Service\Config;
 use Biblys\Service\CurrentSite;
 use Biblys\Service\CurrentUser;
-use Biblys\Test\EntityFactory;
+use Biblys\Service\Images\ImagesService;
+use Biblys\Service\TemplateService;
 use Biblys\Test\ModelFactory;
 use Exception;
 use Mockery;
-use Model\ArticleQuery;
 use PHPUnit\Framework\TestCase;
 use Propel\Runtime\Exception\PropelException;
 use Site;
@@ -55,9 +54,13 @@ class CartTest extends TestCase
         $currentUser->shouldReceive("getOrCreateCart")->andReturn($cart);
         $currentUser->shouldReceive("isAuthentified")->andReturn(false);
         $currentUser->shouldReceive("isAdmin")->andReturn(false);
+        $imagesService = Mockery::mock(ImagesService::class);
+        $imagesService->expects("articleHasCoverImage")->andReturn(true);
+        $templateService = Mockery::mock(TemplateService::class);
+        $templateService->expects("render");
 
         // when
-        $response = $controller($request, $config, $currentSite, $currentUser, $urlGenerator);
+        $response = $controller($request, $config, $currentSite, $currentUser, $urlGenerator, $imagesService, $templateService);
 
         // then
         $this->assertEquals(
@@ -124,9 +127,13 @@ class CartTest extends TestCase
         $currentUser->shouldReceive("isAuthentified")->andReturn(false);
         $currentUser->shouldReceive("getOrCreateCart")->andReturn($cart);
         $config = new Config();
+        $imagesService = Mockery::mock(ImagesService::class);
+        $imagesService->expects("articleHasCoverImage")->andReturn(true);
+        $templateService = Mockery::mock(TemplateService::class);
+        $templateService->expects("render");
 
         // when
-        $response = $controller($request, $config, $currentSite, $currentUser, $urlGenerator);
+        $response = $controller($request, $config, $currentSite, $currentUser, $urlGenerator, $imagesService, $templateService);
 
         // then
         $this->assertStringContainsString(
@@ -188,9 +195,13 @@ class CartTest extends TestCase
         $currentUser->shouldReceive("isAdmin")->andReturn(false);
         $currentUser->shouldReceive("isAuthentified")->andReturn(false);
         $config = new Config();
+        $imagesService = Mockery::mock(ImagesService::class);
+        $imagesService->expects("articleHasCoverImage")->andReturn(true);
+        $templateService = Mockery::mock(TemplateService::class);
+        $templateService->expects("render");
 
         // when
-        $response = $controller($request, $config, $currentSite, $currentUser, $urlGenerator);
+        $response = $controller($request, $config, $currentSite, $currentUser, $urlGenerator, $imagesService, $templateService);
 
         // then
         $this->assertStringContainsString(
@@ -258,9 +269,14 @@ class CartTest extends TestCase
         $config = Mockery::mock(Config::class);
         $config->shouldReceive("get")->with("media_path")->andReturn(null);
         $config->shouldReceive("get")->with("media_url")->andReturn(null);
+        $imagesService = Mockery::mock(ImagesService::class);
+        $imagesService->expects("articleHasCoverImage")->andReturn(true);
+        $imagesService->expects("getCoverUrlForArticle");
+        $templateService = Mockery::mock(TemplateService::class);
+        $templateService->expects("render");
 
         // when
-        $response = $controller($request, $config, $currentSite, $currentUser, $urlGenerator);
+        $response = $controller($request, $config, $currentSite, $currentUser, $urlGenerator, $imagesService, $templateService);
 
         // then
         $this->assertStringContainsString(

--- a/tests/AppBundle/Controller/Legacy/CartTest.php
+++ b/tests/AppBundle/Controller/Legacy/CartTest.php
@@ -267,8 +267,8 @@ class CartTest extends TestCase
         $currentUser->shouldReceive("isAdmin")->andReturn(false);
         $currentUser->shouldReceive("isAuthentified")->andReturn(false);
         $config = Mockery::mock(Config::class);
-        $config->shouldReceive("get")->with("media_path")->andReturn(null);
-        $config->shouldReceive("get")->with("media_url")->andReturn(null);
+        $config->shouldReceive("getImagesPath")->with()->andReturn(null);
+        $config->shouldReceive("getImagesBaseUrl")->with()->andReturn(null);
         $imagesService = Mockery::mock(ImagesService::class);
         $imagesService->expects("articleHasCoverImage")->andReturn(true);
         $imagesService->expects("getCoverUrlForArticle");

--- a/tests/ArticleTest.php
+++ b/tests/ArticleTest.php
@@ -217,19 +217,19 @@ class ArticleTest extends PHPUnit\Framework\TestCase
         $tagWithoutLink = $article->getCoverTag(['link' => false]);
 
         $this->assertMatchesRegularExpression(
-            "/<a href=\"\/media\/book\/\d+\/\d+\.jpg\" rel=\"aRel\"><img src=\"\/media\/book\/\d+\/\d+.jpg\" class=\"aClass\" alt=\"Bara Yogoi\"><\/a>/",
+            "/<a href=\"\/images\/\/book\/\d+\/\d+\.jpg\" rel=\"aRel\"><img src=\"\/images\/\/book\/\d+\/\d+.jpg\" class=\"aClass\" alt=\"Bara Yogoi\"><\/a>/",
             $tag
         );
         $this->assertMatchesRegularExpression(
-            "/<a href=\"\/media\/book\/\d+\/\d+\.jpg\" rel=\"aRel\"><img src=\"\/media\/book\/\d+\/\d+.jpg\" class=\"aClass\" alt=\"Bara Yogoi\" width=\"250\"><\/a>/",
+            "/<a href=\"\/images\/\/book\/\d+\/\d+\.jpg\" rel=\"aRel\"><img src=\"\/images\/\/book\/\d+\/\d+.jpg\" class=\"aClass\" alt=\"Bara Yogoi\" width=\"250\"><\/a>/",
             $tagWithWidth
         );
         $this->assertMatchesRegularExpression(
-            "/<a href=\"\/media\/book\/\d+\/\d+\.jpg\" rel=\"aRel\"><img src=\"\/media\/book\/\d+\/\d+.jpg\" class=\"aClass\" alt=\"Bara Yogoi\" height=\"85\"><\/a>/",
+            "/<a href=\"\/images\/\/book\/\d+\/\d+\.jpg\" rel=\"aRel\"><img src=\"\/images\/\/book\/\d+\/\d+.jpg\" class=\"aClass\" alt=\"Bara Yogoi\" height=\"85\"><\/a>/",
             $tagWithHeight
         );
         $this->assertMatchesRegularExpression(
-            "/<img src=\"\/media\/book\/\d+\/\d+\.jpg\" alt=\"Bara Yogoi\">/",
+            "/<img src=\"\/images\/\/book\/\d+\/\d+\.jpg\" alt=\"Bara Yogoi\">/",
             $tagWithoutLink
         );
     }
@@ -244,7 +244,7 @@ class ArticleTest extends PHPUnit\Framework\TestCase
         $article->getCover("object")->setExists(true);
         $url = $article->getCoverUrl();
 
-        $this->assertMatchesRegularExpression("/\/media\/book\/\d+\/\d+\.jpg/", $url);
+        $this->assertMatchesRegularExpression("/\/images\/\/book\/\d+\/\d+\.jpg/", $url);
     }
 
     /**

--- a/tests/ArticleTest.php
+++ b/tests/ArticleTest.php
@@ -24,6 +24,22 @@ class ArticleTest extends PHPUnit\Framework\TestCase
     /**
      * @throws Exception
      */
+    public function testGetModel(): void
+    {
+        // given
+        $article = new Article(["id" => 1234]);
+
+        // when
+        $model = $article->getModel();
+
+        // then
+        $this->assertInstanceOf(\Model\Article::class, $model);
+        $this->assertEquals(1234, $model->getId());
+    }
+
+    /**
+     * @throws Exception
+     */
     public function testValidateOnFetch()
     {
         // given

--- a/tests/Biblys/Legacy/CartHelpersTest.php
+++ b/tests/Biblys/Legacy/CartHelpersTest.php
@@ -3,6 +3,8 @@
 namespace Biblys\Legacy;
 
 use Biblys\Service\CurrentSite;
+use Biblys\Service\Images\ImagesService;
+use Biblys\Service\TemplateService;
 use Biblys\Test\ModelFactory;
 use DateTime;
 use Mockery;
@@ -34,11 +36,17 @@ class CartHelpersTest extends TestCase
         $currentSite = Mockery::mock(CurrentSite::class);
         $currentSite->shouldReceive("getSite")->andReturn($site);
         $urlGenerator = Mockery::mock(UrlGenerator::class);
+        $imageServices = Mockery::mock(ImagesService::class);
+        $imageServices->expects("articleHasCoverImage")->andReturn(true);
+        $templateService = Mockery::mock(TemplateService::class);
+        $templateService->expects("render");
 
         // when
         $notice = CartHelpers::getSpecialOffersNotice(
             $currentSite,
             $urlGenerator,
+            $imageServices,
+            $templateService,
             ModelFactory::createCart(site: $site),
         );
 
@@ -65,11 +73,17 @@ class CartHelpersTest extends TestCase
         $currentSite = Mockery::mock(CurrentSite::class);
         $currentSite->shouldReceive("getSite")->andReturn($site);
         $urlGenerator = Mockery::mock(UrlGenerator::class);
+        $imageServices = Mockery::mock(ImagesService::class);
+        $imageServices->expects("articleHasCoverImage")->andReturn(true);
+        $templateService = Mockery::mock(TemplateService::class);
+        $templateService->expects("render");
 
         // when
         $notice = CartHelpers::getSpecialOffersNotice(
             $currentSite,
             $urlGenerator,
+            $imageServices,
+            $templateService,
             ModelFactory::createCart(site: $site),
         );
 
@@ -96,11 +110,17 @@ class CartHelpersTest extends TestCase
         $currentSite = Mockery::mock(CurrentSite::class);
         $currentSite->shouldReceive("getSite")->andReturn($site);
         $urlGenerator = Mockery::mock(UrlGenerator::class);
+        $imageServices = Mockery::mock(ImagesService::class);
+        $imageServices->expects("articleHasCoverImage")->andReturn(true);
+        $templateService = Mockery::mock(TemplateService::class);
+        $templateService->expects("render");
 
         // when
         $notice = CartHelpers::getSpecialOffersNotice(
             $currentSite,
             $urlGenerator,
+            $imageServices,
+            $templateService,
             ModelFactory::createCart(site: $site),
         );
 
@@ -130,11 +150,18 @@ class CartHelpersTest extends TestCase
         $currentSite->shouldReceive("getSite")->andReturn($site);
         $urlGenerator = Mockery::mock(UrlGenerator::class);
         $urlGenerator->shouldReceive("generate");
+        $imageServices = Mockery::mock(ImagesService::class);
+        $imageServices->expects("articleHasCoverImage")->andReturn(true);
+        $imageServices->expects("articleHasCoverImage")->andReturn(true);
+        $templateService = Mockery::mock(TemplateService::class);
+        $templateService->expects("render");
 
         // when
         $notice = CartHelpers::getSpecialOffersNotice(
             $currentSite,
             $urlGenerator,
+            $imageServices,
+            $templateService,
             $cart,
         );
 
@@ -182,11 +209,17 @@ class CartHelpersTest extends TestCase
         $currentSite->shouldReceive("getSite")->andReturn($site);
         $urlGenerator = Mockery::mock(UrlGenerator::class);
         $urlGenerator->shouldReceive("generate");
+        $imageServices = Mockery::mock(ImagesService::class);
+        $imageServices->expects("articleHasCoverImage")->andReturn(true);
+        $templateService = Mockery::mock(TemplateService::class);
+        $templateService->expects("render");
 
         // when
         $notice = CartHelpers::getSpecialOffersNotice(
             $currentSite,
             $urlGenerator,
+            $imageServices,
+            $templateService,
             $cart,
         );
 
@@ -226,11 +259,17 @@ class CartHelpersTest extends TestCase
         $urlGenerator->shouldReceive("generate")
             ->with("cart_add_article", ["articleId" => $freeArticle->getId()])
             ->andReturn("/cart_url");
+        $imageServices = Mockery::mock(ImagesService::class);
+        $imageServices->expects("articleHasCoverImage")->andReturn(true);
+        $templateService = Mockery::mock(TemplateService::class);
+        $templateService->expects("render");
 
         // when
         $notice = CartHelpers::getSpecialOffersNotice(
             $currentSite,
             $urlGenerator,
+            $imageServices,
+            $templateService,
             $cart,
         );
 
@@ -275,11 +314,17 @@ class CartHelpersTest extends TestCase
         $urlGenerator->shouldReceive("generate")
             ->with("cart_add_article", ["articleId" => $freeArticle->getId()])
             ->andReturn("/cart_url");
+        $imageServices = Mockery::mock(ImagesService::class);
+        $imageServices->expects("articleHasCoverImage")->andReturn(true);
+        $templateService = Mockery::mock(TemplateService::class);
+        $templateService->expects("render");
 
         // when
         $notice = CartHelpers::getSpecialOffersNotice(
             $currentSite,
             $urlGenerator,
+            $imageServices,
+            $templateService,
             $cart,
         );
 

--- a/tests/Biblys/Service/ConfigTest.php
+++ b/tests/Biblys/Service/ConfigTest.php
@@ -133,6 +133,8 @@ class ConfigTest extends PHPUnit\Framework\TestCase
         $config->getAuthenticationSecret();
     }
 
+    /** isAxysEnabled */
+
     public function testIsAxysEnabledWhenDisabled(): void
     {
         // given
@@ -158,5 +160,69 @@ class ConfigTest extends PHPUnit\Framework\TestCase
 
         // then
         $this->assertTrue($isEnabled);
+    }
+
+    /** getImagesPath */
+
+    /**
+     * @throws Exception
+     */
+    public function testGetImagesPathReturnsConfigValue(): void
+    {
+        // given
+        $config = new Config(["images" => ["path" => "/path/to/images"]]);
+
+        // when
+        $path = $config->getImagesPath();
+
+        // then
+        $this->assertEquals("/path/to/images", $path);
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testGetImagesPathReturnsDefaultValue(): void
+    {
+        // given
+        $config = new Config();
+
+        // when
+        $path = $config->getImagesPath();
+
+        // then
+        $this->assertEquals("public/images/", $path);
+    }
+
+    /** getImagesBaseUrl */
+
+    /**
+     * @throws Exception
+     */
+    public function testGetImagesBaseUrlReturnsConfigValue(): void
+    {
+        // given
+        $config = new Config(["images" => ["base_url" => "https://paronymie.fr/images/"]]);
+
+        // when
+        $baseUrl = $config->getImagesBaseUrl();
+
+        // then
+        $this->assertEquals("https://paronymie.fr/images/", $baseUrl);
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testGetImagesBaseUrlReturnsDefaultValue(): void
+    {
+        // given
+        $config = new Config();
+
+        // when
+        $baseUrl = $config->getImagesBaseUrl();
+
+        // then
+        $this->assertEquals("/images/", $baseUrl);
     }
 }

--- a/tests/Biblys/Service/ConfigTest.php
+++ b/tests/Biblys/Service/ConfigTest.php
@@ -49,10 +49,10 @@ class ConfigTest extends PHPUnit\Framework\TestCase
         $config = new Config();
 
         // when
-        $option = $config->get("media_path");
+        $option = $config->get("site");
 
         // then
-        $this->assertEquals("/public/media", $option);
+        $this->assertEquals("1", $option);
     }
 
     /**

--- a/tests/Biblys/Service/Images/ImagesServiceTest.php
+++ b/tests/Biblys/Service/Images/ImagesServiceTest.php
@@ -247,6 +247,34 @@ class ImagesServiceTest extends TestCase
         $this->assertEquals("images/book/covers/book-cover-updated.jpeg?v=2", $coverUrl);
     }
 
+    /**
+     * @throws PropelException
+     * @throws Exception
+     */
+    public function testGetCoverUrlForArticleWithProtocolInBaseUrl(): void
+    {
+        // given
+        $site = ModelFactory::createSite();
+        $article = ModelFactory::createArticle();
+        ModelFactory::createImage(
+            article: $article,
+            filePath: "book/covers",
+            fileName: "book-cover-updated.jpeg",
+            version: 2,
+        );
+
+        $config = new Config(["media_url" => "https://paronymie.fr/images/"]);
+        $currentSite = new CurrentSite($site);
+        $filesystem = Mockery::mock(Filesystem::class);
+        $service = new ImagesService($config, $currentSite, $filesystem);
+
+        // when
+        $coverUrl = $service->getCoverUrlForArticle($article);
+
+        // then
+        $this->assertEquals("https://paronymie.fr/images/book/covers/book-cover-updated.jpeg?v=2", $coverUrl);
+    }
+
     /** ImagesService->getCoverPathForArticle */
 
     /**

--- a/tests/Biblys/Service/Images/ImagesServiceTest.php
+++ b/tests/Biblys/Service/Images/ImagesServiceTest.php
@@ -177,7 +177,7 @@ class ImagesServiceTest extends TestCase
         $site = ModelFactory::createSite();
         $article = ModelFactory::createArticle();
 
-        $config = new Config(["media_url" => "/images/"]);
+        $config = new Config(["images" => ["path" => "/images/"]]);
         $currentSite = new CurrentSite($site);
         $filesystem = Mockery::mock(Filesystem::class);
         $service = new ImagesService($config, $currentSite, $filesystem);
@@ -199,7 +199,7 @@ class ImagesServiceTest extends TestCase
         // given
         $site = ModelFactory::createSite();
 
-        $config = new Config(["media_url" => "/images/"]);
+        $config = new Config(["images" => ["base_url" => "/images/"]]);
         $currentSite = new CurrentSite($site);
         $filesystem = Mockery::mock(Filesystem::class);
         $service = new ImagesService($config, $currentSite, $filesystem);
@@ -234,7 +234,7 @@ class ImagesServiceTest extends TestCase
             version: 2,
         );
 
-        $config = new Config(["media_url" => "images/"]);
+        $config = new Config(["images" => ["base_url" => "images/"]]);
         $currentSite = new CurrentSite($site);
         $filesystem = Mockery::mock(Filesystem::class);
         $service = new ImagesService($config, $currentSite, $filesystem);
@@ -263,7 +263,7 @@ class ImagesServiceTest extends TestCase
             version: 2,
         );
 
-        $config = new Config(["media_url" => "https://paronymie.fr/images/"]);
+        $config = new Config(["images" => ["base_url" => "https://paronymie.fr/images/"]]);
         $currentSite = new CurrentSite($site);
         $filesystem = Mockery::mock(Filesystem::class);
         $service = new ImagesService($config, $currentSite, $filesystem);
@@ -287,7 +287,7 @@ class ImagesServiceTest extends TestCase
         $site = ModelFactory::createSite();
         $article = ModelFactory::createArticle();
 
-        $config = new Config(["media_url" => "/images/"]);
+        $config = new Config(["images" => ["base_url" => "/images/"]]);
         $currentSite = new CurrentSite($site);
         $filesystem = Mockery::mock(Filesystem::class);
         $service = new ImagesService($config, $currentSite, $filesystem);
@@ -308,7 +308,7 @@ class ImagesServiceTest extends TestCase
         // given
         $site = ModelFactory::createSite();
 
-        $config = new Config(["media_path" => "/images/"]);
+        $config = new Config(["images" => ["path" => "/images/"]]);
         $currentSite = new CurrentSite($site);
         $filesystem = Mockery::mock(Filesystem::class);
         $service = new ImagesService($config, $currentSite, $filesystem);

--- a/tests/PostTest.php
+++ b/tests/PostTest.php
@@ -94,7 +94,7 @@ class PostTest extends PHPUnit\Framework\TestCase
         $post = $pm->create(["post_illustration_legend" => "Une belle image"]);
         $tag = $post->getIllustrationTag();
 
-        $this->assertMatchesRegularExpression('/<img src="\/media\/post\/\d+\/\d+\.jpg" alt="Une belle image" class="illustration">/', $tag);
+        $this->assertMatchesRegularExpression('/<img src="\/images\/\/post\/\d+\/\d+\.jpg" alt="Une belle image" class="illustration">/', $tag);
     }
 
     public function testGetIllustrationUrl()
@@ -106,7 +106,7 @@ class PostTest extends PHPUnit\Framework\TestCase
         $url = $post->getIllustrationUrl();
 
         // then
-        $this->assertEquals("/media/post/01/1.jpg", $url);
+        $this->assertEquals("/images//post/01/1.jpg", $url);
     }
 
     public function testGetIllustrationUrlWithVersion()
@@ -118,7 +118,7 @@ class PostTest extends PHPUnit\Framework\TestCase
         $url = $post->getIllustrationUrl();
 
         // then
-        $this->assertEquals("/media/post/01/1.jpg?v=3", $url);
+        $this->assertEquals("/images//post/01/1.jpg?v=3", $url);
     }
 
     /**
@@ -131,7 +131,7 @@ class PostTest extends PHPUnit\Framework\TestCase
         $post = $pm->create(["post_illustration_legend" => "Une belle image"]);
         $tag = $post->getIllustrationTag(height: 60);
 
-        $this->assertMatchesRegularExpression('/<img src="\/media\/post\/\d+\/\d+\.jpg" alt="Une belle image" height=60 class="illustration">/', $tag);
+        $this->assertMatchesRegularExpression('/<img src="\/images\/\/post\/\d+\/\d+\.jpg" alt="Une belle image" height=60 class="illustration">/', $tag);
     }
 
     /**


### PR DESCRIPTION
## Problème

Aujourd'hui, pour savoir si un article a une image de couverture associé, la classe `Media` doit vérifier la présence d'un fichier sur le disque.

## Solution

Remplacer tous les usages de `Media` par le service ImagesService qui peut vérifier en base de données si l'article a une couverture associée.