### PR TITLE
Hotfix 2.84.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Corrections
 
+- Si un filtre éditeur est configuré, seuls les articles des éditeurs
+  concernés seront comptabilisés sur la page Espace disque.
 - Lors du paiement par chèque l'adresse d'expédition du chèque n'était plus
   affichée correctement. C'est corrigé.
 - La photo sur la page de modification d'un exemplaire s'affichait en basse

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Historique des modifications
 
+## 2.84.1 (DEV)
+
+Corrections
+
+- Lors du paiement par chèque l'adresse d'expédition du chèque n'était plus
+  affichée correctement. C'est corrigé.
+
 ## 2.84.0 (7 août 2024)
 
 Améliorations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Corrections
 
 - Lors du paiement par chèque l'adresse d'expédition du chèque n'était plus
   affichée correctement. C'est corrigé.
+- La photo sur la page de modification d'un exemplaire s'affichait en basse
+  résolution lorsqu'elle était cliquée. Ce n'est plus le cas.
+- Le script de réinitialisation de la base de données renvoyait une erreur.
+  Maintenant, ça fonctionne.
 
 ## 2.84.0 (7 août 2024)
 

--- a/bin/console
+++ b/bin/console
@@ -2,12 +2,13 @@
 
 <?php
 
-require __DIR__."/../vendor/autoload.php";
+require __DIR__ . "/../vendor/autoload.php";
 
 use Biblys\Database\Connection;
 use Biblys\Service\Config;
 use Biblys\Service\CurrentSite;
 use Biblys\Service\Images\ImagesService;
+use Biblys\Service\InvalidSiteIdException;
 use Command\CreateSeedsCommand;
 use Command\ImportImagesCommand;
 use Command\ResetDatabaseCommand;
@@ -17,13 +18,16 @@ use Symfony\Component\Filesystem\Filesystem;
 $config = Config::load();
 Connection::initPropel($config);
 
-$config = Config::load();
-$currentSite = CurrentSite::buildFromConfig($config);
-$filesystem = new Filesystem();
-$imagesServices = new ImagesService($config, $currentSite, $filesystem);
-
 $application = new Application();
-$application->add(new ImportImagesCommand($config, $filesystem, $imagesServices));
 $application->add(new ResetDatabaseCommand());
 $application->add(new CreateSeedsCommand());
+
+try {
+    $currentSite = CurrentSite::buildFromConfig($config);
+    $filesystem = new Filesystem();
+    $imagesServices = new ImagesService($config, $currentSite, $filesystem);
+    $application->add(new ImportImagesCommand($config, $filesystem, $imagesServices));
+} catch (InvalidSiteIdException) {
+}
+
 $application->run();

