### PR TITLE
Correctif 2.86.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Historique des modifications
 
-## 2.86.3 (DEV)
+## 2.86.3 (23 octobre 2024)
 
 ### Corrections
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@
 
 ### Corrections
 
-- L'affichage d'une gallerie pouvait déclencher une erreur. C'est corrigé.
-
+- L'affichage d'une galerie pouvait déclencher une erreur. C'est corrigé.
+- L'ajout d'un média pouvait échouer si le dossier parent contenait des
+  tirets ("-") dans son nom. Maintenant, ça marche.
 
 ## 2.86.2 (16 octobre 2024)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Historique des modifications
 
+## 2.86.3 (DEV)
+
+### Corrections
+
+- L'affichage d'une gallerie pouvait déclencher une erreur. C'est corrigé.
+
+
 ## 2.86.2 (16 octobre 2024)
 
 ### Corrections

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
   tirets ("-") dans son nom. Maintenant, ça marche.
 - L'import de média pouvait échouer si le nom du fichier comportait une
   extension inhabituelle. Ça n'arrivera plus.
+- Les dossiers et fichiers sont désormais triés par ordre alphabétique sur
+  la page "Gestion des médias".
 
 ## 2.86.2 (16 octobre 2024)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - L'affichage d'une galerie pouvait déclencher une erreur. C'est corrigé.
 - L'ajout d'un média pouvait échouer si le dossier parent contenait des
   tirets ("-") dans son nom. Maintenant, ça marche.
+- L'import de média pouvait échouer si le nom du fichier comportait une
+  extension inhabituelle. Ça n'arrivera plus.
 
 ## 2.86.2 (16 octobre 2024)
 

