### PR TITLE
Ajouter un script d'optimisation des images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Historique des modifications
 
+## 2.85.1 (DEV)
+
+Améliorations
+
+- Une nouvelle commande `images:optimize` permet d'optimiser l'espace disque
+  occupée par les images en limitant la taille de leur plus grand côté à
+  2000 pixels.
+
 ## 2.84.0 (7 août 2024)
 
 Améliorations

--- a/bin/console
+++ b/bin/console
@@ -2,6 +2,10 @@
 
 <?php
 
+ini_set("display_errors", 1);
+ini_set("display_startup_errors", 1);
+error_reporting(E_ALL);
+
 require __DIR__ . "/../vendor/autoload.php";
 
 use Biblys\Database\Connection;

--- a/bin/console
+++ b/bin/console
@@ -11,6 +11,7 @@ use Biblys\Service\Images\ImagesService;
 use Biblys\Service\InvalidSiteIdException;
 use Command\CreateSeedsCommand;
 use Command\ImportImagesCommand;
+use Command\OptimizeImagesCommand;
 use Command\ResetDatabaseCommand;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Filesystem\Filesystem;
@@ -27,6 +28,7 @@ try {
     $filesystem = new Filesystem();
     $imagesServices = new ImagesService($config, $currentSite, $filesystem);
     $application->add(new ImportImagesCommand($config, $filesystem, $imagesServices));
+    $application->add(new OptimizeImagesCommand($config, $filesystem, $imagesServices));
 } catch (InvalidSiteIdException) {
 }
 

--- a/bin/console
+++ b/bin/console
@@ -2,12 +2,13 @@
 
 <?php
 
-require __DIR__."/../vendor/autoload.php";
+require __DIR__ . "/../vendor/autoload.php";
 
 use Biblys\Database\Connection;
 use Biblys\Service\Config;
 use Biblys\Service\CurrentSite;
 use Biblys\Service\Images\ImagesService;
+use Biblys\Service\InvalidSiteIdException;
 use Command\CreateSeedsCommand;
 use Command\ImportImagesCommand;
 use Command\ResetDatabaseCommand;
@@ -17,13 +18,16 @@ use Symfony\Component\Filesystem\Filesystem;
 $config = Config::load();
 Connection::initPropel($config);
 
-$config = Config::load();
-$currentSite = CurrentSite::buildFromConfig($config);
-$filesystem = new Filesystem();
-$imagesServices = new ImagesService($config, $currentSite, $filesystem);
-
 $application = new Application();
-$application->add(new ImportImagesCommand($config, $filesystem, $imagesServices));
 $application->add(new ResetDatabaseCommand());
 $application->add(new CreateSeedsCommand());
+
+try {
+    $currentSite = CurrentSite::buildFromConfig($config);
+    $filesystem = new Filesystem();
+    $imagesServices = new ImagesService($config, $currentSite, $filesystem);
+    $application->add(new ImportImagesCommand($config, $filesystem, $imagesServices));
+} catch (InvalidSiteIdException) {
+}
+
 $application->run();

--- a/composer.json
+++ b/composer.json
@@ -78,7 +78,8 @@
     "lemonink/lemonink-php": "^1.1",
     "ext-simplexml": "*",
     "ext-curl": "*",
