### PR TITLE
Ajouter une page "Espace disque"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ Améliorations
 - Pour prévenir toute confusion, les articles physiques à expédier et les 
   articles numériques à télécharger sont désormais clairement distingués 
   dans le panier.
-- Une entrée est désormais créé en base de données pour chaque couverture 
-  d'articles, ce qui permet d'en faciliter la gestion.
+- Une page nouvelle page "Espace disque" dans l'administration permet de 
+  connaître l'espace disque occupé par les images (pour l'instant uniquement 
+  les images de couvertures des articles).
 
 Déploiement
 

--- a/src/AppBundle/Controller/MaintenanceController.php
+++ b/src/AppBundle/Controller/MaintenanceController.php
@@ -2,8 +2,16 @@
 
 namespace AppBundle\Controller;
 
+use Biblys\Service\CurrentUser;
+use Biblys\Service\TemplateService;
 use Framework\Controller;
+use Model\ImageQuery;
+use Propel\Runtime\Exception\PropelException;
 use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Twig\Error\LoaderError;
+use Twig\Error\RuntimeError;
+use Twig\Error\SyntaxError;
 
 class MaintenanceController extends Controller
 {
@@ -12,5 +20,42 @@ class MaintenanceController extends Controller
         return new JsonResponse([
             'version' => BIBLYS_VERSION,
         ]);
+    }
+
+    /**
+     * @throws LoaderError
+     * @throws RuntimeError
+     * @throws SyntaxError
+     * @throws PropelException
+     */
+    public function diskUsageAction(
+        CurrentUser     $currentUser,
+        TemplateService $templateService,
+    ): Response
+    {
+        $currentUser->authAdmin();
+
+        $articles = ImageQuery::create()
+            ->filterByType("cover")
+            ->withColumn('SUM(`fileSize`)', 'total')
+            ->select(['total'])
+            ->find()
+            ->getData()[0];
+
+        $total = ImageQuery::create()
+            ->withColumn('SUM(`fileSize`)', 'total')
+            ->select(['total'])
+            ->find()
+            ->getData()[0];
+
+        return $templateService->renderResponse("AppBundle:Maintenance:disk-usage.html.twig", [
+            "articles" => $this->_convertToGigabytes($articles),
+            "total" => $this->_convertToGigabytes($total),
+        ]);
+    }
+
+    private function _convertToGigabytes(mixed $bytes): float
+    {
+        return number_format($bytes / 1073741824, 3);
     }
 }

--- a/src/AppBundle/Resources/views/Maintenance/disk-usage.html.twig
+++ b/src/AppBundle/Resources/views/Maintenance/disk-usage.html.twig
@@ -1,0 +1,30 @@
+{% extends "layout:base.html.twig" %}
+
+{% block title %}
+  Espace disque
+{% endblock %}
+
+{% block main %}
+  <h1><span class="fa fa-database"></span> Espace disque</h1>
+
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <th>Fichiers</th>
+        <th>Taille</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Articles</td>
+        <td>{{ articles }} Go</td>
+      </tr>
+    </tbody>
+    <tfoot>
+      <tr>
+        <th>Total :</th>
+        <th>{{ total }} Go</th>
+      </tr>
+    </tfoot>
+  </table>
+{% endblock %}

--- a/src/AppBundle/routes.yml
+++ b/src/AppBundle/routes.yml
@@ -4,6 +4,10 @@ maintenance_infos:
   path: /biblys/infos
   controller: AppBundle\Controller\MaintenanceController::infosAction
 
+maintenance_disk_usage:
+  path: /admin/disk-usage
+  controller: AppBundle\Controller\MaintenanceController::diskUsageAction
+
 # Main
 
 main_home:

--- a/src/Biblys/Admin/Entry.php
+++ b/src/Biblys/Admin/Entry.php
@@ -235,6 +235,7 @@ class Entry
 
         $entries = self::_addAnalyticsLinks($config, $entries);
 
