### PR TITLE
Permettre à un utilisateur de rechercher dans sa bibliothèque numérique

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Améliorations
 - Pour prévenir toute confusion, les articles physiques à expédier et les 
   articles numériques à télécharger sont désormais clairement distingués 
   dans le panier.
+- Les livres affichés dans la bibliothèque numérique peuvent désormais être
+  filtrées grâce à un champ de recherche.
 - Les bibliothèques numériques contenant plus de 25 articles sont désormais 
   paginées pour en faciliter l'exploration. 
 - Une page nouvelle page "Espace disque" dans l'administration permet de 

--- a/inc/constants.php
+++ b/inc/constants.php
@@ -1,3 +1,3 @@
 <?php
 
-const BIBLYS_VERSION = "2.83.0-dev.2";
+const BIBLYS_VERSION = "2.83.0-dev.3";

--- a/public/common/css/common.css
+++ b/public/common/css/common.css
@@ -1219,15 +1219,7 @@ span.loading {
 
 /* EBOOKS */
 
-table.ebooks {
-  width: 90%;
-  border-collapse: collapse;
-}
-
-table.ebooks td {
-  padding: 10px;
-  border-bottom: 2px #ebebeb solid;
-  border-top: 2px #ebebeb solid;
+.UserLibrary td {
   vertical-align: middle;
 }
 

--- a/src/AppBundle/Resources/views/User/library.html.twig
+++ b/src/AppBundle/Resources/views/User/library.html.twig
@@ -7,8 +7,15 @@
 {% block main %}
   <h1>Ma bibliothèque numérique</h1>
 
+  {% if searchQuery %}
+    <h2>
+      Recherche de &laquo; {{ searchQuery }} &raquo;
+      <a href="{{ path("user_library") }}" class="btn btn-sm btn-default">retour</a>
+    </h2>
+  {% endif %}
+
   <p>
-    Ci-dessous, vous retrouverez la liste de tous les livres numériques achetés sur notre plateforme. Vous pouvez les
+    Ci-dessous, vous retrouverez la liste de tous les livres numériques achetés sur notre site. Vous pouvez les
     télécharger à volonté et dans le format qui vous convient.
   </p>
   <p>
@@ -16,20 +23,30 @@
     <a href="/docs/ebooks">comment télécharger et lire des livres numériques</a>.
   </p>
 
-  {% if updates_available %}
-    <br>
-    <p class="alert alert-info">
-      <span class="fa fa-refresh"></span>&nbsp;
-      Certains fichiers ont été mis à jour depuis votre dernier téléchargement.
-    </p>
-  {% endif %}
+  <form class="form-inline text-right">
+    <div class="form-group">
+      <input
+        id="library-search-query"
+        name="q"
+        class="form-control"
+        type="search"
+        placeholder="Rechercher…"
+        aria-label="Rechercher dans la bibliothèque"
+        value="{{ searchQuery }}"
+      />
+    </div>
+    <button type="submit" class="btn btn-primary" aria-label="Rechercher">
+      <span class="fa fa-search"></span>
+    </button>
+  </form>
 
   <br />
-  <table class="ebooks">
+
+  <table class="table UserLibrary">
     <tbody>
       {% for item in items %}
-        <tr class="{{ item.updated ? "alert alert-info" : "" }}">
-          <td class="center">
+        <tr>
+          <td class="center align-middle">
             {% if item.article|hasCover %}
               <a href="{{ path("article_show", { slug: item.article.url }) }}">
                 <img src="{{ item.article|coverUrl }}" height="100" alt="{{ item.article.title }}" />
@@ -40,7 +57,7 @@
             <a href="{{ item.article.url }}">{{ item.article.title }}</a>
             <br>{{ item.article.authors }}
           </td>
-          <td class="center" style="width: 125px;">
+          <td class="center align-middle" style="width: 125px;">
             {% if not item.article.isPublished and not item.predownload_is_allowed %}
               À paraître le {{ item.article.pubdate|date('d/m') }}
             {% elseif item.downloadable_files %}
@@ -83,4 +100,12 @@
   </table>
 
   {% include 'AppBundle:Utils:_pagination.html.twig' %}
+
+  {% if updates_available %}
+    <br>
+    <p class="alert alert-info">
+      Les livres signalés par le sigle &nbsp;<span class="fa fa-refresh"></span>&nbsp; ont été mis à jour depuis votre dernier
+      téléchargement.
+    </p>
+  {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Problème

Les livres dans la bibliothèque numérique étant classés par date d'ajout à la bibliothèque, il peut être difficile de retrouver un livre précis.

## Solution

Ajouter un champ de recherche permettant de filtrer les livres affichés.