-    "ext-fileinfo": "*"
+    "ext-fileinfo": "*",
+    "spatie/image": "^2.2"
   },
   "require-dev": {
     "phpunit/phpunit": "9.*",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
     "db:reset": "bin/console db:reset",
     "db:seed": "bin/console db:seed",
     "db:prepare": ["@db:reset", "@db:seed"],
-    "images:import": "bin/console images:import"
+    "images:import": "bin/console images:import",
+    "images:optimize": "bin/console images:optimize"
   },
   "require": {
     "php": "~8.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cc52d38c58802f80d65f35bd838254be",
+    "content-hash": "3325f70f29178c32a730ad1d256eab3a",
     "packages": [
         {
             "name": "biblys/eurotax",
@@ -1686,6 +1686,90 @@
             "time": "2024-07-18T11:15:46+00:00"
         },
         {
+            "name": "intervention/image",
+            "version": "2.7.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Intervention/image.git",
+                "reference": "04be355f8d6734c826045d02a1079ad658322dad"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Intervention/image/zipball/04be355f8d6734c826045d02a1079ad658322dad",
+                "reference": "04be355f8d6734c826045d02a1079ad658322dad",
+                "shasum": ""
+            },
+            "require": {
+                "ext-fileinfo": "*",
+                "guzzlehttp/psr7": "~1.1 || ^2.0",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "~0.9.2",
+                "phpunit/phpunit": "^4.8 || ^5.7 || ^7.5.15"
+            },
+            "suggest": {
+                "ext-gd": "to use GD library based image processing.",
+                "ext-imagick": "to use Imagick based image processing.",
+                "intervention/imagecache": "Caching extension for the Intervention Image library"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.4-dev"
+                },
+                "laravel": {
+                    "providers": [
+                        "Intervention\\Image\\ImageServiceProvider"
+                    ],
+                    "aliases": {
+                        "Image": "Intervention\\Image\\Facades\\Image"
+                    }
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Intervention\\Image\\": "src/Intervention/Image"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Oliver Vogel",
+                    "email": "oliver@intervention.io",
+                    "homepage": "https://intervention.io/"
+                }
+            ],
+            "description": "Image handling and manipulation library with support for Laravel integration",
+            "homepage": "http://image.intervention.io/",
+            "keywords": [
+                "gd",
+                "image",
+                "imagick",
+                "laravel",
+                "thumbnail",
+                "watermark"
+            ],
+            "support": {
+                "issues": "https://github.com/Intervention/image/issues",
+                "source": "https://github.com/Intervention/image/tree/2.7.2"
+            },
+            "funding": [
+                {
+                    "url": "https://paypal.me/interventionio",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/Intervention",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-05-21T17:30:32+00:00"
+        },
+        {
             "name": "ircmaxell/random-lib",
             "version": "v1.2.0",
             "source": {
@@ -1948,6 +2032,203 @@
             "time": "2024-05-24T11:04:54+00:00"
         },
         {
+            "name": "league/flysystem",
+            "version": "3.28.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/flysystem.git",
+                "reference": "e611adab2b1ae2e3072fa72d62c62f52c2bf1f0c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/e611adab2b1ae2e3072fa72d62c62f52c2bf1f0c",
+                "reference": "e611adab2b1ae2e3072fa72d62c62f52c2bf1f0c",
+                "shasum": ""
+            },
+            "require": {
+                "league/flysystem-local": "^3.0.0",
+                "league/mime-type-detection": "^1.0.0",
+                "php": "^8.0.2"
+            },
+            "conflict": {
+                "async-aws/core": "<1.19.0",
+                "async-aws/s3": "<1.14.0",
+                "aws/aws-sdk-php": "3.209.31 || 3.210.0",
+                "guzzlehttp/guzzle": "<7.0",
+                "guzzlehttp/ringphp": "<1.1.1",
+                "phpseclib/phpseclib": "3.0.15",
+                "symfony/http-client": "<5.2"
+            },
+            "require-dev": {
+                "async-aws/s3": "^1.5 || ^2.0",
+                "async-aws/simple-s3": "^1.1 || ^2.0",
+                "aws/aws-sdk-php": "^3.295.10",
+                "composer/semver": "^3.0",
+                "ext-fileinfo": "*",
+                "ext-ftp": "*",
+                "ext-mongodb": "^1.3",
+                "ext-zip": "*",
+                "friendsofphp/php-cs-fixer": "^3.5",
+                "google/cloud-storage": "^1.23",
+                "guzzlehttp/psr7": "^2.6",
+                "microsoft/azure-storage-blob": "^1.1",
+                "mongodb/mongodb": "^1.2",
+                "phpseclib/phpseclib": "^3.0.36",
+                "phpstan/phpstan": "^1.10",
+                "phpunit/phpunit": "^9.5.11|^10.0",
+                "sabre/dav": "^4.6.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "League\\Flysystem\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Frank de Jonge",
+                    "email": "info@frankdejonge.nl"
+                }
+            ],
+            "description": "File storage abstraction for PHP",
+            "keywords": [
+                "WebDAV",
+                "aws",
+                "cloud",
+                "file",
+                "files",
+                "filesystem",
+                "filesystems",
+                "ftp",
+                "s3",
+                "sftp",
+                "storage"
+            ],
+            "support": {
+                "issues": "https://github.com/thephpleague/flysystem/issues",
+                "source": "https://github.com/thephpleague/flysystem/tree/3.28.0"
+            },
+            "time": "2024-05-22T10:09:12+00:00"
+        },
+        {
+            "name": "league/flysystem-local",
+            "version": "3.28.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/flysystem-local.git",
+                "reference": "13f22ea8be526ea58c2ddff9e158ef7c296e4f40"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/flysystem-local/zipball/13f22ea8be526ea58c2ddff9e158ef7c296e4f40",
+                "reference": "13f22ea8be526ea58c2ddff9e158ef7c296e4f40",
+                "shasum": ""
+            },
+            "require": {
+                "ext-fileinfo": "*",
+                "league/flysystem": "^3.0.0",
+                "league/mime-type-detection": "^1.0.0",
+                "php": "^8.0.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "League\\Flysystem\\Local\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Frank de Jonge",
+                    "email": "info@frankdejonge.nl"
+                }
+            ],
+            "description": "Local filesystem adapter for Flysystem.",
+            "keywords": [
+                "Flysystem",
+                "file",
+                "files",
+                "filesystem",
+                "local"
+            ],
+            "support": {
+                "source": "https://github.com/thephpleague/flysystem-local/tree/3.28.0"
+            },
+            "time": "2024-05-06T20:05:52+00:00"
+        },
+        {
+            "name": "league/glide",
+            "version": "2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/glide.git",
+                "reference": "2ff92c8f1edc80b74e2d3c5efccfc7223f74d407"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/glide/zipball/2ff92c8f1edc80b74e2d3c5efccfc7223f74d407",
+                "reference": "2ff92c8f1edc80b74e2d3c5efccfc7223f74d407",
+                "shasum": ""
+            },
+            "require": {
+                "intervention/image": "^2.7",
+                "league/flysystem": "^2.0|^3.0",
+                "php": "^7.2|^8.0",
+                "psr/http-message": "^1.0|^2.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.3.3",
+                "phpunit/php-token-stream": "^3.1|^4.0",
+                "phpunit/phpunit": "^8.5|^9.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "League\\Glide\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jonathan Reinink",
+                    "email": "jonathan@reinink.ca",
+                    "homepage": "http://reinink.ca"
+                },
+                {
+                    "name": "Titouan Galopin",
+                    "email": "galopintitouan@gmail.com",
+                    "homepage": "https://titouangalopin.com"
+                }
+            ],
+            "description": "Wonderfully easy on-demand image manipulation library with an HTTP based API.",
+            "homepage": "http://glide.thephpleague.com",
+            "keywords": [
+                "ImageMagick",
+                "editing",
+                "gd",
+                "image",
+                "imagick",
+                "league",
+                "manipulation",
+                "processing"
+            ],
+            "support": {
+                "issues": "https://github.com/thephpleague/glide/issues",
+                "source": "https://github.com/thephpleague/glide/tree/2.3.0"
+            },
+            "time": "2023-07-08T06:26:07+00:00"
+        },
+        {
             "name": "league/html-to-markdown",
             "version": "5.1.1",
             "source": {
@@ -2035,6 +2316,62 @@
                 }
             ],
             "time": "2023-07-12T21:21:09+00:00"