--- a/controllers/common/php/adm_media.php
+++ b/controllers/common/php/adm_media.php
@@ -20,12 +20,12 @@ return function (
     FlashMessagesService $flashMessagesService,
 ): Response {
 
-    $currentDirectory = $request->query->getAlnum("dir");
+    $currentDirectory = $request->query->get("dir");
     if ($currentDirectory === '/') {
         $currentDirectory = null;
     }
 
-    $postNewDir = $request->request->getAlnum("new_dir");
+    $postNewDir = $request->request->get("new_dir");
     if (!empty($postNewDir)) {
         return _createMediaDirectory($postNewDir, $flashMessagesService);
     }

--- a/controllers/common/php/adm_media.php
+++ b/controllers/common/php/adm_media.php
@@ -300,6 +300,7 @@ function _displayMediaDirectory(CurrentSite $currentSite, string $currentDirecto
     $mediaFiles = MediaFileQuery::create()
         ->filterBySiteId($currentSite->getId())
         ->filterByDir($currentDirectory)
+        ->orderByFile()
         ->find();
 
     foreach ($mediaFiles as $file) {
@@ -360,6 +361,7 @@ function _displayMediaDirectories(CurrentSite $currentSite, Request $request): R
         ->withColumn('SUM(`media_file_size`)', 'size')
         ->select(['name', 'size'])
         ->groupByDir()
+        ->orderByDir()
         ->find();
 
     $request->attributes->set("page_title", "Médias");

--- a/inc/MediaFile.class.php
+++ b/inc/MediaFile.class.php
@@ -1,9 +1,22 @@
 <?php
 
+use Biblys\Legacy\LegacyCodeHelper;
+
 class MediaFile extends Entity
 {
     protected $prefix = 'media';
     public $trackChange = false;
+
+    /**
+     * @throws Exception
+     */
+    public function getUrl(): string
+    {
+        $globalSite = LegacyCodeHelper::getGlobalSite();
+
+        return '/' . $globalSite->get('name') . '/media/' . $this->get('dir') . '/' . $this->get('file')
+            . '.' . $this->get('ext');
+    }
 }
 
 class MediaFileManager extends EntityManager

--- a/inc/MediaFile.class.php
+++ b/inc/MediaFile.class.php
@@ -12,10 +12,7 @@ class MediaFile extends Entity
      */
     public function getUrl(): string
     {
-        $globalSite = LegacyCodeHelper::getGlobalSite();
-
-        return '/' . $globalSite->get('name') . '/media/' . $this->get('dir') . '/' . $this->get('file')
-            . '.' . $this->get('ext');
+        return '/media/' . $this->get('dir') . '/' . $this->get('file') . '.' . $this->get('ext');
     }
 }
 

--- a/inc/constants.php
+++ b/inc/constants.php
@@ -1,3 +1,3 @@
 <?php
 
-const BIBLYS_VERSION = "2.86.3-dev.2";
+const BIBLYS_VERSION = "2.86.3-dev.3";

--- a/inc/constants.php
+++ b/inc/constants.php
@@ -1,3 +1,3 @@
 <?php
 
-const BIBLYS_VERSION = "2.86.3-dev.1";
+const BIBLYS_VERSION = "2.86.3-dev.2";

--- a/inc/constants.php
+++ b/inc/constants.php
@@ -1,3 +1,3 @@
 <?php
 
-const BIBLYS_VERSION = "2.86.3-dev.3";
+const BIBLYS_VERSION = "2.86.3";

--- a/inc/constants.php
+++ b/inc/constants.php
@@ -1,3 +1,3 @@
 <?php
 
-const BIBLYS_VERSION = "2.86.2";
+const BIBLYS_VERSION = "2.86.3-dev.1";

--- a/src/AppBundle/Resources/views/Gallery/_gallery.html.twig
+++ b/src/AppBundle/Resources/views/Gallery/_gallery.html.twig
@@ -3,7 +3,7 @@
     {% for media in gallery.medias %}
       <div class="swiper-slide">
         <a href="{{ media.url }}" class="carousel-slide-link">
-          <img data-src="{{ media.url }}" class="carousel-image swiper-lazy">
+          <img src="" data-src="{{ media.url }}" class="carousel-image swiper-lazy" alt="">
           <div class="swiper-lazy-preloader"></div>
         </a>
       </div>

--- a/src/Biblys/Test/EntityFactory.php
+++ b/src/Biblys/Test/EntityFactory.php
@@ -13,7 +13,11 @@ use Collection;
 use CollectionManager;
 use Country;
 use CountryManager;
+use Entity;
 use Exception;
+use Gallery;
+use GalleryManager;
+use MediaFile;
 use Model\ArticleQuery;
 use Model\PeopleQuery;
 use Model\User;
@@ -280,5 +284,39 @@ class EntityFactory
         $article = ArticleQuery::create()->findPk($article->get("id"));
         $contributor = PeopleQuery::create()->findPk($contributor->get("id"));
         ModelFactory::createContribution($article, $contributor);
+    }
+
+    /**
+     * @param $title
+     * @return Entity|bool
+     * @throws PropelException
+     */
+    public static function createGallery(
+        string $title = "Galerie",
+        string $mediaDir = "galerie"
+    ): Entity|bool
+    {
+        $gallery = ModelFactory::createGallery(title: $title, mediaDir: $mediaDir);
+
+        return new Gallery([
+            "gallery_id" => $gallery->getId(),
+            "gallery_title" => $gallery->getTitle(),
+            "gallery_media_dir" => $gallery->getMediaDir(),
+        ]);
+    }
+
+    /**
+     * @throws PropelException
+     */
+    public static function createMediaFile(string $directory = "medias"): MediaFile
+    {
+        $mediaFile = ModelFactory::createMediaFile(directory: $directory);
+
+        return new MediaFile([
+            "media_id" => $mediaFile->getId(),
+            "media_dir" => $mediaFile->getDir(),
+            "media_file" => $mediaFile->getFile(),
+            "media_ext" => $mediaFile->getExt(),
+        ]);
     }
 }

--- a/src/Biblys/Test/Helpers.php
+++ b/src/Biblys/Test/Helpers.php
@@ -2,9 +2,16 @@
 
 namespace Biblys\Test;
 