+        $entries[] = new Entry('Espace disque', ['category' => 'site', 'path' => 'maintenance_disk_usage', 'icon' => 'database']);
         $entries[] = new Entry('Options', ['category' => 'site', 'path' => 'site_options', 'icon' => 'cogs']);
         $entries[] = new Entry('Valeurs par défaut', ['category' => 'site', 'path' => 'site_default_values', 'icon' => 'pencil-square-o']);
         $entries[] = new Entry('Éditeur de thème', ['category' => 'site', 'path' => 'template_index', 'icon' => 'code']);

--- a/src/Biblys/Test/ModelFactory.php
+++ b/src/Biblys/Test/ModelFactory.php
@@ -791,6 +791,7 @@ class ModelFactory
         string $type = null,
         string $filePath = "/images/",
         string $fileName = "image.jpg",
+        int $fileSize = 100,
         int $version = 1,
     ): Image
     {
@@ -799,6 +800,7 @@ class ModelFactory
         $image->setArticle($article);
         $image->setFilePath($filePath);
         $image->setFileName($fileName);
+        $image->setFileSize($fileSize);
         $image->setVersion($version);
         $image->save();
 

--- a/src/Command/ImportImagesCommand.php
+++ b/src/Command/ImportImagesCommand.php
@@ -96,7 +96,7 @@ class ImportImagesCommand extends Command
 
         $progress->finish();
 
-        $output->writeln(["Loaded $loadedImagesCount images, skilled $skippedFilesCount files and deleted $deletedFilesCount files."]);
+        $output->writeln(["Loaded $loadedImagesCount images, skipped $skippedFilesCount files and deleted $deletedFilesCount files."]);
         return 0;
     }
 }

--- a/tests/AppBundle/Controller/MaintenanceControllerTest.php
+++ b/tests/AppBundle/Controller/MaintenanceControllerTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace AppBundle\Controller;
+
+use Biblys\Service\CurrentUser;
+use Biblys\Service\TemplateService;
+use Biblys\Test\ModelFactory;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+use Propel\Runtime\Exception\PropelException;
+use Symfony\Component\HttpFoundation\Response;
+use Twig\Error\LoaderError;
+use Twig\Error\RuntimeError;
+use Twig\Error\SyntaxError;
+
+require_once __DIR__."/../../../tests/setUp.php";
+
+class MaintenanceControllerTest extends TestCase
+{
+    /**
+     * @throws PropelException
+     * @throws LoaderError
+     * @throws RuntimeError
+     * @throws SyntaxError
+     */
+    public function testDiskUsageAction(): void
+    {
+        // given
+        $controller = new MaintenanceController();
+
+        ModelFactory::createImage(type: 'cover', fileSize: 99999999);
+        ModelFactory::createImage(type: 'photo', fileSize: 99999999);
+        ModelFactory::createImage(type: 'other', fileSize: 1);
+
+        $currentUser = Mockery::mock(CurrentUser::class);
+        $currentUser->expects("authAdmin")->andReturns();
+        $templateService = Mockery::mock(TemplateService::class);
+        $templateService->expects("renderResponse")->andReturns(new Response("response"));
+
+        // when
+        $response = $controller->diskUsageAction($currentUser, $templateService);
+
+        // then
+        /** @noinspection PhpUndefinedMethodInspection */
+        $currentUser->shouldHaveReceived("authAdmin")->withNoArgs();
+        /** @noinspection PhpUndefinedMethodInspection */
+        $templateService->shouldHaveReceived("renderResponse")
+            ->with("AppBundle:Maintenance:disk-usage.html.twig", [
+                "articles" => 0.093,
+                "total" => 0.186
+            ]);
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertEquals("response", $response->getContent());
+    }
+}


### PR DESCRIPTION
## Problème

Il n'est pas possible aujourd'hui de voir dans l'espace d'admnistration l'espace disque occupé par les images.

## Solution

Calculer l'espace disque occupé par les images enregistrées dans la table images et afficher le total dans une nouvelle page de l'administration.