+        },
+        {
+            "name": "league/mime-type-detection",
+            "version": "1.15.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/mime-type-detection.git",
+                "reference": "ce0f4d1e8a6f4eb0ddff33f57c69c50fd09f4301"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/mime-type-detection/zipball/ce0f4d1e8a6f4eb0ddff33f57c69c50fd09f4301",
+                "reference": "ce0f4d1e8a6f4eb0ddff33f57c69c50fd09f4301",
+                "shasum": ""
+            },
+            "require": {
+                "ext-fileinfo": "*",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.2",
+                "phpstan/phpstan": "^0.12.68",
+                "phpunit/phpunit": "^8.5.8 || ^9.3 || ^10.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "League\\MimeTypeDetection\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Frank de Jonge",
+                    "email": "info@frankdejonge.nl"
+                }
+            ],
+            "description": "Mime-type detection for Flysystem",
+            "support": {
+                "issues": "https://github.com/thephpleague/mime-type-detection/issues",
+                "source": "https://github.com/thephpleague/mime-type-detection/tree/1.15.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/frankdejonge",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/league/flysystem",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-01-28T23:22:08+00:00"
         },
         {
             "name": "lemonink/lemonink-php",
@@ -3380,6 +3717,191 @@
                 "source": "https://github.com/Seldaek/phar-utils/tree/1.2.1"
             },
             "time": "2022-08-31T10:31:18+00:00"