+use Biblys\Service\Config;
+use Biblys\Service\CurrentSite;
+use Biblys\Service\CurrentUser;
+use Biblys\Service\MetaTagsService;
+use Biblys\Service\TemplateService;
 use Exception;
+use Mockery;
 use ReflectionClass;
 use ReflectionException;
+use Symfony\Component\HttpFoundation\Request;
 
 class Helpers
 {
@@ -35,5 +42,32 @@ class Helpers
         }
 
         throw new Exception("Excepted function to throw an exception, but none was.");
+    }
+
+    /**
+     * @return TemplateService
+     * @throws Exception
+     */
+    public static function getTemplateService(): TemplateService
+    {
+        $config = new Config(["environment" => "test"]);
+        $currentSite = Mockery::mock(CurrentSite::class);
+        $currentSite->expects("getTitle")->andReturn("Éditions Paronymie");
+        $currentSite->expects("getOption")->andReturn(null);
+        $currentUser = Mockery::mock(CurrentUser::class);
+        $currentUser->expects("isAuthentified")->andReturn(false);
+        $currentUser->expects("isAdmin")->andReturn(false);
+        $currentUser->expects("hasPublisherRight")->andReturn(false);
+        $metaTags = Mockery::mock(MetaTagsService::class);
+        $metaTags->expects("dump")->andReturn("");
+        $request = new Request();
+
+        return new TemplateService(
+            config: $config,
+            currentSiteService: $currentSite,
+            currentUserService: $currentUser,
+            metaTagsService: $metaTags,
+            request: $request
+        );
     }
 }

--- a/src/Biblys/Test/ModelFactory.php
+++ b/src/Biblys/Test/ModelFactory.php
@@ -12,6 +12,7 @@ use Model\AuthenticationMethod;
 use Model\Customer;
 use Model\Event;
 use Model\File;
+use Model\Gallery;
 use Model\Image;
 use Model\Invitation;
 use Model\BookCollection;
@@ -838,12 +839,14 @@ class ModelFactory
      * @throws PropelException
      */
     public static function createMediaFile(
-        Site $site = null,
-        int  $fileSize = 100,
+        Site   $site = null,
+        string $directory = "medias",
+        int    $fileSize = 100,
     ): MediaFile
     {
         $mediaFile = new MediaFile();
         $mediaFile->setSiteId($site ? $site->getId() : self::createSite()->getId());
+        $mediaFile->setDir($directory);
         $mediaFile->setFileSize($fileSize);
         $mediaFile->save();
 
@@ -872,6 +875,25 @@ class ModelFactory
         $event->save();
 
         return $event;
+    }
+
+    /**
+     * @param string $mediaDir
+     * @param $title = "Galerie"
+     * @return Gallery
+     * @throws PropelException
+     */
+    public static function createGallery(
+        string $title = "Galerie",
+        string $mediaDir = "galerie"
+    ): Gallery
+    {
+        $gallery = new Gallery();
+        $gallery->setTitle($title);
+        $gallery->setMediaDir($mediaDir);
+        $gallery->save();
+
+        return $gallery;
     }
 
 }

