### PR TITLE
Gérer en base de données les illustrations de billets de blog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,19 +4,22 @@
 
 ### Gestion des médias
 
-- La présentation de la page "Gestion des médias" a été améliorée, avec notamment
-  l'affichage de la taille de chaque fichier.
-- Une section médias a été installé sur la page "Espace disque".
+- La présentation de la page "Gestion des médias" a été améliorée, avec
+  notamment l'affichage de la taille de chaque fichier.
+- Des sections "Billets de blog" et "Médias" ont été ajoutées à la page "Espace
+  disque".
 - Une commande `media:import` a été ajouté pour importer des médias depuis le
   répertoire public/media.
+- La commande `images:import` gère désormais les illustrations de billets de
+  blog.
 
 ### Expérience développeur
 
-- La documentation d'installation locale de Biblys locale pour le développement
-  ([INSTALL.MD](./INSTALL.md)) a été améliorée (#81 par @HEYGUL).
-- Les pays de livraison et les langues sont désormais ajoutés à la base de données
-  lors de l'installation de Biblys, afin d'éviter une manipulation manuelle (#83
-  et #88 par @HEYGUL).
+- La documentation d'installation locale de Biblys locale pour le
+  développement ([INSTALL.MD](./INSTALL.md)) a été améliorée (#81 par @HEYGUL).
+- Les pays de livraison et les langues sont désormais ajoutés à la base de
+  données lors de l'installation de Biblys, afin d'éviter une manipulation
+  manuelle (#83 et #88 par @HEYGUL).
 
 ### Déploiement
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,19 +23,19 @@
 
 ### Déploiement
 
-1. Jouer les migrations
+#### 1. Jouer les migrations
 
 ```shell
 composer propel migrate
 ```
 
-2. Importer les médias
+#### 2. Importer les médias
 
 ```shell
 composer media:import
 ```
 
-3. Importer les illustrations de billets de blog
+#### 3. Importer les illustrations de billets de blog
 
 ```shell
 composer media:import post
@@ -53,8 +53,8 @@ Correctifs
 Améliorations
 
 - Une nouvelle page individuelle permet de consulter les informations d'un·e
-  utilisateur·ice, notamment ses méthodes de connexion.  
-- La page "Espace disque" affiche désormais la taille occupée par les 
+  utilisateur·ice, notamment ses méthodes de connexion.
+- La page "Espace disque" affiche désormais la taille occupée par les
   fichiers téléchargeables.
 - Une nouvelle commande `images:optimize` permet d'optimiser l'espace disque
   occupée par les images en limitant la taille de leur plus grand côté à
@@ -118,15 +118,15 @@ Améliorations
 
 - La validation d'une commande contenant des articles téléchargeables
   requiert maintenant l'acceptation des conditions spécifiques au numérique.
-- Pour prévenir toute confusion, les articles physiques à expédier et les 
-  articles numériques à télécharger sont désormais clairement distingués 
+- Pour prévenir toute confusion, les articles physiques à expédier et les
+  articles numériques à télécharger sont désormais clairement distingués
   dans le panier.
 - Les livres affichés dans la bibliothèque numérique peuvent désormais être
   filtrées grâce à un champ de recherche.
-- Les bibliothèques numériques contenant plus de 25 articles sont désormais 
-  paginées pour en faciliter l'exploration. 
-- Une page nouvelle page "Espace disque" dans l'administration permet de 
-  connaître l'espace disque occupé par les images (pour l'instant uniquement 
+- Les bibliothèques numériques contenant plus de 25 articles sont désormais
+  paginées pour en faciliter l'exploration.
+- Une page nouvelle page "Espace disque" dans l'administration permet de
+  connaître l'espace disque occupé par les images (pour l'instant uniquement
   les images de couvertures des articles).
 
 Déploiement
@@ -138,12 +138,12 @@ composer db:migrate
 ```
 
 \2. Mettre à jour la configuration, en remplaçant les paramètres `media_path`,
-  `media_url` et `images_cdn` :
+`media_url` et `images_cdn` :
 
 ```yaml
 media_path: public/images
 media_url: /images/
-images_cdn: 
+images_cdn:
   service: weserv
 ```
 
@@ -180,31 +180,31 @@ Utilisateurs locaux
 
 Offres spéciales
 
-- Les articles offerts dans le cadre d'une offre spéciale peuvent désormais 
+- Les articles offerts dans le cadre d'une offre spéciale peuvent désormais
   être ajoutés ou retirés du panier par le client
-- Les paniers contenant des articles liés à une offre spéciale font 
+- Les paniers contenant des articles liés à une offre spéciale font
   maintenant l'objet d'une validation au moment de la validation de commande.
 
 Autres améliorations
 
-- Un lien vers le panier apparaît désormais dans le menu supérieur, à côté 
+- Un lien vers le panier apparaît désormais dans le menu supérieur, à côté
   du lien "Mon compte".
 - Une page listant les utilisateur·ices a été ajouté à l'administration.
 
 Déploiement
 
-- Ajouter une chaine de 32 caractères aléatoire pour la valeur de l'optiond 
+- Ajouter une chaine de 32 caractères aléatoire pour la valeur de l'optiond
   configuration `authentication.secret`.
 
 ## 2.81.2 (22 mai 2024)
 
 Corrections
 
-- Dans la liste des exemplaires, le client ayant acheté un exemplaire 
+- Dans la liste des exemplaires, le client ayant acheté un exemplaire
   pouvait ne plus être affiché. C'est corrigé.
-- La page des options pouvait laisser apparaître les options des 
+- La page des options pouvait laisser apparaître les options des
   utilisateurs. Ce n'est plus le cas.
-- La mention "Déjà acheté" pouvait apparaître sur le panier pour des livres 
+- La mention "Déjà acheté" pouvait apparaître sur le panier pour des livres
   numérique n'ayant pas été acheté. C'est corrigé.
 
 Déploiement
@@ -222,10 +222,10 @@ des comptes utilisateurs locaux ont été corrigés.
 
 ## Utilisateurs locaux
 
-- Les utilisateurs sont désormais importés depuis le fournisseur d'identité 
+- Les utilisateurs sont désormais importés depuis le fournisseur d'identité
   à la première connexion et enregistrées localement.
-- Les échanges avec le fournisseur d'identité Axys se font désormais 
-  uniquement via le protocole OpenID Connect et sont conditionnés au 
+- Les échanges avec le fournisseur d'identité Axys se font désormais
+  uniquement via le protocole OpenID Connect et sont conditionnés au
   consentement de l'utilisateur.
 
 ## Autres améliorations
@@ -239,7 +239,7 @@ des comptes utilisateurs locaux ont été corrigés.
 
 Corrections
 
-- Les erreurs survenant lors de la gestion d'une commande dans 
+- Les erreurs survenant lors de la gestion d'une commande dans
   l'administration pouvaient ne pas s'afficher correctement. C'est corrigé.
 
 ## 2.80.0 (1er mai 2024)
@@ -247,10 +247,10 @@ Corrections
 Améliorations
 
 - Il est désormais possible dans le panier plusieurs offres simultanées.
-- Lors de l'accès à une page nécessitant d'être authentifié, l'utilisateur 
-  est désormais redirigé vers la page de connexion plutôt que vers une page 
+- Lors de l'accès à une page nécessitant d'être authentifié, l'utilisateur
+  est désormais redirigé vers la page de connexion plutôt que vers une page
   d'erreur.
-- Des boutons pour ajouter ou supprimer des adresses dans une liste de 
+- Des boutons pour ajouter ou supprimer des adresses dans une liste de
   contacts ont été ajoutés.
 - Un lien vers le stock des articles a été ajouté sur la page Catalogue.
 
@@ -258,23 +258,23 @@ Améliorations
 
 Corrections
 
-- L'affichage d'une page de collection pouvait déclencher une erreur si 
+- L'affichage d'une page de collection pouvait déclencher une erreur si
   l'option `articles_per_page` n'avait pas de valeur définie. C'est corrigé.
 
 ## 2.79.2 (17 avril 2024)
 
 Corrections
 
-- L'option `articles_per_page`, qui permet de spécifier le nombre d'articles 
-  à afficher sur une page, n'était pas pris en compte sur les pages de 
+- L'option `articles_per_page`, qui permet de spécifier le nombre d'articles
+  à afficher sur une page, n'était pas pris en compte sur les pages de
   collection. C'est corrigé.
 
 ## 2.79.1 (10 avril 2024)
 
 Corrections
 
-- L'entrée de valeurs trop longues pour les codes BISAC, CLIC, Dewey et 
-  Electre pouvait déclencher une erreur. Une limite de 16 caratère a été 
+- L'entrée de valeurs trop longues pour les codes BISAC, CLIC, Dewey et
+  Electre pouvait déclencher une erreur. Une limite de 16 caratère a été
   ajoutée.
 - Le lien vers la documentation des options de site a été mis à jour.
 
@@ -282,8 +282,8 @@ Corrections
 
 Offres spéciales
 
-- Il est désormais possible de créer une offre spéciale pour afficher une 
-  information dans le panier du type "Un article offert pour deux livres de 
+- Il est désormais possible de créer une offre spéciale pour afficher une
+  information dans le panier du type "Un article offert pour deux livres de
   la collection X achetés".
 
 Autres améliorations
@@ -291,7 +291,7 @@ Autres améliorations
 - Une option de site "order_phone_required" a été ajouté pour rendre
   obligatoire le numéro de téléphone lors de la validation de commande.
 - La validation des paramètres de requête lors de la recherche a été améliorée.
-- Si renseigné, le numéro de téléphone du client apparaîtra désormais sur la 
+- Si renseigné, le numéro de téléphone du client apparaîtra désormais sur la
   page de la commande
 
 ## 2.78.4 (3 avril 2024)
@@ -305,14 +305,14 @@ Corrections
 
 Corrections
 
-- Une erreur pouvait survenir sur la page d'ajout d'exemplaire si une alerte 
+- Une erreur pouvait survenir sur la page d'ajout d'exemplaire si une alerte
   était associé à un utilisateur supprimé. C'est corrigé.
 
 ## 2.78.2 (20 mars 2024)
 
 Corrections
 
-- L'état des livres d'occasion n'apparaissaient plus sur la facture. C'est 
+- L'état des livres d'occasion n'apparaissaient plus sur la facture. C'est
   corrigé.
 
 ## 2.78.1 (13 mars 2024)
@@ -1071,7 +1071,8 @@ Corrections
   "Ventes par article". C'est corrigé.
 - L'erreur affichée lors de l'enregistrement d'un modèle était laconique.
   C'est amélioré.
-- L'enregistrement du fichier de styles CSS pouvait déclencher une erreur 500. Ce
+- L'enregistrement du fichier de styles CSS pouvait déclencher une erreur 500.
+  Ce
   n'est plus le cas.
 
 ## 2.58.2 (4 février 2022)
@@ -1141,7 +1142,7 @@ le mode d'expédition "retrait en magasin" était mal enregitrée. C'est rétabl
 
 ## 2.56.2 (19 décembre 2021)
 
-Correction : Une commande pouvait être enregistrée avec des frais de port à 0 €
+Correction: Une commande pouvait être enregistrée avec des frais de port à 0 €
 si le client double-cliquait sur le bouton de validation. C'est corrigé.
 
 ## 2.56.1 (19 novembre 2021)
@@ -1561,7 +1562,7 @@ Corrections
   à nouveau
 - Les médias uploadés s'affichent correctement dans l'administration
 
-Déploiement :
+Déploiement:
 
 - Déplacer `/public/:site/media/` vers `
 
@@ -1772,7 +1773,7 @@ Déploiement
   PayPal
 - Amélioration de l'affichage des erreurs dans l'outil de gestion des commandes
 
-Déploiement :
+Déploiement:
 
 - Configurer SMTP
 - Configurer CDN images
@@ -1944,7 +1945,8 @@ Déploiement :
 - Refonte de la gestion des fournisseurs des éditeurs
 - Suppression de l'ancienne interface d'administration
 - Correction d'un bug affectant le téléchargement de fichier sur Safari iOS
-- Correction d'un bug affectant l'ajout de mots-clés sur une fiche article vierge
+- Correction d'un bug affectant l'ajout de mots-clés sur une fiche article
+  vierge
 - Correction du calcul de la TVA des articles de type 'Jeu de rôle'
 - Correction d'un bug affectant la suppression des billets
 - Correction d'un bug affectant les notifications pour les termes de recherche
@@ -2393,7 +2395,7 @@ Déploiement :
 
 ## 2.3.22 (2 octobre 2015)
 
-- Librairies : réactivation de la précommande pour les livres à paraître s'ils
+- Librairies: réactivation de la précommande pour les livres à paraître s'ils
   sont en stock
 
 ## 2.3.21 (27 septembre 2015)
@@ -2576,7 +2578,7 @@ Biblys 2.3 : Financement participatif
 
 ## 2.2.18 (1er février 2015)
 
-- Traitement par lot : application d'une promotion sur tous les exemplaires 
+- Traitement par lot : application d'une promotion sur tous les exemplaires
   d'une liste
 - Page d'inventaire : Ajout d'un filtre par type d'article
 - Il est désormais possible de lier un billet de blog à un éditeur

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,12 @@ composer propel migrate
 composer media:import
 ```
 
+3. Importer les illustrations de billets de blog
+
+```shell
+composer media:import post
+```
+
 ## 2.85.1 (11 septembre 2024)
 
 Correctifs

--- a/bin/console
+++ b/bin/console
@@ -33,7 +33,7 @@ try {
     $filesystem = new Filesystem();
     $imagesServices = new ImagesService($config, $currentSite, $filesystem);
     $application->add(new ImportImagesCommand($config, $filesystem, $imagesServices));
-    $application->add(new OptimizeImagesCommand($config, $filesystem, $imagesServices));
+    $application->add(new OptimizeImagesCommand($config, $filesystem));
     $application->add(new ImportMediaCommand($currentSite, $filesystem));
 } catch (InvalidSiteIdException) {
 }

--- a/controllers/common/php/post_edit.php
+++ b/controllers/common/php/post_edit.php
@@ -2,214 +2,218 @@
 /** @noinspection PhpPossiblePolymorphicInvocationInspection */
 /** @noinspection PhpUnhandledExceptionInspection */
 
-use Biblys\Legacy\LegacyCodeHelper;
 use Biblys\Service\Config;
 use Biblys\Service\CurrentUser;
 use Biblys\Service\Slug\SlugService;
+use Propel\Runtime\Exception\PropelException;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Generator\UrlGenerator;
 
-$globalSite = LegacyCodeHelper::getGlobalSite();
+/**
+ * @throws PropelException
+ */
+return function (
+    Request $request,
+    CurrentUser $currentUser,
+    UrlGenerator $urlGenerator,
+): Response|RedirectResponse
+{
+    $currentUser->authPublisher();
 
-if (!isset($rank)) {
-    throw new AccessDeniedHttpException("Accès réservé aux administrateurs.");
-}
+    $pm = new PostManager();
+    $content = '';
 
-$pm = new PostManager();
-$content = '';
+    if ($request->getMethod() === 'POST') {
 
-/** @var Request $request */
-if ($request->getMethod() === 'POST') {
+        // Creation d'un nouveau billet
+        $postId = $request->request->get('post_id');
+        if (!$postId) {
+            /** @var @Post $post */
+            $post = $pm->create();
+        } else {
+            /** @var @Post $post */
+            $post = $pm->getById($postId);
+        }
 
-    // Creation d'un nouveau billet
-    $postId = $request->request->get('post_id');
-    if (!$postId) {
-        /** @var @Post $post */
-        $post = $pm->create();
-    } else {
-        $update = 1;
-        /** @var @Post $post */
-        $post = $pm->getById($postId);
-    }
+        // URL de la page
+        $slugService = new SlugService();
+        $postUrl = $slugService->slugify($request->request->get('post_title'));
+        $urls = $pm->get(['post_id' => '!= ' . $post->get('id'), 'post_url' => $postUrl]);
+        if ($urls) {
+            $postUrl .= '_' . $postId;
+        }
+        $post->set('post_url', $postUrl);
 
-    // URL de la page
-    $slugService = new SlugService();
-    $postUrl = $slugService->slugify($request->request->get('post_title'));
-    $urls = $pm->get(['post_id' => '!= '.$post->get('id'), 'post_url' => $postUrl]);
-    if ($urls) {
-        $postUrl .= '_'.$postId;
-    }
-    $post->set('post_url', $postUrl);
+        // Illustration
+        $illustration = new  Media("post", $post->get("id"));
+        $illustrationVersion = $post->get("illustration_version");
+        if (!empty($_FILES["post_illustration_upload"]["tmp_name"])) {
+            $illustration->upload($_FILES["post_illustration_upload"]["tmp_name"]);
+            $illustrationVersion++;
+        } elseif (isset($_POST["post_illustration_delete"]) && $_POST['post_illustration_delete']) {
+            $illustration->delete();
+        }
+        $post->set("post_illustration_version", $illustrationVersion);
 
-    // Illustration
-    $illustration = new Media("post", $post->get("id"));
-    $illustrationVersion = $post->get("illustration_version");
-    if (!empty($_FILES["post_illustration_upload"]["tmp_name"])) {
-        $illustration->upload($_FILES["post_illustration_upload"]["tmp_name"]);
-        $illustrationVersion++;
-    } elseif (isset($_POST["post_illustration_delete"]) && $_POST['post_illustration_delete']) {
-        $illustration->delete();
-    }
-    $post->set("post_illustration_version", $illustrationVersion);
-
-    $fields = $request->request->all();
-    foreach ($fields as $field => $val) {
-        if (in_array($field, [
+        $fields = $request->request->all();
+        foreach ($fields as $field => $val) {
+            if (in_array($field, [
                 "post_id",
                 "post_url",
                 "post_url_old",
                 "post_time",
                 "post_illustration_version",
                 "post_illustration_delete",
-        ])) {
-            continue;
+            ])) {
+                continue;
+            }
+            $post->set($field, $val);
         }
-        $post->set($field, $val);
+
+        // Dates
+        $date = $request->request->get("post_date");
+        $time = $request->request->get("post_time");
+        $post->set('post_date', $date . " " . $time);
+
+        // Selected checkbox
+        $selected = $request->request->get("post_selected") ? 1 : 0;
+        $post->set('post_selected', $selected);
+
+        $post->remove("author_id");
+
+        $pm->update($post);
+
+        $postUrl = $urlGenerator->generate(
+            "post_show",
+            ["slug" => $post->get("url")]
+        );
+        return new RedirectResponse($postUrl);
+
+    } elseif (!empty($_POST) and empty($_POST["title"])) {
+        $p = $_POST;
+        $content .= '<p class="error">Erreur : Le titre du billet est obligatoire !</p>';
     }
 
-    // Dates
-    $date = $request->request->get("post_date");
-    $time = $request->request->get("post_time");
-    $post->set('post_date', $date." ".$time);
-    
-    // Selected checkbox
-    $selected = $request->request->get("post_selected") ? 1 : 0;
-    $post->set('post_selected', $selected);
+    if (!isset($_GET['id'])) $_GET['id'] = NULL;
+    $status_online = NULL;
+    $post_selected = NULL;
 
-    $post->remove("author_id");
+    $postId = $request->query->get('id');
+    $post = $pm->getById($postId);
+    $author = null;
 
-    $pm->update($post);
+    $pageTitle = 'Nouveau billet';
 
-    $postUrl = \Biblys\Legacy\LegacyCodeHelper::getGlobalUrlGenerator()->generate(
-        "post_show",
-        ["slug" => $post->get("url")]
-    );
-    return new RedirectResponse($postUrl);
+    $request = Request::createFromGlobals();
+    $config = Config::load();
+    $currentUser = CurrentUser::buildFromRequestAndConfig($request, $config);
 
-} elseif(!empty($_POST) AND empty($_POST["title"])) {
-    $p = $_POST;
-    $content .= '<p class="error">Erreur : Le titre du billet est obligatoire !</p>';
-}
+    // Valeurs par défaut pour un nouveau billet
+    $p["user_id"] = $currentUser->getUser()->getId();
+    $p["post_date"] = date("Y-m-d");
+    $p["post_time"] = date("H:i");
 
-if (!isset($_GET['id'])) $_GET['id'] = NULL;
-$status_online = NULL;
-$post_selected = NULL;
-
-$postId = $request->query->get('id');
-$post = $pm->getById($postId);
-$author = null;
-
-$pageTitle = 'Nouveau billet';
-
-$request = Request::createFromGlobals();
-$config = Config::load();
-$currentUser = CurrentUser::buildFromRequestAndConfig($request, $config);
-
-// Valeurs par defaut pour un nouveau billet
-$p["user_id"] = $currentUser->getUser()->getId();
-$p["post_date"] = date("Y-m-d");
-$p["post_time"] = date("H:i");
-
-// Auteur
-if ($currentUser->isAdmin()) {
-    $author = $currentUser->getUser()->getEmail();
-} elseif ($currentUser->hasPublisherRight()) {
-    $pum = new PublisherManager();
-    $publisherId = $currentUser->getCurrentRight()->getPublisherId();
-    $publisher = $pum->getById($publisherId);
-    if ($publisher) {
-        $author = $publisher->get("name");
+    // Auteur
+    if ($currentUser->isAdmin()) {
+        $author = $currentUser->getUser()->getEmail();
+    } elseif ($currentUser->hasPublisherRight()) {
+        $pum = new PublisherManager();
+        $publisherId = $currentUser->getCurrentRight()->getPublisherId();
+        $publisher = $pum->getById($publisherId);
+        if ($publisher) {
+            $author = $publisher->get("name");
+        }
     }
-}
 
-$postIllustrationUpload = '
+    $postIllustrationUpload = '
         <label for="post_illustration">Image :</label>
         <input type="file" id="post_illustration_upload" name="post_illustration_upload" accept="image/jpeg" />
     ';
 
-if ($post) {
-    $p = $post;
-    $pageTitle = 'Modifier « <a href="/blog/'.$p["post_url"].'">'.$p["post_title"].'</a> »';
-    $content .= '
-        <div class="admin">
-            <p>Billet n° '.$p["post_id"].'</p>
-            <p><a href="/blog/'.$p["post_url"].'">voir</a></p>
-            <p><a href="/pages/links?post_id='.$p["post_id"].'">lier</a></p>
-            <p><a href="'.\Biblys\Legacy\LegacyCodeHelper::getGlobalUrlGenerator()->generate('post_delete', ['id' => $p['post_id']]).'" data-confirm="Voulez-vous vraiment SUPPRIMER ce billet ?">supprimer</a></p>
-            <p><a href="/pages/'.$rank.'posts">billets</a></p>
-        </div>
-    ';
-    $author = $currentUser->getUser()->getEmail();
-    $date = explode(" ", $p["post_date"]);
-    $p["post_date"] = $date[0];
-    $p["post_time"] = substr($date[1],0,5);
-
-    // Illustration
-    $postIllustration = new Media("post", $post->get("id"));
-    if ($postIllustration->exists()) {
-        $postIllustrationUpload = '
-            <div class="text-center">
-                '.$post->getIllustrationTag(height: 300).'<br />
-                <input type="checkbox" value=1 name="post_illustration_delete" id="illustration_delete" />
-                <label for="illustration_delete">Supprimer</label>
+    if ($post) {
+        $p = $post;
+        $pageTitle = 'Modifier « <a href="/blog/' . $p["post_url"] . '">' . $p["post_title"] . '</a> »';
+        $content .= '
+            <div class="admin">
+                <p>Billet n° ' . $p["post_id"] . '</p>
+                <p><a href="/blog/' . $p["post_url"] . '">voir</a></p>
+                <p><a href="/pages/links?post_id=' . $p["post_id"] . '">lier</a></p>
+                <p><a href="' . $urlGenerator->generate('post_delete', ['id' => $p['post_id']]) . '" data-confirm="Voulez-vous vraiment SUPPRIMER ce billet ?">supprimer</a></p>
+                <p><a href="/pages/adm_posts">billets</a></p>
             </div>
         ';
+        $author = $currentUser->getUser()->getEmail();
+        $date = explode(" ", $p["post_date"]);
+        $p["post_date"] = $date[0];
+        $p["post_time"] = substr($date[1], 0, 5);
+
+        // Illustration
+        $postIllustration = new Media("post", $post->get("id"));
+        if ($postIllustration->exists()) {
+            $postIllustrationUpload = '
+                <div class="text-center">
+                    ' . $post->getIllustrationTag(height: 300) . '<br />
+                    <input type="checkbox" value=1 name="post_illustration_delete" id="illustration_delete" />
+                    <label for="illustration_delete">Supprimer</label>
+                </div>
+            ';
+        }
+
+        if ($p['post_status']) $status_online = ' selected';
+        if ($p['post_selected']) $post_selected = ' checked';
     }
 
-    if ($p['post_status']) $status_online = ' selected';
-    if ($p['post_selected']) $post_selected = ' checked';
-}
+    $post = false;
+    $post_id = $request->query->get('id', false);
+    if ($post_id) {
+        $pm = new PostManager();
+        $post = $pm->getById($post_id);
 
-$post = false;
-$post_id = $request->query->get('id', false);
-if ($post_id) {
-    $pm = new PostManager();
-    $post = $pm->getById($post_id);
-
-    if (!$post) {
-        throw new Exception("Billet n° $post_id introuvable.");
+        if (!$post) {
+            throw new Exception("Billet n° $post_id introuvable.");
+        }
     }
-}
 
-$content .= '
-    <h1><i class="fa fa-newspaper-o"></i> '.$pageTitle.'</h1>
-
-    <form method="post" class="check fieldset" enctype="multipart/form-data">
-        <fieldset>
-            <legend>Informations</legend>
-            <p>
-                <label class="floating" for="post_author">Auteur :</label>
-                <input type="text" name="post_author" id="post_author" value="'.$author.'" class="long" disabled="disabled" />
-                <input type="hidden" name="user_id" id="user_id" value="'.$p["user_id"].'" />
-                <input type="hidden" name="publisher_id" id="publisher_id" value="'.($p['publisher_id'] ?? null).'">
-            </p>
-';
-if($currentUser->isAdmin()) {
     $content .= '
+        <h1><i class="fa fa-newspaper-o"></i> ' . $pageTitle . '</h1>
+    
+        <form method="post" class="check fieldset" enctype="multipart/form-data">
+            <fieldset>
+                <legend>Informations</legend>
+                <p>
+                    <label class="floating" for="post_author">Auteur :</label>
+                    <input type="text" name="post_author" id="post_author" value="' . $author . '" class="long" disabled="disabled" />
+                    <input type="hidden" name="user_id" id="user_id" value="' . $p["user_id"] . '" />
+                    <input type="hidden" name="publisher_id" id="publisher_id" value="' . ($p['publisher_id'] ?? null) . '">
+                </p>
+    ';
+    if ($currentUser->isAdmin()) {
+        $content .= '
             <p>
                 <label class="floating" for="category_id">Catégorie :</label>
                 <select name="category_id">
                     <option />
     ';
-    $cm = new CategoryManager();
-    $categories = $cm->getAll();
-    foreach ($categories as $category) {
-        $c = $category;
-        if (isset($p['category_id']) && $p['category_id'] == $c['category_id']) $c['selected'] = ' selected'; else $c['selected'] = NULL;
-        $content .= '<option value="'.$c["category_id"].'"'.$c['selected'].'>'.$c["category_name"].'</option>';
-    }
+        $cm = new CategoryManager();
+        $categories = $cm->getAll();
+        foreach ($categories as $category) {
+            $c = $category;
+            if (isset($p['category_id']) && $p['category_id'] == $c['category_id']) $c['selected'] = ' selected'; else $c['selected'] = NULL;
+            $content .= '<option value="' . $c["category_id"] . '"' . $c['selected'] . '>' . $c["category_name"] . '</option>';
+        }
 
-    $content .= '
+        $content .= '
                 </select>
                 <br />
             </p>
     ';
-}
-$content .= '
+    }
+    $content .= '
             <p>
                 <label class="floating" for="post_title" class="required">Titre :</label>
-                <input type="text" name="post_title" id="post_title" value="'.(isset($p['post_title']) ? htmlentities($p['post_title']) : null).'" class="long required" required />
+                <input type="text" name="post_title" id="post_title" value="' . (isset($p['post_title']) ? htmlentities($p['post_title']) : null) . '" class="long required" required />
             </p>
             <br>
 
@@ -217,104 +221,105 @@ $content .= '
                 <label class="floating" for="post_status">État :</label>
                 <select name="post_status">
                     <option value="0">Hors-ligne</option>
-                    <option value="1" '.$status_online.'>En ligne</option>
+                    <option value="1" ' . $status_online . '>En ligne</option>
                 </select>
             </p>
             <p>
                 <label class="floating" for="post_date" class="required">Date de parution :</label>
-                <input type="date" name="post_date" id="post_date" value="'.$p["post_date"].'" placeholder="AAAA-MM-JJ" required>
-                <input type="time" name="post_time" id="post_time" value="'.$p["post_time"].'" placeholder="HH:MM" required>
+                <input type="date" name="post_date" id="post_date" value="' . $p["post_date"] . '" placeholder="AAAA-MM-JJ" required>
+                <input type="time" name="post_time" id="post_time" value="' . $p["post_time"] . '" placeholder="HH:MM" required>
             </p>
-';
+    ';
 
-if ($currentUser->isAdmin()) {
-    $content .= '
+    if ($currentUser->isAdmin()) {
+        $content .= '
             <label class="floating" for="post_link">Lien :</label>
             <input 
                 type="url" 
                 name="post_link" 
                 id="post_link" 
                 placeholder="https://" 
-                value="'.($p['post_link'] ?? null).'" 
+                value="' . ($p['post_link'] ?? null) . '" 
                 class="long" 
             />
             <br /><br />
 
             <label class="floating" for="post_selected">À la une :</label>
-            <input type="checkbox" name="post_selected" id="post_selected" value="1"'.$post_selected.' />
+            <input type="checkbox" name="post_selected" id="post_selected" value="1"' . $post_selected . ' />
             <br /><br />
-    ';
-}
+      ';
+    }
 
-$content .= '
+    $content .= '
         </fieldset>
         <fieldset>
             <legend>Illustration</legend>
             <p>
-                '.$postIllustrationUpload.'
+                ' . $postIllustrationUpload . '
             </p>
             <p>
                 <label class="floating" for="illustration_version">Version :</label>
-                <input type="number" value="'.(isset($post) ? "" : $post->get("illustration_version")).'" name="post_illustration_version" id="illustration_version" class="nano" />
+                <input type="number" value="" name="post_illustration_version" id="illustration_version" class="nano" />
             </p>
             <p>
                 <label class="floating" for="post_illustration_legend">Légende :</label>
-                <input type="text" name="post_illustration_legend" id="post_illustration_legend" value="'.($p['post_illustration_legend'] ?? null).'" maxlength=64 class="long" />
+                <input type="text" name="post_illustration_legend" id="post_illustration_legend" value="' . ($p['post_illustration_legend'] ?? null) . '" maxlength=64 class="long" />
             </p>
             <p>Cette image (au format JPEG) sera utilisée comme vignette pour les aperçus du billet sur le site ou sur les réseaux sociaux. Taille minimale conseillée pour Facebook : 1200 x 627 pixels.</p>
         </fieldset>
         <fieldset>
             <legend>Contenu</legend>
-            <textarea id="post_content" name="post_content" class="wysiwyg">'.($p['post_content'] ?? null).'</textarea>
+            <textarea id="post_content" name="post_content" class="wysiwyg">' . ($p['post_content'] ?? null) . '</textarea>
         </fieldset>
 
         <fieldset class="center">
     ';
 
-if ($post) {
+    if ($post) {
+        $content .= '
+            <a class="btn btn-danger" data-confirm="Voulez-vous vraiment SUPPRIMER ce billet ?"
+                href="' . $urlGenerator->generate('post_delete', ['id' => $post->get('id')]) . '">
+                <span class="fa fa-trash-o"></span>
+                Supprimer le billet
+            </a>
+        ';
+    }
+
     $content .= '
-    <a class="btn btn-danger" data-confirm="Voulez-vous vraiment SUPPRIMER ce billet ?"
-        href="'.\Biblys\Legacy\LegacyCodeHelper::getGlobalUrlGenerator()->generate('post_delete', [ 'id' => $post->get('id') ]).'">
-        <span class="fa fa-trash-o"></span>
-        Supprimer le billet
-    </a>
+                <button class="btn btn-primary" type="submit">
+                    <span class="fa fa-save"></span>
+                    Enregistrer le billet
+                </button>
+            </fieldset>
+        
+            <fieldset>
+                <legend>Base de données</legend>
+        
+                <p>
+                    <label class="floating" for="post_id" class="disabled">Billet n°</label>
+                    <input type="text" name="post_id" id="post_id" value="' . ($p['post_id'] ?? null) . '" readonly>
+                </p>
+        
+                <p>
+                    <label class="floating" for="post_url">Adresse du billet :</label>
+                    <input type="hidden" name="post_url_old" value=' . ($p['post_url'] ?? null) . '>
+                    <input type="text" name="post_url" id="post_url" value="' . ($p['post_url'] ?? null) . '" placeholder="Champ rempli automatiquement" class="long" />
+                </p>
+                <br>
+        
+                <p>
+                    <label class="floating" for="post_insert" class="readonly">Billet créé le :</label>
+                    <input type="text" name="post_insert" id="post_insert" value="' . ($p['post_insert'] ?? null) . '" placeholder="AAAA-MM-DD HH:MM:SS" class="datetime" disabled>
+                </p>
+                <p>
+                    <label class="floating" for="post_update" class="readonly">Billet modifié le :</label>
+                    <input type="text" name="post_update" id="post_update" value="' . ($p['post_update'] ?? null) . '" placeholder="AAAA-MM-DD HH:MM:SS" class="datetime" disabled>
+                </p>
+            </fieldset>
+        </form>
     ';
-}
 
-$content .= '
-        <button class="btn btn-primary" type="submit">
-            <span class="fa fa-save"></span>
-            Enregistrer le billet
-        </button>
-    </fieldset>
+    $request->attributes->set("page_title", $pageTitle);
 
-    <fieldset>
-        <legend>Base de données</legend>
-
-        <p>
-            <label class="floating" for="post_id" class="disabled">Billet n°</label>
-            <input type="text" name="post_id" id="post_id" value="'.($p['post_id'] ?? null).'" readonly>
-        </p>
-
-        <p>
-            <label class="floating" for="post_url">Adresse du billet :</label>
-            <input type="hidden" name="post_url_old" value='.($p['post_url'] ?? null).'>
-            <input type="text" name="post_url" id="post_url" value="'.($p['post_url'] ?? null).'" placeholder="Champ rempli automatiquement" class="long" />
-        </p>
-        <br>
-
-        <p>
-            <label class="floating" for="post_insert" class="readonly">Billet créé le :</label>
-            <input type="text" name="post_insert" id="post_insert" value="'.($p['post_insert'] ?? null).'" placeholder="AAAA-MM-DD HH:MM:SS" class="datetime" disabled>
-        </p>
-        <p>
-            <label class="floating" for="post_update" class="readonly">Billet modifié le :</label>
-            <input type="text" name="post_update" id="post_update" value="'.($p['post_update'] ?? null).'" placeholder="AAAA-MM-DD HH:MM:SS" class="datetime" disabled>
-        </p>
-    </fieldset>
-</form>
-';
-
-$request->attributes->set("page_title", $pageTitle);
-
-return new Symfony\Component\HttpFoundation\Response($content);
+    return new Symfony\Component\HttpFoundation\Response($content);
+};

--- a/inc/Event.class.php
+++ b/inc/Event.class.php
@@ -24,29 +24,6 @@ class Event extends Entity
         parent::__construct($data);
     }
 
-    public function getIllustration()
-    {
-        if (!isset($this->illustration)) {
-            $this->illustration = new Media('post', $this->get('id'));
-        }
-        return $this->illustration;
-    }
-
-    public function hasIllustration()
-    {
-        $illustration = $this->getIllustration();
-        if (!isset($this->illustrationExists)) {
-            $this->illustrationExists = $illustration->exists();
-        }
-        return $this->illustrationExists;
-    }
-
-    public function getIllustrationTag()
-    {
-        $illustration = $this->getIllustration();
-        return '<img src="'.$illustration->url().'" alt="'.$this->get('illustration_legend').'" class="illustration">';
-    }
-
     /**
      * Get related articles
      * @return {array} of {Articles}

--- a/inc/Media.class.php
+++ b/inc/Media.class.php
@@ -24,12 +24,12 @@ class Media
     {
         $this->config = Config::load();
 
-        if ($type === "article") {
+        if (in_array($type, ["article", "stock", "post"])) {
             trigger_deprecation(
                 "biblys",
                 "2.83.0",
-                "Using Media with 'article' type is deprecated." .
-                "Use ImagesService->getCoverUrlForArticle instead"
+                "Using Media with '$type' type is deprecated." .
+                "Use ImagesService->getImageFor instead"
             );
         }
 

--- a/inc/Post.class.php
+++ b/inc/Post.class.php
@@ -45,10 +45,17 @@ class Post extends Entity
     }
 
     /**
+     * @deprecated Post->getIllustration is deprecated. Use method ImagesService->getImageUrlFor instead.
      * @throws Exception
      */
     public function getIllustration(): Media
     {
+        trigger_deprecation(
+            "biblys/biblys",
+            "2.86.0",
+            "Post->getIllustration… methods are deprecated. Use method ImagesService->getImageUrlFor instead.",
+        );
+
         if (!isset($this->illustration)) {
             $this->illustration = new Media('post', $this->get('id'));
         }
@@ -57,6 +64,7 @@ class Post extends Entity
     }
 
     /**
+     * @deprecated Post->hasIllustration is deprecated. Use method ImagesService->imageExistsFor instead.
      * @throws Exception
      */
     public function hasIllustration(): bool
@@ -69,6 +77,7 @@ class Post extends Entity
     }
 
     /**
+     * @deprecated Post->getIllustrationUrl is deprecated. Use method ImagesService->getIllustrationUrl instead.
      * @throws Exception
      */
     public function getIllustrationUrl(): string
@@ -84,6 +93,7 @@ class Post extends Entity
     }
 
     /**
+     * @deprecated Post->getIllustrationTag is deprecated. Use method ImagesService->getImageUrlFor instead.
      * @throws Exception
      */
     public function getIllustrationTag(?int $height = null): string

--- a/inc/Post.class.php
+++ b/inc/Post.class.php
@@ -36,6 +36,14 @@ class Post extends Entity
         parent::__construct($data);
     }
 
+    public function getModel(): \Model\Post
+    {
+        $model = new \Model\Post();
+        $model->setId($this->get("id"));
+
+        return $model;
+    }
+
     /**
      * @throws Exception
      */

--- a/inc/Post.class.php
+++ b/inc/Post.class.php
@@ -6,16 +6,8 @@ use Propel\Runtime\Exception\PropelException;
 class Post extends Entity
     {
         protected $prefix = 'post';
-
-        /**
-         * @var Media
-         */
-        private $illustration = null;
-
-        /**
-         * @var Publisher
-         */
-        private $publisher = null;
+        private ?Media $illustration = null;
+        private ?Publisher $publisher = null;
 
         /**
          * @throws PropelException
@@ -44,7 +36,10 @@ class Post extends Entity
             parent::__construct($data);
         }
 
-        public function getIllustration(): Media
+    /**
+     * @throws Exception
+     */
+    public function getIllustration(): Media
         {
             if (!isset($this->illustration)) {
                 $this->illustration = new Media('post', $this->get('id'));
@@ -53,7 +48,10 @@ class Post extends Entity
             return $this->illustration;
         }
 
-        public function hasIllustration(): bool
+    /**
+     * @throws Exception
+     */
+    public function hasIllustration(): bool
         {
             $illustration = $this->getIllustration();
             if (!isset($this->illustrationExists)) {
@@ -62,7 +60,10 @@ class Post extends Entity
             return $this->illustrationExists;
         }
 
-        public function getIllustrationUrl(): string
+    /**
+     * @throws Exception
+     */
+    public function getIllustrationUrl(): string
         {
             $options = [];
 
@@ -74,7 +75,10 @@ class Post extends Entity
             return $this->getIllustration()->getUrl($options);
         }
 
-        public function getIllustrationTag(?int $height = null): string
+    /**
+     * @throws Exception
+     */
+    public function getIllustrationTag(?int $height = null): string
         {
             $illustration = $this->getIllustration();
 
@@ -83,7 +87,7 @@ class Post extends Entity
                 $heightAttribute = " height=$height";
             }
 
-            return '<img src="'.$illustration->url().'" alt="'.$this->get('illustration_legend').'"'.$heightAttribute.' class="illustration">';
+            return '<img src="'.$illustration->getUrl().'" alt="'.$this->get('illustration_legend').'"'.$heightAttribute.' class="illustration">';
         }
 
         public function getFirstImageUrl(): ?string
@@ -165,7 +169,7 @@ class Post extends Entity
         }
 
         /**
-         * @return bool true if user is admin or post's author
+         * @return bool true if a user is admin or post's author
          */
         public function canBeDeletedBy(User $user): bool
         {
@@ -178,6 +182,7 @@ class Post extends Entity
 
         /**
          * Returns previous post from current post's date
+         * @noinspection PhpUnused
          */
         public function getPrevPost()
         {
@@ -190,6 +195,7 @@ class Post extends Entity
 
         /**
          * Returns next post from current post's date
+         * @noinspection PhpUnused
          */
         public function getNextPost()
         {
@@ -208,7 +214,7 @@ class Post extends Entity
         /**
          * @throws Exception
          */
-        public function create(array $defaults = array())
+        public function create(array $defaults = array()): Entity
         {
             if (!isset($defaults['site_id'])) $defaults['site_id'] = $this->site['site_id'];
             return parent::create($defaults);

--- a/src/AppBundle/Controller/MaintenanceController.php
+++ b/src/AppBundle/Controller/MaintenanceController.php
@@ -81,6 +81,15 @@ class MaintenanceController extends Controller
             ->find()
             ->getData()[0];
 
+        $postIllustrations = ImageQuery::create()
+            ->filterByType("illustration")
+            ->filterBySite($currentSite->getSite())
+            ->withColumn('COUNT(`id`)', 'count')
+            ->withColumn('SUM(`fileSize`)', 'size')
+            ->select(['count', 'size'])
+            ->find()
+            ->getData()[0];
+
         $mediaFiles = MediaFileQuery::create()
             ->filterBySiteId($currentSite->getSite()->getId())
             ->withColumn('COUNT(`media_id`)', 'count')
@@ -89,14 +98,24 @@ class MaintenanceController extends Controller
             ->find()
             ->getData()[0];
 
-        $totalCount = $articles["count"] + $downloadableFiles["count"] + $stockItems["count"] + $mediaFiles["count"];
-        $totalSize = $articles["size"] + $downloadableFiles["size"] + $stockItems["size"] + $mediaFiles["size"];
+        $totalCount = $articles["count"]
+            + $stockItems["count"]
+            + $postIllustrations["count"]
+            + $mediaFiles["count"]
+            + $downloadableFiles["count"];
+        $totalSize = $articles["size"]
+            + $stockItems["size"]
+            + $postIllustrations["size"]
+            + $mediaFiles["size"]
+            + $downloadableFiles["size"];
 
         return $templateService->renderResponse("AppBundle:Maintenance:disk-usage.html.twig", [
             "articlesCount" => $articles["count"],
             "articlesSize" => $this->_convertToGigabytes($articles["size"]),
             "stockItemsCount" => $stockItems["count"],
             "stockItemsSize" => $this->_convertToGigabytes($stockItems["size"]),
+            "postIllustrationsCount" => $postIllustrations["count"],
+            "postIllustrationsSize" => $this->_convertToGigabytes($postIllustrations["size"]),
             "downloadableFilesCount" => $downloadableFiles["count"],
             "downloadableFilesSize" => $this->_convertToGigabytes($downloadableFiles["size"]),
             "mediaFilesCount" => $mediaFiles["count"],

--- a/src/AppBundle/Controller/PostController.php
+++ b/src/AppBundle/Controller/PostController.php
@@ -215,14 +215,11 @@ class PostController extends Controller
     private
     function _writePostToFile(Post $post, TemplateService $templateService): void
     {
-        $cover = new Media("post", $post->getId());
-
         $converter = new HtmlConverter();
         $markdown = $converter->convert($post->getContent());
 
         $response = $templateService->renderResponse('AppBundle:Post:export.md.twig', [
             "post" => $post,
-            "cover" => $cover,
             "content" => $markdown,
             "published" => $post->getStatus() ? "true" : "false",
         ]);

--- a/src/AppBundle/Resources/views/Maintenance/disk-usage.html.twig
+++ b/src/AppBundle/Resources/views/Maintenance/disk-usage.html.twig
@@ -27,19 +27,24 @@
         <td class="text-right">{{ articlesSize }} Go</td>
       </tr>
       <tr>
-        <td>Fichiers téléchargeables</td>
-        <td class="text-right">{{ downloadableFilesCount }}</td>
-        <td class="text-right">{{ downloadableFilesSize }} Go</td>
-      </tr>
-      <tr>
         <td>Exemplaires d'occasion (photos)</td>
         <td class="text-right">{{ stockItemsCount }}</td>
         <td class="text-right">{{ stockItemsSize }} Go</td>
       </tr>
       <tr>
+        <td>Billets de blog (illustrations)</td>
+        <td class="text-right">{{ postIllustrationsCount }}</td>
+        <td class="text-right">{{ postIllustrationsSize }} Go</td>
+      </tr>
+      <tr>
         <td>Médias</td>
         <td class="text-right">{{ mediaFilesCount }}</td>
         <td class="text-right">{{ mediaFilesSize }} Go</td>
+      </tr>
+      <tr>
+        <td>Fichiers téléchargeables</td>
+        <td class="text-right">{{ downloadableFilesCount }}</td>
+        <td class="text-right">{{ downloadableFilesSize }} Go</td>
       </tr>
     </tbody>
     <tfoot>

--- a/src/Biblys/Service/TemplateService.php
+++ b/src/Biblys/Service/TemplateService.php
@@ -10,6 +10,7 @@ use Cart;
 use Exception;
 use Framework\TemplateLoader;
 use Model\Article;
+use Model\Post;
 use Model\Stock;
 use Propel\Runtime\Exception\PropelException;
 use Symfony\Bridge\Twig\Extension\FormExtension;
@@ -273,6 +274,10 @@ class TemplateService
 
         $imagesService = new ImagesService($config, $currentSite, new Filesystem());
 
+        $filters[] = new TwigFilter('hasImage', function (Article|Stock|Post $model) use($imagesService) {
+            return $imagesService->imageExistsFor($model);
+        });
+
         $filters[] = new TwigFilter('hasCover', function (Article $article) use($imagesService) {
             return $imagesService->imageExistsFor($article);
         });
@@ -287,7 +292,7 @@ class TemplateService
         );
 
         $filters[] = new TwigFilter('imageUrl',
-            function (Article|Stock $model, array $options = []) use ($imagesService) {
+            function (Article|Stock|Post $model, array $options = []) use ($imagesService) {
                 $width = $options[0] ?? null;
                 $height = $options[1] ?? null;
                 return $imagesService->getImageUrlFor($model, width: $width, height: $height);

--- a/src/Biblys/Test/ModelFactory.php
+++ b/src/Biblys/Test/ModelFactory.php
@@ -793,6 +793,7 @@ class ModelFactory
     public static function createImage(
         Article $article = null,
         Stock   $stockItem = null,
+        Post    $post = null,
         Site    $site = null,
         string  $type = null,
         string  $filePath = "/images/",
@@ -805,6 +806,7 @@ class ModelFactory
         $image->setType($type);
         $image->setArticle($article);
         $image->setStockItem($stockItem);
+        $image->setPost($post);
         $image->setSite($site);
         $image->setFilePath($filePath);
         $image->setFileName($fileName);

--- a/src/Command/OptimizeImagesCommand.php
+++ b/src/Command/OptimizeImagesCommand.php
@@ -4,9 +4,7 @@ namespace Command;
 
 use Biblys\Service\Config;
 use Biblys\Service\Images\ImageForModel;
-use Biblys\Service\Images\ImagesService;
 use Biblys\Service\LoggerService;
-use Biblys\Test\ModelFactory;
 use Exception;
 use Model\ImageQuery;
 use Propel\Runtime\ActiveQuery\Criteria;
@@ -24,7 +22,6 @@ class OptimizeImagesCommand extends Command
     public function __construct(
         private readonly Config        $config,
         private readonly Filesystem    $filesystem,
-        private readonly ImagesService $imagesService,
         string                         $name = null,
     )
     {
@@ -73,8 +70,6 @@ class OptimizeImagesCommand extends Command
                 ->save($optimizedImagePath);
             $newSizeInMB = round(filesize($optimizedImagePath) / 1024 / 1024, 2);
 
-            $model = $image->getArticle() ?? $image->getStockItem();
-//            $this->imagesService->addImageFor($model, $optimizedImagePath);
             $this->filesystem->remove($optimizedImagePath);
 
             $loggerService = new LoggerService();

--- a/tests/AppBundle/Controller/MaintenanceControllerTest.php
+++ b/tests/AppBundle/Controller/MaintenanceControllerTest.php
@@ -33,6 +33,7 @@ class MaintenanceControllerTest extends TestCase
         ModelFactory::createImage(type: 'cover', fileSize: 99999999);
         ModelFactory::createImage(site: $site, type: 'photo', fileSize: 99999999);
         ModelFactory::createImage(type: 'other', fileSize: 99999999);
+        ModelFactory::createImage(site: $site, type: 'illustration', fileSize: 99999999);
         ModelFactory::createMediaFile(site: $site,
             fileSize: 99999999);
 
@@ -57,12 +58,14 @@ class MaintenanceControllerTest extends TestCase
                 "articlesSize" => 0.093,
                 "stockItemsCount" => 1,
                 "stockItemsSize" => 0.093,
+                "postIllustrationsCount" => 1,
+                "postIllustrationsSize" => 0.093,
                 "downloadableFilesCount" => 0,
                 "downloadableFilesSize" => 0.0,
                 "mediaFilesCount" => 1,
                 "mediaFilesSize" => 0.093,
-                "totalCount" => 3,
-                "totalSize" => 0.279,
+                "totalCount" => 4,
+                "totalSize" => 0.373,
             ]);
         $this->assertInstanceOf(Response::class, $response);
         $this->assertEquals("response", $response->getContent());
@@ -105,6 +108,8 @@ class MaintenanceControllerTest extends TestCase
             ->with("AppBundle:Maintenance:disk-usage.html.twig", [
                 "articlesCount" => 1,
                 "articlesSize" => 0.093,
+                "postIllustrationsCount" => 0,
+                "postIllustrationsSize" => 0,
                 "downloadableFilesCount" => 1,
                 "downloadableFilesSize" => 0.093,
                 "stockItemsCount" => 0,

--- a/tests/PostTest.php
+++ b/tests/PostTest.php
@@ -14,6 +14,22 @@ require_once "setUp.php";
 class PostTest extends PHPUnit\Framework\TestCase
 {
     /**
+     * @throws Exception
+     */
+    public function testGetModel(): void
+    {
+        // given
+        $entity = new Post(["id" => 1234]);
+
+        // when
+        $model = $entity->getModel();
+
+        // then
+        $this->assertInstanceOf(\Model\Post::class, $model);
+        $this->assertEquals(1234, $model->getId());
+    }
+
+    /**
      * Test creating a post
      */
     public function testCreate()


### PR DESCRIPTION
## Problème

Aujourd'hui, Biblys n'a pas de moyen de savoir s'il existe une illustration pour un billet de blog autrement qu'en interrogeant le système de fichiers.

## Solution

Utiliser la table `images` pour les billets de blog [comme cela a été fait pour photos d'exemplaires](https://github.com/biblys/biblys/pull/42).

## Todo

- [x] Vérifier l'existence une photo d'exemplaire à l'aide du `ImagesService`
- [x] Ajouter une photo d'exemplaire à l'aide du `ImagesService`
- [x] Obtenir l'url d'une photo d'exemplaire à l'aide du `ImagesService`
- [x] Supprimer une photo d'exemplaire à l'aide du `ImagesService`
- [x] Remplacer `Media` par `ImagesService` pour les photos d'exemplaire
- [x] Renseigner le `site_id` des images en fonction du `site_id` de l'exemplaire
- [x] Ajouter un script pour charger les images déjà existantes en base
- [x] Ajouter la catégorie "Illustrations" à la page espace disque