+        },
+        {
+            "name": "spatie/image",
+            "version": "2.2.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/image.git",
+                "reference": "2f802853aab017aa615224daae1588054b5ab20e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/image/zipball/2f802853aab017aa615224daae1588054b5ab20e",
+                "reference": "2f802853aab017aa615224daae1588054b5ab20e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-exif": "*",
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "league/glide": "^2.2.2",
+                "php": "^8.0",
+                "spatie/image-optimizer": "^1.7",
+                "spatie/temporary-directory": "^1.0|^2.0",
+                "symfony/process": "^3.0|^4.0|^5.0|^6.0"
+            },
+            "require-dev": {
+                "pestphp/pest": "^1.22",
+                "phpunit/phpunit": "^9.5",
+                "symfony/var-dumper": "^4.0|^5.0|^6.0",
+                "vimeo/psalm": "^4.6"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\Image\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Freek Van der Herten",
+                    "email": "freek@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Manipulate images with an expressive API",
+            "homepage": "https://github.com/spatie/image",
+            "keywords": [
+                "image",
+                "spatie"
+            ],
+            "support": {
+                "source": "https://github.com/spatie/image/tree/2.2.7"
+            },
+            "funding": [
+                {
+                    "url": "https://spatie.be/open-source/support-us",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/spatie",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-07-24T13:54:13+00:00"
+        },
+        {
+            "name": "spatie/image-optimizer",
+            "version": "1.7.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/image-optimizer.git",
+                "reference": "43aff6725cd87bb78ccd8532633cfa8bdc962505"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/image-optimizer/zipball/43aff6725cd87bb78ccd8532633cfa8bdc962505",
+                "reference": "43aff6725cd87bb78ccd8532633cfa8bdc962505",
+                "shasum": ""
+            },
+            "require": {
+                "ext-fileinfo": "*",
+                "php": "^7.3|^8.0",
+                "psr/log": "^1.0 | ^2.0 | ^3.0",
+                "symfony/process": "^4.2|^5.0|^6.0|^7.0"
+            },
+            "require-dev": {
+                "pestphp/pest": "^1.21",
+                "phpunit/phpunit": "^8.5.21|^9.4.4",
+                "symfony/var-dumper": "^4.2|^5.0|^6.0|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\ImageOptimizer\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Freek Van der Herten",
+                    "email": "freek@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Easily optimize images using PHP",
+            "homepage": "https://github.com/spatie/image-optimizer",
+            "keywords": [
+                "image-optimizer",
+                "spatie"
+            ],
+            "support": {
+                "issues": "https://github.com/spatie/image-optimizer/issues",
+                "source": "https://github.com/spatie/image-optimizer/tree/1.7.5"
+            },
+            "time": "2024-05-16T08:48:33+00:00"
+        },
+        {
+            "name": "spatie/temporary-directory",
+            "version": "2.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/temporary-directory.git",
+                "reference": "76949fa18f8e1a7f663fd2eaa1d00e0bcea0752a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/temporary-directory/zipball/76949fa18f8e1a7f663fd2eaa1d00e0bcea0752a",
+                "reference": "76949fa18f8e1a7f663fd2eaa1d00e0bcea0752a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\TemporaryDirectory\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Alex Vanderbist",
+                    "email": "alex@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Easily create, use and destroy temporary directories",
+            "homepage": "https://github.com/spatie/temporary-directory",
+            "keywords": [
+                "php",
+                "spatie",
+                "temporary-directory"
+            ],
+            "support": {
+                "issues": "https://github.com/spatie/temporary-directory/issues",
+                "source": "https://github.com/spatie/temporary-directory/tree/2.2.1"
+            },
+            "funding": [
+                {
+                    "url": "https://spatie.be/open-source/support-us",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/spatie",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-25T11:46:58+00:00"
         },
         {
             "name": "spomky-labs/base64url",

--- a/controllers/common/php/adm_stock.php
+++ b/controllers/common/php/adm_stock.php
@@ -327,12 +327,12 @@ return function (
         // Photo
         /** @var Stock $stockEntity */
         if ($imagesService->imageExistsFor($stock)) {
-            $photoThumbnailUrl = $imagesService->getImageUrlFor($stock, width: 250);
+            $photoThumbnailUrl = $imagesService->getImageUrlFor($stock, width: 200);
             $photoUrl = $imagesService->getImageUrlFor($stock);
             $photo_field = '
             <div class="floatR center">
-                <a href="'.$photoThumbnailUrl.'" rel="lightbox">
-                    <img src="' .$photoUrl.'" alt="Photo de l‘exemplaire" width="200">
+                <a href="'.$photoUrl.'" rel="lightbox">
+                    <img src="' .$photoThumbnailUrl.'" alt="Photo de l‘exemplaire" width="200">
                 </a><br/>
                 <input type="checkbox" name="delete_photo" value="1" /> Supprimer
             </div>';

--- a/inc/constants.php
+++ b/inc/constants.php
@@ -1,3 +1,3 @@
 <?php
 
-const BIBLYS_VERSION = "2.84.0";
+const BIBLYS_VERSION = "2.85.0-dev";

--- a/src/AppBundle/Resources/views/Maintenance/disk-usage.html.twig
+++ b/src/AppBundle/Resources/views/Maintenance/disk-usage.html.twig
@@ -11,27 +11,27 @@
     <thead>
       <tr>
         <th>Type</th>
-        <th>Fichiers</th>
-        <th>Taille</th>
+        <th class="text-center">Fichiers</th>
+        <th class="text-center">Taille</th>
       </tr>
     </thead>
     <tbody>
       <tr>
         <td>Articles (images de couverture)</td>
-        <td>{{ articlesCount }}</td>
-        <td>{{ articlesSize }} Go</td>
+        <td class="text-right">{{ articlesCount }}</td>
+        <td class="text-right">{{ articlesSize }} Go</td>
       </tr>
       <tr>
         <td>Exemplaires d'occasion (photos)</td>
-        <td>{{ stockItemsCount }}</td>
-        <td>{{ stockItemsSize }} Go</td>
+        <td class="text-right">{{ stockItemsCount }}</td>
+        <td class="text-right">{{ stockItemsSize }} Go</td>
       </tr>
     </tbody>
     <tfoot>
       <tr>
-        <th>Total :</th>
-        <th>{{ totalCount }}</th>
-        <th>{{ totalSize }} Go</th>
+        <th>Total</th>
+        <th class="text-right">{{ totalCount }}</th>
+        <th class="text-right">{{ totalSize }} Go</th>
       </tr>
     </tfoot>
   </table>

--- a/src/Biblys/Service/CurrentSite.php
+++ b/src/Biblys/Service/CurrentSite.php
@@ -2,7 +2,6 @@
 
 namespace Biblys\Service;
 
-use Exception;
 use Model\Option;
 use Model\OptionQuery;
 use Model\Publisher;
@@ -38,9 +37,7 @@ class CurrentSite
     }
 
     /**
-     * @param Config $config
-     * @return CurrentSite
-     * @throws Exception
+     * @throws InvalidSiteIdException
      */
     public static function buildFromConfig(Config $config): CurrentSite
     {
@@ -48,7 +45,7 @@ class CurrentSite
 
         $site = SiteQuery::create()->findPk($siteId);
         if (!$site) {
-            throw new Exception("Unable to find site with id $siteId");
+            throw new InvalidSiteIdException("Unable to find site with id $siteId");
         }
 
         return new CurrentSite($site);

--- a/src/Biblys/Service/InvalidSiteIdException.php
+++ b/src/Biblys/Service/InvalidSiteIdException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Biblys\Service;
+
+use Exception;
+
+class InvalidSiteIdException extends Exception
+{
+}

--- a/src/Command/OptimizeImagesCommand.php
+++ b/src/Command/OptimizeImagesCommand.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Command;
+
+use Biblys\Service\Config;
+use Biblys\Service\Images\ImageForModel;
+use Biblys\Service\Images\ImagesService;
+use Biblys\Service\LoggerService;
+use Biblys\Test\ModelFactory;
+use Exception;
+use Model\ImageQuery;
+use Propel\Runtime\ActiveQuery\Criteria;
+use Spatie\Image\Image;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Filesystem\Filesystem;
+
+class OptimizeImagesCommand extends Command
+{
+    protected static $defaultName = "images:optimize";
+
+    public function __construct(
+        private readonly Config        $config,
+        private readonly Filesystem    $filesystem,
+        private readonly ImagesService $imagesService,
+        string                         $name = null,
+    )
+    {
+        parent::__construct($name);
+    }
+
+    protected function configure(): void
+    {
+        $this->setDescription("Optimizes images found in the images directory");
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $targetDimension = 2000;
+        $images = ImageQuery::create()
+            ->filterByWidth($targetDimension, Criteria::GREATER_THAN)
+            ->orderByFilesize(Criteria::DESC)
+            ->find();
+        $progressBar = new ProgressBar($output, $images->count());
+        $progressBar->setFormat("%current%/%max% [%bar%] %percent:3s%% (%remaining:6s%) %message%");
+        $progressBar->start();
+
+        $optimizedImages = 0;
+        $skippedImages = 0;
+        $spaceSaved = 0;
+
+        foreach ($images as $image) {
+            $imageForModel = new ImageForModel($this->config, $image);
+
+            if (!file_exists($imageForModel->getFilePath())) {
+                $progressBar->setMessage("Skipping not found {$image->getType()}: {$image->getFilename()}");
+                $progressBar->advance();
+                $skippedImages++;
+                continue;
+            }
+
+            $oldSizeInMB = round(filesize($imageForModel->getFilePath()) / 1024 / 1024, 2);
+
+            $optimizedImagePath = "{$imageForModel->getFilePath()}-optimized.jpg";
+            Image::load($imageForModel->getFilePath())
+                ->width($targetDimension)
+                ->height($targetDimension)
+                ->save($optimizedImagePath);
+            $newSizeInMB = round(filesize($optimizedImagePath) / 1024 / 1024, 2);
+
+            $model = $image->getArticle() ?? $image->getStockItem();
+            $this->imagesService->addImageFor($model, $optimizedImagePath);
+            $this->filesystem->remove($optimizedImagePath);
+
+            $loggerService = new LoggerService();
+            $successMessage = "Optimized {$image->getType()}: {$image->getFilename()} ($oldSizeInMB Mo > $newSizeInMB Mo)";
+            $loggerService->log("images-optimize", "info", $successMessage);
+            $progressBar->setMessage($successMessage);
+
+            $spaceSaved += $oldSizeInMB - $newSizeInMB;
+
+            $progressBar->advance();
+            $optimizedImages++;
+        }
+
+        $progressBar->finish();
+        $output->writeln("\n$optimizedImages images optimized, $skippedImages images skipped, $spaceSaved Mo saved");
+
+        return 0;
+    }
+}

--- a/src/Command/OptimizeImagesCommand.php
+++ b/src/Command/OptimizeImagesCommand.php
@@ -74,7 +74,7 @@ class OptimizeImagesCommand extends Command
             $newSizeInMB = round(filesize($optimizedImagePath) / 1024 / 1024, 2);
 
             $model = $image->getArticle() ?? $image->getStockItem();
-            $this->imagesService->addImageFor($model, $optimizedImagePath);
+//            $this->imagesService->addImageFor($model, $optimizedImagePath);
             $this->filesystem->remove($optimizedImagePath);
 
             $loggerService = new LoggerService();


### PR DESCRIPTION
## Problème

Certains sites Biblys occupent un espace disque très important à cause à la résolution inutilement élevée.

## Solution

Ajouter un script d'optimisation des images en limitant la taille du plus grand côté à 2000 pixels.

- [x] Optimiser les photos d'exemplaires
- [x] Optimiser les images de couvertures d'article

