### PR TITLE
Permettre d'utiliser un CDN pour l'affichage des images

### DIFF
--- a/config.example.yml
+++ b/config.example.yml
@@ -55,6 +55,8 @@ site: 1
 #images:
 #  path: public/images/
 #  base_url: /images/
+#  cdn:
+#    service: weserv
 
 ## Path to composer home folder must be defined
 ## to allow auto-updates

--- a/src/Biblys/Service/Images/CdnService.php
+++ b/src/Biblys/Service/Images/CdnService.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Biblys\Service\Images;
+
+interface CdnService
+{
+    public function buildUrl(string $url, int $width = null, int $height = null): string;
+}

--- a/src/Biblys/Service/Images/ImagesService.php
+++ b/src/Biblys/Service/Images/ImagesService.php
@@ -120,7 +120,14 @@ class ImagesService
         $fileName = trim($image->getFilename(), "/");
         $url = "$baseUrl/$filePath/$fileName";
         $version = $image->getVersion() > 1 ? "?v={$image->getVersion()}" : "";
-        return $url . $version;
+        $urlWithVersion = $url . $version;
+
+        if ($this->config->get("images.cdn.service") === "weserv") {
+            $cdnService = new WeservCdnService();
+            return $cdnService->buildUrl(url: $urlWithVersion, width: $width, height: $height);
+        }
+
+        return $urlWithVersion;
     }
 
     public function getCoverPathForArticle(Article $article): ?string

--- a/src/Biblys/Service/Images/WeservCdnService.php
+++ b/src/Biblys/Service/Images/WeservCdnService.php
@@ -2,7 +2,7 @@
 
 namespace Biblys\Service\Images;
 
-class WeservCdnService
+class WeservCdnService implements CdnService
 {
     public function buildUrl(string $url, int $width = null, int $height = null): string
     {

--- a/src/Biblys/Service/Images/WeservCdnService.php
+++ b/src/Biblys/Service/Images/WeservCdnService.php
@@ -4,9 +4,18 @@ namespace Biblys\Service\Images;
 
 class WeservCdnService
 {
-    public function buildUrl(string $localUrl): string
+    public function buildUrl(string $url, int $width = null, int $height = null): string
     {
-        $weservOptions = ["url" => $localUrl];
+        $weservOptions = ["url" => $url];
+
+        if ($width !== null) {
+            $weservOptions["w"] = $width;
+        }
+
+        if ($height !== null) {
+            $weservOptions["h"] = $height;
+        }
+
         return "//images.weserv.nl/?".http_build_query($weservOptions);
     }
 }

--- a/src/Biblys/Service/TemplateService.php
+++ b/src/Biblys/Service/TemplateService.php
@@ -279,8 +279,8 @@ class TemplateService
 
         $filters[] = new TwigFilter('coverUrl',
             function (Article $article, array $options = []) use ($imagesService) {
-                $width = $options["width"] ?? null;
-                $height = $options["height"] ?? null;
+                $width = $options[0] ?? null;
+                $height = $options[1] ?? null;
                 return $imagesService->getCoverUrlForArticle($article, width: $width, height: $height);
             },
             ['is_variadic' => true]

--- a/tests/Biblys/Service/Images/ImagesServiceTest.php
+++ b/tests/Biblys/Service/Images/ImagesServiceTest.php
@@ -247,6 +247,43 @@ class ImagesServiceTest extends TestCase
         $this->assertEquals("images/book/covers/book-cover-updated.jpeg?v=2", $coverUrl);
     }
 
+
+    /**
+     * @throws PropelException
+     * @throws Exception
+     */
+    public function testGetCoverUrlForArticleWithCDN(): void
+    {
+        // given
+        $site = ModelFactory::createSite();
+
+        $config = new Config([
+            "images" => [
+                "base_url" => "https://paronymie.fr/images/",
+                "cdn" => ["service" => "weserv"],
+            ],
+        ]);
+        $currentSite = new CurrentSite($site);
+        $filesystem = Mockery::mock(Filesystem::class);
+        $service = new ImagesService($config, $currentSite, $filesystem);
+
+        $article = ModelFactory::createArticle();
+        ModelFactory::createImage(
+            article: $article,
+            filePath: "book/covers/",
+            fileName: "book-cover.jpeg",
+        );
+
+        // when
+        $coverUrl = $service->getCoverUrlForArticle($article);
+
+        // then
+        $this->assertEquals(
+            "//images.weserv.nl/?url=https%3A%2F%2Fparonymie.fr%2Fimages%2Fbook%2Fcovers%2Fbook-cover.jpeg",
+            $coverUrl
+        );
+    }
+
     /**
      * @throws PropelException
      * @throws Exception

--- a/tests/Biblys/Service/Images/WeservCdnServiceTest.php
+++ b/tests/Biblys/Service/Images/WeservCdnServiceTest.php
@@ -6,7 +6,6 @@ use PHPUnit\Framework\TestCase;
 
 class WeservCdnServiceTest extends TestCase
 {
-
     public function testBuildUrl()
     {
         // given
@@ -19,6 +18,40 @@ class WeservCdnServiceTest extends TestCase
         // then
         $this->assertEquals(
             "//images.weserv.nl/?url=https%3A%2F%2Fwww.biblys.fr%2Fimages%2F1955.jpg",
+            $url,
+            "builds url for Weserv CDN",
+        );
+    }
+
+    public function testBuildUrlWithWidth()
+    {
+        // given
+        $localUrl = "https://www.biblys.fr/images/1955.jpg";
+        $service = new WeservCdnService();
+
+        // when
+        $url = $service->buildUrl(url: $localUrl, width: 512);
+
+        // then
+        $this->assertEquals(
+            "//images.weserv.nl/?url=https%3A%2F%2Fwww.biblys.fr%2Fimages%2F1955.jpg&w=512",
+            $url,
+            "builds url for Weserv CDN",
+        );
+    }
+
+    public function testBuildUrlWithHeight()
+    {
+        // given
+        $localUrl = "https://www.biblys.fr/images/1955.jpg";
+        $service = new WeservCdnService();
+
+        // when
+        $url = $service->buildUrl(url: $localUrl, height: 768);
+
+        // then
+        $this->assertEquals(
+            "//images.weserv.nl/?url=https%3A%2F%2Fwww.biblys.fr%2Fimages%2F1955.jpg&h=768",
             $url,
             "builds url for Weserv CDN",
         );


### PR DESCRIPTION
## Problème

Le nouveau service `ImagesService` ne permet pas d'utiliser un CDN pour afficher les images.


## Solution

- Ajouter une option de configuration `images.cdn.service` qui lorsqu'elle a pour valeur `"weserv"` permet d'afficher les images via le CDN WeServ. 
- Utiliser une interface pour la classe WeServCdnService afin de pouvoir ajouter facilement d'autres services de CDN à l'avenir