--- a/controllers/common/php/adm_stock.php
+++ b/controllers/common/php/adm_stock.php
@@ -327,12 +327,12 @@ return function (
         // Photo
         /** @var Stock $stockEntity */
         if ($imagesService->imageExistsFor($stock)) {
-            $photoThumbnailUrl = $imagesService->getImageUrlFor($stock, width: 250);
+            $photoThumbnailUrl = $imagesService->getImageUrlFor($stock, width: 200);
             $photoUrl = $imagesService->getImageUrlFor($stock);
             $photo_field = '
             <div class="floatR center">
-                <a href="'.$photoThumbnailUrl.'" rel="lightbox">
-                    <img src="' .$photoUrl.'" alt="Photo de l‘exemplaire" width="200">
+                <a href="'.$photoUrl.'" rel="lightbox">
+                    <img src="' .$photoThumbnailUrl.'" alt="Photo de l‘exemplaire" width="200">
                 </a><br/>
                 <input type="checkbox" name="delete_photo" value="1" /> Supprimer
             </div>';

--- a/controllers/common/php/order_payment.php
+++ b/controllers/common/php/order_payment.php
@@ -1,381 +1,349 @@
-<?php /** @noinspection HtmlUnknownTarget */
+<?php
 
+/** @noinspection PhpUnhandledExceptionInspection */
+/** @noinspection HtmlUnknownTarget */
 
 use Biblys\Legacy\LegacyCodeHelper;
 use Biblys\Service\Config;
+use Biblys\Service\CurrentSite;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Exception\ResourceNotFoundException as NotFoundException;
 
-/** @var Request $request */
+return function (Request $request, Config $config, CurrentSite $currentSite): Response|RedirectResponse
+{
+    $om = new OrderManager();
 
-$om = new OrderManager();
-$sm = new StockManager();
+    $request->attributes->set("page_title", "Commande » Paiement");
+    $content = '<h2 class="noprint">Commande » Paiement</h2>';
 
-$request->attributes->set("page_title", "Commande » Paiement");
+    $orderUrl = LegacyCodeHelper::getRouteParam("url");
+    /** @var Order $order */
+    $order = $om->get(["order_url" => $orderUrl]);
 
-$content = '<h2 class="noprint">Commande » Paiement</h2>';
+    if (!$order) {
+        throw new NotFoundException("Order $orderUrl not found.");
+    }
 
-$numerique = 0;
-$paypal = null;
-$cheque = null;
+    $paypalIsAvailable = !!$config->get("paypal");
+    $payplugIsAvailable = !!$config->get('payplug');
 
-$om = new OrderManager();
+    $stripeConfig = $config->get('stripe');
+    $stripeIsAvailable = $stripeConfig;
 
-$orderUrl = LegacyCodeHelper::getRouteParam("url");
-/** @var Order $order */
-$order = $om->get(["order_url" => $orderUrl]);
+    $nameForCheckPayment = $currentSite->getOption("name_for_check_payment", $currentSite->getTitle());
+    if ($request->getMethod() === "POST") {
 
-if (!$order) {
-    throw new NotFoundException("Order $orderUrl not found.");
-}
+        $payment_mode = $request->request->get("payment");
 
-// Is Paypal available ?
-$paypal = false;
-/** @var Config $config */
-$paypal_config = $config->get("paypal");
-if ($paypal_config) {
-    $paypal = true;
-}
+        // Update order's payment mode
+        $order->set("payment_mode", $payment_mode);
+        $om->update($order);
 
-// Is Payplug available ?
-$payplug = false;
-$payplug_config = $config->get('payplug');
-if ($payplug_config) {
-    $payplug = true;
-}
+        if ($payment_mode == "paypal" && $paypalIsAvailable) {
 
-// Is Stripe available
-$stripe = false;
-$stripeConfig = $config->get('stripe');
-if ($stripeConfig) {
-    $stripe = true;
-}
+            $url = $order->createPaypalPaymentLink();
+            return new RedirectResponse($url);
 
-$o = $order;
+        } elseif ($payment_mode == 'payplug' && $payplugIsAvailable) {
 
-if ($request->getMethod() === "POST") {
-
-    $payment_mode = $request->request->get("payment");
-
-    // Update order's payment mode
-    /** @var PDO $_SQL */
-    $update = $_SQL->prepare("UPDATE `orders` SET `order_payment_mode` = :mode WHERE `order_id` = :id LIMIT 1");
-    $update->execute(["mode" => $payment_mode, "id" => $order->get("id")]);
-
-    if ($payment_mode == "paypal" && $paypal)  {
-
-        $url = $order->createPaypalPaymentLink();
-        return new RedirectResponse($url);
-
-    } elseif ($payment_mode == 'payplug' && $payplug) {
-
-        try {
-            $payment = $order->createPayplugPayment();
-            return new RedirectResponse($payment->get("url"));
-        } catch(Payplug\Exception\BadRequestException $exception) {
-            $error = $exception->getErrorObject();
-            $content = '
-                <p class="alert alert-danger">
-                    Une erreur est survenue lors de la création du paiement via PayPlug :<br />
-                    <strong>Message : '.$error['message'].'</strong>
-                </p>
-                <pre>'.json_encode($error['details'], JSON_PRETTY_PRINT).'</pre>
-            ';
-        }
-
-    } elseif ($payment_mode == 'stripe' && $stripe) {
-
-        $payment = $order->createStripePayment();
-        $content .= '
-            <script src="https://js.stripe.com/v3/"></script>
-            <script>
-                const stripe = Stripe("'.$stripeConfig["public_key"].'");
-                stripe.redirectToCheckout({
-                    sessionId: "'.$payment->get("provider_id").'"
-                  }).then(function (result) {
-                    alert(result.error.message);
-                  });
-            </script>
-
-            <p>Redirection vers la page de paiement…</p>
-        ';
-
-    } elseif($payment_mode == "transfer") {
-
-                $content .= '
-            <p class="noprint">Pour régler votre commande par virement&nbsp;:</p>
-            <ol class="noprint">
-                <li>
-                    Effectuez un virement SEPA d\'un montant de 
-                    <strong>'.currency($order->getTotal() / 100).'</strong> 
-                    en précisant le code IBAN <strong>
-                    '.$globalSite->getOpt('payment_iban').'.</strong>
-                </li>
-                <li>
-                    Précisez <strong>votre numéro de 
-                    commande</strong> ('.$order->get('id').') dans le motif 
-                    du virement.
-                </li>
-            </ol>
-        ';
-
-    } elseif($payment_mode == "cheque") {
-
-        if($order->get('shipping_mode') == "magasin") {
-            $content .= '
-                <p>Vous avez choisi de payer votre commande en magasin.</p>
-                <p>Pour payer par chèque, merci d\'établir un chèque à l\'ordre de <strong>'.$globalSite->getNameForCheckPayment().'.</strong></p>
-                <br />
-                <p class="noprint"><a href="/payment/'.$order->get('url').'"><span class="button">&laquo; Choisir un autre mode de paiement</span></a></p>
-            ';
-        } else {
-            $shipping_fee = null;
-            if ($order->has('shipping')) {
-                $shipping_fee = '<tr><td></td><td class="right">Frais de port :</td><td class="right">'.currency($order->get('shipping') / 100).'</td></tr>';
+            try {
+                $payment = $order->createPayplugPayment();
+                return new RedirectResponse($payment->get("url"));
+            } catch (Payplug\Exception\BadRequestException $exception) {
+                $error = $exception->getErrorObject();
+                $content = '
+                    <p class="alert alert-danger">
+                        Une erreur est survenue lors de la création du paiement via PayPlug :<br />
+                        <strong>Message : ' . $error['message'] . '</strong>
+                    </p>
+                    <pre>' . json_encode($error['details'], JSON_PRETTY_PRINT) . '</pre>
+                ';
             }
 
+        } elseif ($payment_mode == 'stripe' && $stripeIsAvailable) {
+
+            $payment = $order->createStripePayment();
+            /** @noinspection JSUnresolvedReference */
             $content .= '
-                <p class="noprint">Pour régler votre commande par chèque&nbsp;:</p>
+                <script src="https://js.stripe.com/v3/"></script>
+                <script>
+                    const stripe = Stripe("' . $stripeConfig["public_key"] . '");
+                    stripe.redirectToCheckout({
+                        sessionId: "' . $payment->get("provider_id") . '"
+                      }).then(function (result) {
+                        alert(result.error.message);
+                      });
+                </script>
+    
+                <p>Redirection vers la page de paiement…</p>
+            ';
+
+        } elseif ($payment_mode == "transfer") {
+
+            $content .= '
+                <p class="noprint">Pour régler votre commande par virement&nbsp;:</p>
                 <ol class="noprint">
-                    <li>Établissez un chèque d\'un montant de <strong>'.currency($order->getTotal() / 100).'</strong> à l\'ordre de <strong>'.$globalSite->getNameForCheckPayment().'</strong>.</li>
-                    <li>Inscrivez au dos du chèque <strong>votre nom</strong> et <strong>votre numéro de commande</strong> ('.$order->get('id').') ou imprimez cette page et joignez-la 
-                     votre envoi.</li>
-                    <li>Envoyez votre chèque à l\'adresse :</li>
+                    <li>
+                        Effectuez un virement SEPA d\'un montant de 
+                        <strong>' . currency($order->getTotal() / 100) . '</strong> 
+                        en précisant le code IBAN <strong>
+                        ' . $currentSite->getOption('payment_iban') . '.</strong>
+                    </li>
+                    <li>
+                        Précisez <strong>votre numéro de 
+                        commande</strong> (' . $order->get('id') . ') dans le motif 
+                        du virement.
+                    </li>
                 </ol>
-                <p class="noprint center">
-                    '.$globalSite->get('title').'<br />
-                    '.str_replace('|','<br />',$globalSite->get('address')).'
-                </p>
-                <br />
-                <p class="noprint">
-                    <a href="/payment/'.$order->get('url').'" class="btn btn-default">» Choisir un autre mode de paiement</a>
-                </p>
+            ';
 
-                <h2>Bon de commande n° '.$order->get('id').'</h2>
+        } elseif ($payment_mode == "cheque") {
 
-                <p>
-                    '.$order->get('firstname').' '.$order->get('lastname').'<br />
-                    '.$order->get('address1').' '.$order->get('address2').'<br />
-                    '.$order->get('postalcode').' '.$order->get('city').'<br />
-                    '.($order->has('country') ? $order->get('country')->get('name') : null).'<br />
-                </p>
-                <br />
+            if ($order->get('shipping_mode') == "magasin") {
+                $content .= '
+                    <p>Vous avez choisi de payer votre commande en magasin.</p>
+                    <p>Pour payer par chèque, merci d\'établir un chèque à l\'ordre de <strong>' . $nameForCheckPayment . '.</strong></p>
+                    <br />
+                    <p class="noprint"><a href="/payment/' . $order->get('url') . '"><span class="button">&laquo; Choisir un autre mode de paiement</span></a></p>
+                ';
+            } else {
+                $content .= '
+                    <p class="noprint">Pour régler votre commande par chèque&nbsp;:</p>
+                    <ol class="noprint">
+                        <li>Établissez un chèque d\'un montant de <strong>' . currency($order->getTotal() / 100) . '</strong> à l\'ordre de <strong>' . $nameForCheckPayment . '</strong>.</li>
+                        <li>Inscrivez au dos du chèque <strong>votre nom</strong> et <strong>votre numéro de commande</strong> (' . $order->get('id') . ') ou imprimez cette page et joignez-la 
+                         votre envoi.</li>
+                        <li>Envoyez votre chèque à l\'adresse :</li>
+                    </ol>
+                    <p class="noprint center">
+                        ' . $currentSite->getTitle() . '<br />
+                        ' . str_replace('|', '<br />', $currentSite->getSite()->getAddress()) . '
+                    </p>
+                    <br />
+                    <p class="noprint">
+                        <a href="/payment/' . $order->get('url') . '" class="btn btn-default">» Choisir un autre mode de paiement</a>
+                    </p>
+    
+                    <h2>Bon de commande n° ' . $order->get('id') . '</h2>
+    
+                    <p>
+                        ' . $order->get('firstname') . ' ' . $order->get('lastname') . '<br />
+                        ' . $order->get('address1') . ' ' . $order->get('address2') . '<br />
+                        ' . $order->get('postalcode') . ' ' . $order->get('city') . '<br />
+                        ' . ($order->has('country') ? $order->get('country')->get('name') : null) . '<br />
+                    </p>
+                    <br />
+                ';
+            }
+        } else {
+            $content .= '
+                <p class="alert alert-danger">Vous devez choisir un moyen de paiement.</p>
+                <a class="btn btn-primary" href="javascript:history.back()">retour</a>
             ';
         }
-    } else {
-        $content .= '
-            <p class="alert alert-danger">Vous devez choisir un moyen de paiement.</p>
-            <a class="btn btn-primary" href="javascript:history.back()">retour</a>
-        ';
-    }
-}
-else // CHOIX DU MODE DE PAIMENT
-{
-    $payment_options = NULL;
-
-    // Disable Stripe if < 50
-    if (($stripe) && $order->getTotal() < 50) {
-        $payment_options = '
-            <p class="alert alert-warning">
-                <span class="fa fa-warning"></span>&nbsp;
-                Les commandes dont le montant total est inférieur à 0,50 €<br>
-                ne peuvent être réglés par carte bancaire.
-            </p>
-        ';
-        $stripe = false;
-    }
-
-    // Disable Payplug / Paypal if amount is < 100
-    if (($payplug || $paypal) && $order->getTotal() < 100) {
-        $payment_options = '
-            <p class="alert alert-warning">
-                <span class="fa fa-warning"></span>&nbsp;
-                Les commandes dont le montant total est inférieur à 1,00 €<br>
-                ne peuvent être réglés par carte bancaire ou Paypal.
-            </p>
-        ';
-        $payplug = false;
-        $paypal = false;
-    }
-
-    // Withdrawal
-    if ($order->get('shipping_mode') == "magasin") {
-
-        // Check
-        if ($globalSite->getOpt('payment_check')) {
-            $payment_options .= '
-                <h4 class="radio">
-                    <label for="payment_cheque" class="radio">
-                        <input type="radio" name="payment" id="payment_cheque" value="cheque" checked> 
-                        Paiement en magasin (chèque ou espèce)
-                    </label>
-                </h4>
-                <p>
-                    Payez directement en magasin, au moment du retrait de votre commande, par chèque à l\'ordre de 
-                    '.$globalSite->getNameForCheckPayment().' ou en espèces.
-                </p>
-            ';
-        }
-
-        if ($globalSite->getOpt('payment_iban')) {
-            $payment_options .= '
-                <h4 class="radio">
-                    <label for="payment_transfer" class="radio">
-                        <input type="radio" name="payment" id="payment_transfer" value="transfer"> Virement
-                    </label>
-                </h4>
-                <p>
-                    Effectuer un virement vers notre compte. Votre commande sera expédiée après apparition du virement sur notre relevé de compte.
-                </p>
-            ';
-        }
-
-        // Stripe
-        if ($stripe) {
-            $payment_options .= '
-                <h4 class="radio">
-                    <label for="payment_stripe" class="radio">
-                        <input type="radio" name="payment" id="payment_stripe" value="stripe"> 
-                        Paiement en ligne (carte bancaire)
-                    </label>
-                </h4>
-                <p>
-                    Paiement par carte bancaire via le serveur sécurisé SSL de notre partenaire Stripe.
-                </p>
-            ';
-        }
-
-        // Payplug
-        if ($payplug) {
-            $payment_options .= '
-                <h4 class="radio">
-                    <label for="payment_payplug" class="radio">
-                        <input type="radio" name="payment" id="payment_payplug" value="payplug"> 
-                        Paiement en ligne (carte bancaire)
-                    </label>
-                </h4>
-                <p>
-                    Paiement par carte bancaire via le serveur sécurisé SSL de notre partenaire PayPlug.
-                </p>
-                <img src="/common/img/payplug_cards.png" alt="PayPlug" height=50>
-            ';
-        }
-
-        // Paypal
-        if ($paypal) {
-            $payment_options .= '
-                <h4 class="radio">
-                    <label for="payment_paypal" class="radio">
-                        <input type="radio" name="payment" id="payment_paypal" value="paypal"> 
-                        Paiement en ligne (PayPal)
-                    </label>
-                </h4>
-                <p>
-                    Payez en ligne par carte bancaire via le serveur sécurisé SSL de notre partenaire PayPal.
-                </p>
-                <img src="/common/img/paypal_cards.png" alt="PayPal Acceptance Mark" height="50">
-            ';
-        }
-    }
-    else
+    } else // CHOIX DU MODE DE PAIEMENT
     {
-        // Stripe
-        if ($stripe) {
-            $payment_options .= '
-                <h4 class="radio">
-                    <label for="payment_stripe" class="radio">
-                        <input type="radio" name="payment" id="payment_stripe" value="stripe"> Carte bancaire
-                    </label>
-                </h4>
-                <p>
-                    Paiement par carte bancaire via le serveur sécurisé de notre partenaire Stripe.<br /> 
-                    Pour une expédition rapide, préférez le paiement par carte bancaire.
-                </p>
-                <a href="https://www.stripe.com/" target="_blank" rel="nooreferrer noopener">
-                    <img src="/assets/images/powered-by-stripe.png" alt="PayPlug" height=41>
-                </a>
-                <br><br>
-            ';
-        }
+        $payment_options = NULL;
 
-        // Payplug
-        if ($payplug) {
-            $payment_options .= '
-                <h4 class="radio">
-                    <label for="payment_payplug" class="radio">
-                        <input type="radio" name="payment" id="payment_payplug" value="payplug"> Carte bancaire
-                    </label>
-                </h4>
-                <p>
-                    Paiement par carte bancaire via le serveur sécurisé de notre partenaire PayPlug.<br /> 
-                    Pour une expédition rapide, préférez le paiement par carte bancaire.
-                </p>
-                <img src="/common/img/payplug_cards.png" alt="PayPlug" height=50>
-                <br><br>
-            ';
-        }
-
-        // Paypal
-        if ($paypal) {
-            $payment_options .= '
-                <h4 class="radio">
-                    <label for="payment_paypal" class="radio">
-                        <input type="radio" name="payment" id="payment_paypal" value="paypal"> PayPal
-                    </label>
-                </h4>
-                <p>
-                    Paiement par compte PayPal via le serveur sécurisé de notre partenaire PayPal.<br /> 
-                    Pour une expédition rapide, préférez le paiement par carte bancaire.
-                </p>
-                <img src="/common/img/paypal_cards.png" alt="PayPal Acceptance Mark">
-                <br><br>
-            ';
-
-        }
-
-        if ($globalSite->getOpt('payment_iban')) {
-            $payment_options .= '
-                <h4 class="radio">
-                    <label for="payment_transfer" class="radio">
-                        <input type="radio" name="payment" id="payment_transfer" value="transfer"> Virement
-                    </label>
-                </h4>
-                <p>
-                    Effectuer un virement vers notre compte. Votre commande sera expédiée après apparition du virement sur notre relevé de compte.
-                </p>
-                <br>
-            ';
-        }
-
-        if ($globalSite->getOpt('payment_check')) {
-            $payment_options .= '
-                <h4 class="radio">
-                    <label for="payment_cheque" class="radio">
-                        <input type="radio" name="payment" id="payment_cheque" value="cheque"> Chèque
-                    </label>
-                </h4>
-                <p>
-                    Expédiez un chèque à l\'ordre de '.$globalSite->getNameForCheckPayment().'. Votre commande 
-                    sera expédiée après encaissement du chèque.
+        if (($stripeIsAvailable) && $order->getTotal() < 50) {
+            $payment_options = '
+                <p class="alert alert-warning">
+                    <span class="fa fa-warning"></span>&nbsp;
+                    Les commandes dont le montant total est inférieur à 0,50 €<br>
+                    ne peuvent être réglés par carte bancaire.
                 </p>
             ';
+            $stripeIsAvailable = false;
         }
+
+        if (($payplugIsAvailable || $paypalIsAvailable) && $order->getTotal() < 100) {
+            $payment_options = '
+                <p class="alert alert-warning">
+                    <span class="fa fa-warning"></span>&nbsp;
+                    Les commandes dont le montant total est inférieur à 1,00 €<br>
+                    ne peuvent être réglés par carte bancaire ou Paypal.
+                </p>
+            ';
+            $payplugIsAvailable = false;
+            $paypalIsAvailable = false;
+        }
+
+        // Withdrawal
+        if ($order->get('shipping_mode') == "magasin") {
+
+            // Check
+            if ($currentSite->getOption('payment_check')) {
+                $payment_options .= '
+                    <h4 class="radio">
+                        <label for="payment_cheque" class="radio">
+                            <input type="radio" name="payment" id="payment_cheque" value="cheque" checked> 
+                            Paiement en magasin (chèque ou espèce)
+                        </label>
+                    </h4>
+                    <p>
+                        Payez directement en magasin, au moment du retrait de votre commande, par chèque à l\'ordre de 
+                        ' . $nameForCheckPayment . ' ou en espèces.
+                    </p>
+              ';
+            }
+
+            if ($currentSite->getOption('payment_iban')) {
+                $payment_options .= '
+                    <h4 class="radio">
+                        <label for="payment_transfer" class="radio">
+                            <input type="radio" name="payment" id="payment_transfer" value="transfer"> Virement
+                        </label>
+                    </h4>
+                    <p>
+                        Effectuer un virement vers notre compte. Votre commande sera expédiée après apparition du virement sur notre relevé de compte.
+                    </p>
+                ';
+            }
+
+            // Stripe
+            if ($stripeIsAvailable) {
+                $payment_options .= '
+                    <h4 class="radio">
+                        <label for="payment_stripe" class="radio">
+                            <input type="radio" name="payment" id="payment_stripe" value="stripe"> 
+                            Paiement en ligne (carte bancaire)
+                        </label>
+                    </h4>
+                    <p>
+                        Paiement par carte bancaire via le serveur sécurisé SSL de notre partenaire Stripe.
+                    </p>
+                ';
+            }
+
+            // PayPlug
+            if ($payplugIsAvailable) {
+                $payment_options .= '
+                    <h4 class="radio">
+                        <label for="payment_payplug" class="radio">
+                            <input type="radio" name="payment" id="payment_payplug" value="payplug"> 
+                            Paiement en ligne (carte bancaire)
+                        </label>
+                    </h4>
+                    <p>
+                        Paiement par carte bancaire via le serveur sécurisé SSL de notre partenaire PayPlug.
+                    </p>
+                    <img src="/common/img/payplug_cards.png" alt="PayPlug" height=50>
+                ';
+            }
+
+            // Paypal
+            if ($paypalIsAvailable) {
+                $payment_options .= '
+                    <h4 class="radio">
+                        <label for="payment_paypal" class="radio">
+                            <input type="radio" name="payment" id="payment_paypal" value="paypal"> 
+                            Paiement en ligne (PayPal)
+                        </label>
+                    </h4>
+                    <p>
+                        Payez en ligne par carte bancaire via le serveur sécurisé SSL de notre partenaire PayPal.
+                    </p>
+                    <img src="/common/img/paypal_cards.png" alt="PayPal Acceptance Mark" height="50">
+                ';
+            }
+        } else {
+            // Stripe
+            if ($stripeIsAvailable) {
+                $payment_options .= '
+                    <h4 class="radio">
+                        <label for="payment_stripe" class="radio">
+                            <input type="radio" name="payment" id="payment_stripe" value="stripe"> Carte bancaire
+                        </label>
+                    </h4>
+                    <p>
+                        Paiement par carte bancaire via le serveur sécurisé de notre partenaire Stripe.<br /> 
+                        Pour une expédition rapide, préférez le paiement par carte bancaire.
+                    </p>
+                    <a href="https://www.stripe.com/" target="_blank" rel="nooreferrer noopener">
+                        <img src="/assets/images/powered-by-stripe.png" alt="PayPlug" height=41>
+                    </a>
+                    <br><br>
+                ';
+            }
+
+            // Payplug
+            if ($payplugIsAvailable) {
+                $payment_options .= '
+                    <h4 class="radio">
+                        <label for="payment_payplug" class="radio">
+                            <input type="radio" name="payment" id="payment_payplug" value="payplug"> Carte bancaire
+                        </label>
+                    </h4>
+                    <p>
+                        Paiement par carte bancaire via le serveur sécurisé de notre partenaire PayPlug.<br /> 
+                        Pour une expédition rapide, préférez le paiement par carte bancaire.
+                    </p>
+                    <img src="/common/img/payplug_cards.png" alt="PayPlug" height=50>
+                    <br><br>
+                ';
+            }
+
+            // Paypal
+            if ($paypalIsAvailable) {
+                $payment_options .= '
+                    <h4 class="radio">
+                        <label for="payment_paypal" class="radio">
+                            <input type="radio" name="payment" id="payment_paypal" value="paypal"> PayPal
+                        </label>
+                    </h4>
+                    <p>
+                        Paiement par compte PayPal via le serveur sécurisé de notre partenaire PayPal.<br /> 
+                        Pour une expédition rapide, préférez le paiement par carte bancaire.
+                    </p>
+                    <img src="/common/img/paypal_cards.png" alt="PayPal Acceptance Mark">
+                    <br><br>
+                ';
+            }
+
+            if ($currentSite->getOption('payment_iban')) {
+                $payment_options .= '
+                    <h4 class="radio">
+                        <label for="payment_transfer" class="radio">
+                            <input type="radio" name="payment" id="payment_transfer" value="transfer"> Virement
+                        </label>
+                    </h4>
+                    <p>
+                        Effectuer un virement vers notre compte. Votre commande sera expédiée après apparition du virement sur notre relevé de compte.
+                    </p>
+                    <br>
+                ';
+            }
+
+            if ($currentSite->getOption('payment_check')) {
+                $payment_options .= '
+                    <h4 class="radio">
+                        <label for="payment_cheque" class="radio">
+                            <input type="radio" name="payment" id="payment_cheque" value="cheque"> Chèque
+                        </label>
+                    </h4>
+                    <p>
+                        Expédiez un chèque à l\'ordre de ' . $nameForCheckPayment . '. Votre commande 
+                        sera expédiée après encaissement du chèque.
+                    </p>
+                ';
+            }
+        }
+
+        $content .= '
+            <p class="alert alert-info">Veuillez choisir le mode de paiement pour la commande n° ' . $order->get('id') . '.<br>Montant à régler : ' . currency($order->get('amount_tobepaid') / 100) . '</p>
+    
+            <form method="post">
+                <fieldset>
+                    ' . $payment_options . '
+                    <div class="center"><br />
+                        <button type="submit" class="btn btn-primary">Poursuivre la commande</button>
+                    </div>
+                </fieldset>
+            </form>
+        ';
     }
 
-    $content .= '
-        <p class="alert alert-info">Veuillez choisir le mode de paiement pour la commande n° '.$order->get('id').'.<br>Montant à régler : '.currency($order->get('amount_tobepaid') / 100).'</p>
-
-        <form method="post">
-            <fieldset>
-                '.$payment_options.'
-                <div class="center"><br />
-                    <button type="submit" class="btn btn-primary">Poursuivre la commande</button>
-                </div>
-            </fieldset>
-        </form>
-    ';
-}
-
-return new Response($content);
+    return new Response($content);
+};

--- a/inc/constants.php
+++ b/inc/constants.php
@@ -1,3 +1,3 @@
 <?php
 
-const BIBLYS_VERSION = "2.84.0";
+const BIBLYS_VERSION = "2.84.1-dev";

--- a/src/AppBundle/Resources/views/Maintenance/disk-usage.html.twig
+++ b/src/AppBundle/Resources/views/Maintenance/disk-usage.html.twig
@@ -7,6 +7,11 @@
 {% block main %}
   <h1><span class="fa fa-database"></span> Espace disque</h1>
 
+  <p class="alert alert-warning">
+    <span class="fa fa-flask"></span>
+    Cette fonctionnalité est encore expérimentale et peut ne pas refléter exactement la réalité.
+  </p>
+
   <table class="table table-striped">
     <thead>
       <tr>


### PR DESCRIPTION
Corrections

- Si un filtre éditeur est configuré, seuls les articles des éditeurs
  concernés seront comptabilisés sur la page Espace disque.
- Lors du paiement par chèque l'adresse d'expédition du chèque n'était plus
  affichée correctement. C'est corrigé.
- La photo sur la page de modification d'un exemplaire s'affichait en basse
  résolution lorsqu'elle était cliquée. Ce n'est plus le cas.
- Le script de réinitialisation de la base de données renvoyait une erreur.
  Maintenant, ça fonctionne.