--- a/src/Command/ImportMediaCommand.php
+++ b/src/Command/ImportMediaCommand.php
@@ -85,7 +85,7 @@ class ImportMediaCommand extends Command
         foreach ($mediaSubDirectories as $imagesDirectoryFiles) {
             foreach ($imagesDirectoryFiles as $imageFile) {
                 $filePath = $imageFile->getRealPath();
-                $re = '/(.*)\/(.*)\/(.*).([a-z]{3,4})$/m';
+                $re = '/(.*)\/(.*)\/(.*)\.(.*)$/m';
 
                 preg_match_all($re, $filePath, $matches, PREG_SET_ORDER);
 

--- a/tests/AppBundle/Resources/views/GalleryTemplatesTest.php
+++ b/tests/AppBundle/Resources/views/GalleryTemplatesTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace AppBundle\Resources\views;
+
+use Biblys\Test\EntityFactory;
+use Biblys\Test\Helpers;
+use Exception;
+use PHPUnit\Framework\TestCase;
+use Propel\Runtime\Exception\PropelException;
+use Twig\Error\LoaderError;
+use Twig\Error\RuntimeError;
+use Twig\Error\SyntaxError;
+
+require_once __DIR__ . "/../../../setUp.php";
+
+class GalleryTemplatesTest extends TestCase
+{
+    /**
+     * @throws SyntaxError
+     * @throws RuntimeError
+     * @throws LoaderError
+     * @throws PropelException
+     * @throws Exception
+     */
+    public function testIndexTemplate()
+    {
+        // given
+        $templateService = Helpers::getTemplateService();
+        $gallery = EntityFactory::createGallery(title: "Les Photos", mediaDir: "photos");
+        EntityFactory::createMediaFile(directory: "photos");
+
+        // when
+        $html = $templateService->render('AppBundle:Gallery:index.html.twig', [
+            'galleries' => [$gallery],
+        ]);
+
+        // then
+        $this->assertStringContainsString("Les Photos", $html);
+    }
+
+    /**
+     * @throws SyntaxError
+     * @throws RuntimeError
+     * @throws LoaderError
+     * @throws PropelException
+     * @throws Exception
+     */
+    public function testShowTemplate()
+    {
+        // given
+        $templateService = Helpers::getTemplateService();
+        $gallery = EntityFactory::createGallery(title: "Les Photos", mediaDir: "photos");
+        EntityFactory::createMediaFile(directory: "photos");
+
+        // when
+        $html = $templateService->render('AppBundle:Gallery:show.html.twig', [
+            'gallery' => $gallery,
+        ]);
+
+        // then
+        $this->assertStringContainsString("Les Photos", $html);
+    }
+}

--- a/tests/MediaFileTest.php
+++ b/tests/MediaFileTest.php
@@ -61,6 +61,25 @@ class MediaFileTest extends PHPUnit\Framework\TestCase
     }
 
     /**
+     * Test getting media file url
+     */
+    public function testGetUrl()
+    {
+        $globalSite = LegacyCodeHelper::getGlobalSite();
+
+        $mfm = new MediaFileManager();
+        $media = $mfm->create([
+            'media_dir' => 'dir',
+            'media_file' => 'file',
+            'media_ext' => 'ext'
+        ]);
+
+        $globalSite->set('site_name', 'site');
+
+        $this->assertEquals($media->getUrl(), '/site/media/dir/file.ext');
+    }
+
+    /**
      * Test deleting a copy
      */
     public function testDelete()

--- a/tests/MediaFileTest.php
+++ b/tests/MediaFileTest.php
@@ -65,8 +65,6 @@ class MediaFileTest extends PHPUnit\Framework\TestCase
      */
     public function testGetUrl()
     {
-        $globalSite = LegacyCodeHelper::getGlobalSite();
-
         $mfm = new MediaFileManager();
         $media = $mfm->create([
             'media_dir' => 'dir',
@@ -74,9 +72,7 @@ class MediaFileTest extends PHPUnit\Framework\TestCase
             'media_ext' => 'ext'
         ]);
 
-        $globalSite->set('site_name', 'site');
-
-        $this->assertEquals($media->getUrl(), '/site/media/dir/file.ext');
+        $this->assertEquals($media->getUrl(), '/media/dir/file.ext');
     }
 
     /**


### PR DESCRIPTION
### Corrections

- L'affichage d'une galerie pouvait déclencher une erreur. C'est corrigé.
- L'ajout d'un média pouvait échouer si le dossier parent contenait des
  tirets ("-") dans son nom. Maintenant, ça marche.
- L'import de média pouvait échouer si le nom du fichier comportait une
  extension inhabituelle. Ça n'arrivera plus.
- Les dossiers et fichiers sont désormais triés par ordre alphabétique sur
  la page "Gestion des médias".