### PR TITLE
Gérer en base de données les portraits de contributeur·ice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Historique des modifications
 
-## 3.1.0 (DEV)
+## 3.0.0 (DEV)
 
 #### Expédition avec Mondial Relay
 
@@ -14,11 +14,11 @@
 ### Améliorations
 
 - Les images (couvertures d'articles, photos d'exemplaires, illustrations de
-  billets de blog, logo d'éditeurs) peuvent désormais être au format PNG ou WebP
-  en plus de JPEG.
+  billets de blog, logo d'éditeurs, portraits de contribeur·ices) peuvent
+  désormais être au format PNG ou WebP en plus de JPEG.
 - La page "Espace disque" affiche désormais la taille occupée par les logos
-  d'éditeurs.
-- La commande `images:import` gère désormais les logos d'éditeurs.
+  d'éditeurs et les portraits de contributeur·ices.
+- La commande `images:import` gère désormais les portraits de contributeur·ices.
 - Une nouvelle commande `images:export` permet d'exporter les images de
   couverture des articles d'une collection précise.
 - Sur la page d'édition d'un exemplaire, un nouveau bouton permet de marquer un
@@ -26,11 +26,12 @@
 
 ### Instructions de mise à jour
 
-Après avoir l'installation de cette version, les logos d'éditeurs doivent être
-importés avec la commande :
+Après avoir procédé à l'installation de cette version, les logos d'éditeurs et
+les portraits de contributeur·ices doivent être importés avec les commandes :
 
 ```shell
 composer images:import post
+composer images:import people
 ```
 
 ## 2.86.3 (23 octobre 2024)

--- a/inc/Media.class.php
+++ b/inc/Media.class.php
@@ -24,7 +24,7 @@ class Media
     {
         $this->config = Config::load();
 
-        if (in_array($type, ["article", "stock", "post", "publisher"])) {
+        if (in_array($type, ["article", "stock", "post", "publisher", "people"])) {
             trigger_deprecation(
                 "biblys",
                 "2.83.0",

--- a/inc/People.class.php
+++ b/inc/People.class.php
@@ -74,24 +74,6 @@ class People extends Entity
     }
 
     /**
-     * Save uploaded file as contributor's photo
-     * @param UploadedFile $file a file that was uploaded
-     * @return Media             the contributor's saved Media
-     * @throws Exception
-     */
-    public function addPhoto(UploadedFile $file): Media
-    {
-        if ($file->getMimeType() !== 'image/jpeg') {
-            throw new Exception('La photo doit être au format JPEG.');
-        }
-
-        $photo = new Media('people', $this->get('id'));
-        $photo->upload($file->getRealPath());
-
-        return $photo;
-    }
-
-    /**
      * Get twitter url from Twitter username prop
      * @return String Twitter url
      */

--- a/inc/People.class.php
+++ b/inc/People.class.php
@@ -8,6 +8,17 @@ class People extends Entity
 {
     protected $prefix = 'people';
 
+    public function getModel(): \Model\People
+    {
+        $model = new \Model\People();
+        $model->setId($this->get("id"));
+        $model->setFirstName($this->get("first_name"));
+        $model->setLastName($this->get("last_name"));
+        $model->setName($this->get("name"));
+
+        return $model;
+    }
+
     /**
      * Returns concatenated first (if exists) and last name
      * @return String people's full name

--- a/inc/People.class.php
+++ b/inc/People.class.php
@@ -32,12 +32,18 @@ class People extends Entity
     }
 
     /**
-     * Returns true if author's photo exists
-     * @return bool
+     * @throws Exception
+     * @deprecated People->hasPhoto is deprecated. Use ImagesService->imageExistsFor instead.
      */
     public function hasPhoto(): bool
     {
-        $photo = $this->getPhoto();
+        trigger_deprecation(
+            "biblys",
+            "3.0.0",
+            "Using People->hasPhoto is deprecated. Use ImagesService->imageExistsFor instead"
+        );
+
+        $photo = $this->getPhoto(ignoreDeprecation: true);
 
         if ($photo->exists()) {
             return true;
@@ -47,11 +53,19 @@ class People extends Entity
     }
 
     /**
-     * Get people photo
-     * @return Media the media object for the photo, or false
+     * @throws Exception
+     * @deprecated People->getPhoto is deprecated. Use ImagesService->getImageUrlFor instead.
      */
-    public function getPhoto(): Media
+    public function getPhoto(bool $ignoreDeprecation = false): Media
     {
+        if (!$ignoreDeprecation) {
+            trigger_deprecation(
+                "biblys",
+                "3.0.0",
+                "Using People->getPhoto is deprecated. Use ImagesService->getImageUrlFor instead"
+            );
+        }
+
         if (!isset($this->photo)) {
             $this->photo = new Media('people', $this->get('id'));
         }

--- a/inc/constants.php
+++ b/inc/constants.php
@@ -1,3 +1,3 @@
 <?php
 
-const BIBLYS_VERSION = "3.1.0-dev";
+const BIBLYS_VERSION = "3.0.0-dev";

--- a/src/AppBundle/Controller/MaintenanceController.php
+++ b/src/AppBundle/Controller/MaintenanceController.php
@@ -58,6 +58,11 @@ class MaintenanceController extends Controller
 
         $articles = $articlesQuery->find()->getData()[0];
 
+        $contributors = ImageQuery::create()
+            ->filterByType("portrait")
+            ->withColumn("COUNT(`id`)", "count")
+            ->withColumn("SUM(`fileSize`)", "size")
+            ->select(["count", "size"])->find()->getData()[0];
 
         $publishers = ImageQuery::create()
             ->filterByType("logo")
@@ -106,12 +111,14 @@ class MaintenanceController extends Controller
             ->getData()[0];
 
         $totalCount = $articles["count"]
+            + $contributors["count"]
             + $publishers["count"]
             + $stockItems["count"]
             + $postIllustrations["count"]
             + $mediaFiles["count"]
             + $downloadableFiles["count"];
         $totalSize = $articles["size"]
+            + $contributors["size"]
             + $publishers["size"]
             + $stockItems["size"]
             + $postIllustrations["size"]
@@ -121,6 +128,8 @@ class MaintenanceController extends Controller
         return $templateService->renderResponse("AppBundle:Maintenance:disk-usage.html.twig", [
             "articlesCount" => $articles["count"],
             "articlesSize" => $this->_convertToGigabytes($articles["size"]),
+            "contributorsCount" => $contributors["count"],
+            "contributorsSize" => $this->_convertToGigabytes($contributors["size"]),
             "publishersCount" => $publishers["count"],
             "publishersSize" => $this->_convertToGigabytes($publishers["size"]),
             "stockItemsCount" => $stockItems["count"],

--- a/src/AppBundle/Controller/PeopleController.php
+++ b/src/AppBundle/Controller/PeopleController.php
@@ -5,10 +5,12 @@ namespace AppBundle\Controller;
 use ArticleManager;
 use Biblys\Legacy\LegacyCodeHelper;
 use Biblys\Service\CurrentUser;
+use Biblys\Service\Images\ImagesService;
 use Biblys\Service\Pagination;
 use Biblys\Service\QueryParamsService;
 use Exception;
 use Framework\Controller;
+use People;
 use PeopleManager;
 use Propel\Runtime\Exception\PropelException;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
@@ -112,10 +114,11 @@ class PeopleController extends Controller
      * @throws Exception
      */
     public function editAction(
-        Request      $request,
-        UrlGenerator $urlGenerator,
-        CurrentUser  $currentUser,
-        int          $id,
+        Request       $request,
+        UrlGenerator  $urlGenerator,
+        CurrentUser   $currentUser,
+        ImagesService $imagesService,
+        int           $id,
     ): RedirectResponse|Response
     {
         $currentUser->authAdmin();
@@ -175,11 +178,11 @@ class PeopleController extends Controller
                 ->set('people_twitter', $data['twitter']);
 
             try {
+                /** @var People $updated */
                 $updated = $pm->update($updated);
 
-                // If photo file is present
-                if ($data['photo'] !== null) {
-                    $updated->addPhoto($data['photo']);
+                if ($data["photo"] !== null) {
+                    $imagesService->addImageFor($updated->getModel(), $data["photo"]->getPathname());
                 }
             } catch (Exception $e) {
                 $error = $e->getMessage();

--- a/src/AppBundle/Resources/views/Maintenance/disk-usage.html.twig
+++ b/src/AppBundle/Resources/views/Maintenance/disk-usage.html.twig
@@ -27,6 +27,11 @@
         <td class="text-right">{{ articlesSize }} Go</td>
       </tr>
       <tr>
+        <td>Contributeur·ices (portrait)</td>
+        <td class="text-right">{{ contributorsCount }}</td>
+        <td class="text-right">{{ contributorsSize }} Go</td>
+      </tr>
+      <tr>
         <td>Éditeurs (logos)</td>
         <td class="text-right">{{ publishersCount }}</td>
         <td class="text-right">{{ publishersSize }} Go</td>

--- a/src/AppBundle/Resources/views/People/show.html.twig
+++ b/src/AppBundle/Resources/views/People/show.html.twig
@@ -22,8 +22,8 @@
     </div>
 
     <div class="contributor__informations">
-      {% if people|hasImage %}
-        <img src="{{ people|imageUrl }}" alt="Photo de {{ people.name }}" class="contributor__photo" />
+      {% if people.model|hasImage %}
+        <img src="{{ people.model|imageUrl }}" alt="Photo de {{ people.name }}" class="contributor__photo" />
       {% endif %}
 
       {% if people.has('bio') %}

--- a/src/AppBundle/Resources/views/People/show.html.twig
+++ b/src/AppBundle/Resources/views/People/show.html.twig
@@ -22,8 +22,8 @@
     </div>
 
     <div class="contributor__informations">
-      {% if people.hasPhoto %}
-        <img src="{{ people.photo.url }}" alt="Photo de {{ people.name }}" class="contributor__photo" />
+      {% if people|hasImage %}
+        <img src="{{ people|imageUrl }}" alt="Photo de {{ people.name }}" class="contributor__photo" />
       {% endif %}
 
       {% if people.has('bio') %}

--- a/src/Biblys/Service/Images/ImageForModel.php
+++ b/src/Biblys/Service/Images/ImageForModel.php
@@ -45,7 +45,7 @@ class ImageForModel
     {
         $imageModel = $this->getModel();
 
-        $baseUrl = rtrim($this->config->get("images.base_url"), "/");
+        $baseUrl = rtrim($this->config->getImagesBaseUrl(), "/");
         $filePath = trim($imageModel->getFilepath(), "/");
         $fileName = trim($imageModel->getFilename(), "/");
         $url = "$baseUrl/$filePath/$fileName";

--- a/src/Biblys/Service/TemplateService.php
+++ b/src/Biblys/Service/TemplateService.php
@@ -10,6 +10,7 @@ use Cart;
 use Exception;
 use Framework\TemplateLoader;
 use Model\Article;
+use Model\People;
 use Model\Post;
 use Model\Publisher;
 use Model\Stock;
@@ -276,11 +277,11 @@ class TemplateService
         $imagesService = new ImagesService($config, $currentSite, new Filesystem());
 
         $filters[] = new TwigFilter('hasImage',
-            fn (Article|Stock|Post|Publisher $model) => $imagesService->imageExistsFor($model)
+            fn (Article|Stock|Post|Publisher|People $model) => $imagesService->imageExistsFor($model)
         );
 
         $filters[] = new TwigFilter('imageUrl',
-            fn (Article|Stock|Post|Publisher $model, array $options = []) =>
+            fn (Article|Stock|Post|Publisher|People $model, array $options = []) =>
                 $imagesService->getImageUrlFor(
                     model: $model,
                     width: $options[0] ?? null,

--- a/src/Biblys/Test/ModelFactory.php
+++ b/src/Biblys/Test/ModelFactory.php
@@ -812,6 +812,7 @@ class ModelFactory
         Stock     $stockItem = null,
         Post      $post = null,
         Publisher $publisher = null,
+        People    $contributor = null,
         Site      $site = null,
         string    $type = null,
         string    $filePath = "/images/",
@@ -826,6 +827,7 @@ class ModelFactory
         $image->setStockItem($stockItem);
         $image->setPost($post);
         $image->setPublisher($publisher);
+        $image->setContributor($contributor);
         $image->setSite($site);
         $image->setFilePath($filePath);
         $image->setFileName($fileName);

--- a/src/Command/ImportImagesCommand.php
+++ b/src/Command/ImportImagesCommand.php
@@ -8,7 +8,9 @@ use Biblys\Service\LoggerService;
 use Exception;
 use Model\Article;
 use Model\ArticleQuery;
+use Model\Base\People;
 use Model\ImageQuery;
+use Model\PeopleQuery;
 use Model\Post;
 use Model\PostQuery;
 use Model\Publisher;
@@ -174,13 +176,14 @@ class ImportImagesCommand extends Command
     /**
      * @throws Exception
      */
-    private function _getModelQuery(string $modelType): ArticleQuery|StockQuery|PostQuery|PublisherQuery
+    private function _getModelQuery(string $modelType): ArticleQuery|StockQuery|PostQuery|PublisherQuery|PeopleQuery
     {
         return match ($modelType) {
             "article" => ArticleQuery::create(),
             "stock" => StockQuery::create(),
             "post" => PostQuery::create(),
             "publisher" => PublisherQuery::create(),
+            "people" => PeopleQuery::create(),
             default => throw new Exception("Unsupported model type $modelType"),
         };
     }
@@ -189,12 +192,12 @@ class ImportImagesCommand extends Command
      * @throws PropelException
      * @throws Exception
      */
-    private function _getModelTitle(Article|Stock|Post|Publisher $model, string $modelType): string
+    private function _getModelTitle(Article|Stock|Post|Publisher|People $model, string $modelType): string
     {
         return match ($modelType) {
             "article", "post" => $model->getTitle(),
             "stock" => $model->getArticle()->getTitle(),
-            "publisher" => $model->getName(),
+            "publisher", "people" => $model->getName(),
             default => throw new Exception("Unsupported model type $modelType"),
         };
     }

--- a/src/Model/ImageQuery.php
+++ b/src/Model/ImageQuery.php
@@ -19,13 +19,14 @@ class ImageQuery extends BaseImageQuery
     /**
      * @throws PropelException
      */
-    public function filterByModel(Article|Stock|Post|Publisher $model): ImageQuery
+    public function filterByModel(Article|Stock|Post|Publisher|People $model): ImageQuery
     {
         return match (get_class($model)) {
             Article::class => $this->filterByArticle($model),
             Stock::class => $this->filterByStockItem($model),
             Post::class => $this->filterByPost($model),
             Publisher::class => $this->filterByPublisher($model),
+            People::class => $this->filterByContributor($model),
             default => $this,
         };
     }

--- a/tests/AppBundle/Controller/MaintenanceControllerTest.php
+++ b/tests/AppBundle/Controller/MaintenanceControllerTest.php
@@ -35,6 +35,7 @@ class MaintenanceControllerTest extends TestCase
         ModelFactory::createImage(type: 'other', fileSize: 99999999);
         ModelFactory::createImage(site: $site, type: 'illustration', fileSize: 99999999);
         ModelFactory::createImage(site: $site, type: 'logo', fileSize: 99999999);
+        ModelFactory::createImage(site: $site, type: 'portrait', fileSize: 99999999);
         ModelFactory::createMediaFile(site: $site, fileSize: 99999999);
 
         $currentUser = Mockery::mock(CurrentUser::class);
@@ -56,6 +57,8 @@ class MaintenanceControllerTest extends TestCase
             ->with("AppBundle:Maintenance:disk-usage.html.twig", [
                 "articlesCount" => 1,
                 "articlesSize" => 0.093,
+                "contributorsCount" => 1,
+                "contributorsSize" => 0.093,
                 "publishersCount" => 1,
                 "publishersSize" => 0.093,
                 "stockItemsCount" => 1,
@@ -66,8 +69,8 @@ class MaintenanceControllerTest extends TestCase
                 "downloadableFilesSize" => 0.0,
                 "mediaFilesCount" => 1,
                 "mediaFilesSize" => 0.093,
-                "totalCount" => 5,
-                "totalSize" => 0.466,
+                "totalCount" => 6,
+                "totalSize" => 0.559,
             ]);
         $this->assertInstanceOf(Response::class, $response);
         $this->assertEquals("response", $response->getContent());
@@ -110,6 +113,8 @@ class MaintenanceControllerTest extends TestCase
             ->with("AppBundle:Maintenance:disk-usage.html.twig", [
                 "articlesCount" => 1,
                 "articlesSize" => 0.093,
+                "contributorsCount" => 1,
+                "contributorsSize" => 0.093,
                 "publishersCount" => 1,
                 "publishersSize" => 0.093,
                 "postIllustrationsCount" => 0,
@@ -120,8 +125,8 @@ class MaintenanceControllerTest extends TestCase
                 "stockItemsSize" => 0,
                 "mediaFilesCount" => 0,
                 "mediaFilesSize" => 0,
-                "totalCount" => 3,
-                "totalSize" => 0.279,
+                "totalCount" => 4,
+                "totalSize" => 0.373,
             ]);
         $this->assertInstanceOf(Response::class, $response);
         $this->assertEquals("response", $response->getContent());

--- a/tests/Biblys/Service/Images/ImageForModelTest.php
+++ b/tests/Biblys/Service/Images/ImageForModelTest.php
@@ -56,6 +56,24 @@ class ImageForModelTest extends TestCase
      * @throws PropelException
      * @throws Exception
      */
+    public function testGetUrlWithDefaultBaseUrl()
+    {
+        // given
+        $config = new Config();
+        $model = ModelFactory::createImage(filePath: "/directory/", fileName: "image.jpeg");
+        $image = new ImageForModel($config, $model);
+
+        // when
+        $path = $image->getUrl(null, null);
+
+        // then
+        $this->assertEquals("/images/directory/image.jpeg", $path);
+    }
+
+    /**
+     * @throws PropelException
+     * @throws Exception
+     */
     public function testGetUrlWithVersion()
     {
         // given

--- a/tests/Model/ImageQueryTest.php
+++ b/tests/Model/ImageQueryTest.php
@@ -75,4 +75,20 @@ class ImageQueryTest extends TestCase
         $this->assertEquals($image->getPublisher(), $publisher);
     }
 
+    /**
+     * @throws PropelException
+     */
+    public function testFilterByModelWithContributor(): void
+    {
+        // given
+        $contributor = ModelFactory::createContributor();
+        ModelFactory::createImage(contributor: $contributor);
+
+        // when
+        $image = ImageQuery::create()->filterByModel($contributor)->findOne();
+
+        // then
+        $this->assertEquals($image->getContributor(), $contributor);
+    }
+
 }

--- a/tests/PeopleTest.php
+++ b/tests/PeopleTest.php
@@ -5,6 +5,7 @@
 */
 
 use Biblys\Legacy\LegacyCodeHelper;
+use Biblys\Test\EntityFactory;
 
 require_once "setUp.php";
 
@@ -206,5 +207,21 @@ class PeopleTest extends PHPUnit\Framework\TestCase
         $people = $pm->getById($people->get('id'));
 
         $this->assertFalse($people);
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testGetModel(): void
+    {
+        // given
+        $entity = EntityFactory::createPeople();
+
+        // when
+        $model = $entity->getModel();
+
+        // then
+        $this->assertInstanceOf(\Model\People::class, $model);
+        $this->assertEquals($model->getId(), $entity->get('id'));
     }
 }


### PR DESCRIPTION
## 📸 Problème

Aujourd'hui, Biblys n'a pas de moyen de savoir s'il existe un portrait pour un·e contributeur·ice autrement qu'en interrogeant le système de fichiers.

## 😛 Solution

Utiliser la table `images` pour les  portraits de contributeur·ice [comme cela a été fait pour les illustrations de billet de blog](https://github.com/biblys/biblys/pull/98).

## 🎞️ Todo

- [x] Vérifier l'existence un portrait de contributeur·ice à l'aide du `ImagesService`
- [x] Ajouter un portrait de contributeur·ice à l'aide du `ImagesService`
- [x] Obtenir l'url d'un portrait de contributeur·ice à l'aide du `ImagesService`
- [x] Supprimer un portrait de contributeur·ice à l'aide du `ImagesService`
- [x] Permettre d'utiliser `contributor.model|hasImage` et `contributor.model|imageUrl` dans les templates
- [x] Remplacer `Media` par `ImagesService` pour les portraits de contributeur·ice
- [x] Ajouter un script pour charger les portraits de contributeur·ice déjà existants en base
- [x] Ajouter la catégorie "Contributeur·ices" à la page espace disque