### PR TITLE
Gérer en base de données les illustrations d'évènements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,13 @@
 ### Améliorations
 
 - Les images (couvertures d'articles, photos d'exemplaires, illustrations de
-  billets de blog, logo d'éditeurs, portraits de contribeur·ices) peuvent
-  désormais être au format PNG ou WebP en plus de JPEG.
+  billets de blog, logo d'éditeurs, portraits de contributeur·ices,
+  illustrations d'évènements) peuvent désormais être au format PNG ou WebP.
 - La page "Espace disque" affiche désormais la taille occupée par les logos
-  d'éditeurs et les portraits de contributeur·ices.
-- La commande `images:import` gère désormais les portraits de contributeur·ices.
+  d'éditeurs, les portraits de contributeur·ices et les illustrations
+  d'évènements.
+- La commande `images:import` gère désormais les logos d'éditeurs, les portraits
+  de contributeur·ices et les illustrations d'évènements.
 - Une nouvelle commande `images:export` permet d'exporter les images de
   couverture des articles d'une collection précise.
 - Sur la page d'édition d'un exemplaire, un nouveau bouton permet de marquer un
@@ -32,6 +34,7 @@ les portraits de contributeur·ices doivent être importés avec les commandes :
 ```shell
 composer images:import post
 composer images:import people
+composer images:import event
 ```
 
 ## 2.86.3 (23 octobre 2024)

--- a/inc/Event.class.php
+++ b/inc/Event.class.php
@@ -26,6 +26,14 @@ class Event extends Entity
         parent::__construct($data);
     }
 
+    public function getModel(): \Model\Event
+    {
+        $model = new \Model\Event();
+        $model->setId($this->get('id'));
+
+        return $model;
+    }
+
     public function hasIllustration(): bool
     {
         return false;

--- a/inc/Event.class.php
+++ b/inc/Event.class.php
@@ -26,33 +26,11 @@ class Event extends Entity
         parent::__construct($data);
     }
 
-    public function getIllustration()
+    public function hasIllustration(): bool
     {
-        if (!isset($this->illustration)) {
-            $this->illustration = new Media('post', $this->get('id'));
-        }
-        return $this->illustration;
+        return false;
     }
 
-    public function hasIllustration()
-    {
-        $illustration = $this->getIllustration();
-        if (!isset($this->illustrationExists)) {
-            $this->illustrationExists = $illustration->exists();
-        }
-        return $this->illustrationExists;
-    }
-
-    public function getIllustrationTag()
-    {
-        $illustration = $this->getIllustration();
-        return '<img src="'.$illustration->url().'" alt="'.$this->get('illustration_legend').'" class="illustration">';
-    }
-
-    /**
-     * Get related articles
-     * @return {array} of {Articles}
-     */
     public function getArticles()
     {
         $lm = new LinkManager();

--- a/inc/Media.class.php
+++ b/inc/Media.class.php
@@ -18,20 +18,18 @@ class Media
     private Config $config;
 
     /**
+     * @deprecated Using Media class is deprecated. Use ImagesService instead.
      * @throws Exception
      */
     public function __construct($type, $id)
     {
         $this->config = Config::load();
 
-        if (in_array($type, ["article", "stock", "post", "publisher", "people"])) {
-            trigger_deprecation(
-                "biblys",
-                "2.83.0",
-                "Using Media with '$type' type is deprecated." .
-                "Use ImagesService->getImageFor instead"
-            );
-        }
+        trigger_deprecation(
+            "biblys",
+            "3.0.0",
+            "Using Media class is deprecated. Use ImagesService instead."
+        );
 
         $this->setDomain('media'); // domaine par défaut
 

--- a/inc/Media.class.php
+++ b/inc/Media.class.php
@@ -14,7 +14,6 @@ class Media
     private string $_directoryPath;
     private ?string $_path = null;
     private bool $_exists = false;
-    private array $_dimensions;
     private Config $config;
 
     /**
@@ -57,96 +56,6 @@ class Media
         // Exists
         if (realpath($this->path()) !== false) {
             $this->setExists(true);
-        }
-    }
-
-    /**
-     * Upload a new file
-     */
-    public function upload($file): bool
-    {
-        // If file already exists, delete it
-        if ($this->exists()) {
-            $this->delete();
-        }
-
-        // If directory do not already exists create it
-        if (!is_dir($this->directoryPath())) {
-            mkdir($this->directoryPath(), 0777, true);
-        }
-
-        // Copy file from temp upload path
-        if (copy($file, $this->path())) {
-            $this->update();
-            return true;
-        }
-
-        return false;
-    }
-
-    public function getDimensions(): array
-    {
-        if (!isset($this->_dimensions)) {
-            $size = getimagesize($this->path());
-            $this->_dimensions = [
-                'height' => $size[1],
-                'width' => $size[0],
-            ];
-        }
-
-        return $this->_dimensions;
-    }
-
-    public function getOrientation(): string
-    {
-        $dimensions = $this->getDimensions();
-        $height = $dimensions['height'];
-        $width = $dimensions['width'];
-        $ratio = $width / $height;
-
-        if ($ratio > 1) {
-            return 'landscape';
-        }
-
-        return 'portrait';
-    }
-
-    /**
-     * Fix image orientation based on exif
-     *
-     * @param string $file file path to image to fix
-     */
-    public function fixImageOrientation(string $file): void
-    {
-
-        // Skip if image is not jpeg
-        $mimeType = mime_content_type($file);
-        if ($mimeType !== 'image/jpeg') {
-            return;
-        }
-
-        $image = imagecreatefromjpeg($file);
-
-        $exif = exif_read_data($file);
-        if (!empty($exif['Orientation'])) {
-            switch ($exif['Orientation']) {
-                case 3:
-                    $image = imagerotate($image, 180, 0);
-                    break;
-
-                case 6:
-                    $image = imagerotate($image, -90, 0);
-                    break;
-
-                case 8:
-                    $image = imagerotate($image, 90, 0);
-                    break;
-            }
-        }
-
-        if ($image) {
-            imagejpeg($image, $file);
-            imagedestroy($image);
         }
     }
 

--- a/src/AppBundle/Controller/MaintenanceController.php
+++ b/src/AppBundle/Controller/MaintenanceController.php
@@ -9,6 +9,7 @@ use Framework\Controller;
 use Model\FileQuery;
 use Model\ImageQuery;
 use Model\MediaFileQuery;
+use Propel\Runtime\ActiveQuery\Criteria;
 use Propel\Runtime\Exception\PropelException;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
@@ -95,6 +96,17 @@ class MaintenanceController extends Controller
 
         $postIllustrations = ImageQuery::create()
             ->filterByType("illustration")
+            ->filterByPostId(null, Criteria::ISNOTNULL)
+            ->filterBySite($currentSite->getSite())
+            ->withColumn('COUNT(`id`)', 'count')
+            ->withColumn('SUM(`fileSize`)', 'size')
+            ->select(['count', 'size'])
+            ->find()
+            ->getData()[0];
+
+        $eventIllustrations = ImageQuery::create()
+            ->filterByType("illustration")
+            ->filterByEventId(null, Criteria::ISNOTNULL)
             ->filterBySite($currentSite->getSite())
             ->withColumn('COUNT(`id`)', 'count')
             ->withColumn('SUM(`fileSize`)', 'size')
@@ -115,6 +127,7 @@ class MaintenanceController extends Controller
             + $publishers["count"]
             + $stockItems["count"]
             + $postIllustrations["count"]
+            + $eventIllustrations["count"]
             + $mediaFiles["count"]
             + $downloadableFiles["count"];
         $totalSize = $articles["size"]
@@ -122,6 +135,7 @@ class MaintenanceController extends Controller
             + $publishers["size"]
             + $stockItems["size"]
             + $postIllustrations["size"]
+            + $eventIllustrations["size"]
             + $mediaFiles["size"]
             + $downloadableFiles["size"];
 
@@ -136,6 +150,8 @@ class MaintenanceController extends Controller
             "stockItemsSize" => $this->_convertToGigabytes($stockItems["size"]),
             "postIllustrationsCount" => $postIllustrations["count"],
             "postIllustrationsSize" => $this->_convertToGigabytes($postIllustrations["size"]),
+            "eventIllustrationsCount" => $eventIllustrations["count"],
+            "eventIllustrationsSize" => $this->_convertToGigabytes($eventIllustrations["size"]),
             "downloadableFilesCount" => $downloadableFiles["count"],
             "downloadableFilesSize" => $this->_convertToGigabytes($downloadableFiles["size"]),
             "mediaFilesCount" => $mediaFiles["count"],

--- a/src/AppBundle/Resources/views/Event/_event.html.twig
+++ b/src/AppBundle/Resources/views/Event/_event.html.twig
@@ -12,10 +12,11 @@
     </p>
   </header>
 
-  {% if event.hasIllustration() %}
+  {% if event.model|hasImage %}
     <div class="event-illustration">
-      <img src="{{ event.illustration.url }}"
-           class="event-illustration-image" {% if event.has('illustration_legend') %} alt="{{ event.illustration_legend }}" {% endif %}>
+      <img src="{{ event.model|imageUrl }}" class="event-illustration-image"
+        {% if event.has('illustration_legend') %} alt="{{ event.illustration_legend }}" {% endif %}
+      >
     </div>
   {% endif %}
 

--- a/src/AppBundle/Resources/views/Maintenance/disk-usage.html.twig
+++ b/src/AppBundle/Resources/views/Maintenance/disk-usage.html.twig
@@ -47,6 +47,11 @@
         <td class="text-right">{{ postIllustrationsSize }} Go</td>
       </tr>
       <tr>
+        <td>Évènements (illustrations)</td>
+        <td class="text-right">{{ eventIllustrationsCount }}</td>
+        <td class="text-right">{{ eventIllustrationsSize }} Go</td>
+      </tr>
+      <tr>
         <td>Médias</td>
         <td class="text-right">{{ mediaFilesCount }}</td>
         <td class="text-right">{{ mediaFilesSize }} Go</td>

--- a/src/Biblys/Service/Images/ImagesService.php
+++ b/src/Biblys/Service/Images/ImagesService.php
@@ -6,6 +6,7 @@ use Biblys\Service\Config;
 use Biblys\Service\CurrentSite;
 use Exception;
 use Model\Article;
+use Model\Event;
 use Model\Image;
 use Model\ImageQuery;
 use Model\Map\ImageTableMap;
@@ -31,7 +32,7 @@ class ImagesService
     /**
      * @throws PropelException
      */
-    public function addImageFor(Article|Stock|Post|Publisher|People $model, string $imagePath): void
+    public function addImageFor(Article|Stock|Post|Publisher|People|Event $model, string $imagePath): void
     {
         match (get_class($model)) {
             Article::class => $this->_addImage($imagePath, type: "cover", typeDirectory: "book", article: $model),
@@ -39,6 +40,7 @@ class ImagesService
             Post::class => $this->_addImage($imagePath, type: "illustration", typeDirectory: "post", post: $model),
             Publisher::class => $this->_addImage($imagePath, type: "logo", typeDirectory: "publisher", publisher: $model),
             People::class => $this->_addImage($imagePath, type: "portrait", typeDirectory: "people", contributor: $model),
+            Event::class => $this->_addImage($imagePath, type: "illustration", typeDirectory: "event", event: $model),
         };
     }
 
@@ -54,9 +56,10 @@ class ImagesService
         Post      $post = null,
         Publisher $publisher = null,
         People    $contributor = null,
+        Event     $event = null,
     ): void
     {
-        $model = $article ?? $stockItem ?? $post ?? $publisher ?? $contributor;
+        $model = $article ?? $stockItem ?? $post ?? $publisher ?? $contributor ?? $event;
 
         $imageDirectory = str_pad(
             string: substr(string: $model->getId(), offset: -2, length: 2),
@@ -94,6 +97,7 @@ class ImagesService
         $imageModel->setPostId($post?->getId());
         $imageModel->setPublisherId($publisher?->getId());
         $imageModel->setContributorId($contributor?->getId());
+        $imageModel->setEventId($event?->getId());
         $imageModel->setFilepath("$typeDirectory/$imageDirectory/");
         $imageModel->setFilename("{$model->getId()}$fileExtension");
         $imageModel->setMediatype($mediaType);
@@ -117,7 +121,7 @@ class ImagesService
     /**
      * @throws PropelException
      */
-    public function deleteImageFor(Article|Stock|Post|Publisher|People $model): void
+    public function deleteImageFor(Article|Stock|Post|Publisher|People|Event $model): void
     {
         $db = Propel::getWriteConnection(ImageTableMap::DATABASE_NAME);
         $db->beginTransaction();
@@ -137,7 +141,7 @@ class ImagesService
     /**
      * @throws PropelException
      */
-    public function imageExistsFor(Article|Stock|Post|Publisher|People $model): bool
+    public function imageExistsFor(Article|Stock|Post|Publisher|People|Event $model): bool
     {
         return ImageQuery::create()->filterByModel($model)->exists();
     }
@@ -146,7 +150,7 @@ class ImagesService
      * @throws PropelException
      */
     public function getImageUrlFor(
-        Article|Stock|Post|Publisher|People $model,
+        Article|Stock|Post|Publisher|People|Event $model,
         int                                 $width = null,
         int                                 $height = null
     ):
@@ -176,7 +180,7 @@ class ImagesService
     /**
      * @throws PropelException
      */
-    private function _getImageFor(Article|Stock|Post|Publisher|People $model): ImageForModel
+    private function _getImageFor(Article|Stock|Post|Publisher|People|Event $model): ImageForModel
     {
         $image = ImageQuery::create()->filterByModel($model)->findOne();
         return new ImageForModel($this->config, $image);

--- a/src/Biblys/Service/TemplateService.php
+++ b/src/Biblys/Service/TemplateService.php
@@ -10,6 +10,7 @@ use Cart;
 use Exception;
 use Framework\TemplateLoader;
 use Model\Article;
+use Model\Event;
 use Model\People;
 use Model\Post;
 use Model\Publisher;
@@ -277,11 +278,11 @@ class TemplateService
         $imagesService = new ImagesService($config, $currentSite, new Filesystem());
 
         $filters[] = new TwigFilter('hasImage',
-            fn (Article|Stock|Post|Publisher|People $model) => $imagesService->imageExistsFor($model)
+            fn (Article|Stock|Post|Publisher|People|Event $model) => $imagesService->imageExistsFor($model)
         );
 
         $filters[] = new TwigFilter('imageUrl',
-            fn (Article|Stock|Post|Publisher|People $model, array $options = []) =>
+            fn (Article|Stock|Post|Publisher|People|Event $model, array $options = []) =>
                 $imagesService->getImageUrlFor(
                     model: $model,
                     width: $options[0] ?? null,

--- a/src/Biblys/Test/ModelFactory.php
+++ b/src/Biblys/Test/ModelFactory.php
@@ -813,6 +813,7 @@ class ModelFactory
         Post      $post = null,
         Publisher $publisher = null,
         People    $contributor = null,
+        Event     $event = null,
         Site      $site = null,
         string    $type = null,
         string    $filePath = "/images/",
@@ -828,6 +829,7 @@ class ModelFactory
         $image->setPost($post);
         $image->setPublisher($publisher);
         $image->setContributor($contributor);
+        $image->setEvent($event);
         $image->setSite($site);
         $image->setFilePath($filePath);
         $image->setFileName($fileName);

--- a/src/Model/ImageQuery.php
+++ b/src/Model/ImageQuery.php
@@ -19,7 +19,7 @@ class ImageQuery extends BaseImageQuery
     /**
      * @throws PropelException
      */
-    public function filterByModel(Article|Stock|Post|Publisher|People $model): ImageQuery
+    public function filterByModel(Article|Stock|Post|Publisher|People|Event $model): ImageQuery
     {
         return match (get_class($model)) {
             Article::class => $this->filterByArticle($model),
@@ -27,6 +27,7 @@ class ImageQuery extends BaseImageQuery
             Post::class => $this->filterByPost($model),
             Publisher::class => $this->filterByPublisher($model),
             People::class => $this->filterByContributor($model),
+            Event::class => $this->filterByEvent($model),
             default => $this,
         };
     }

--- a/tests/AppBundle/Controller/MaintenanceControllerTest.php
+++ b/tests/AppBundle/Controller/MaintenanceControllerTest.php
@@ -33,7 +33,12 @@ class MaintenanceControllerTest extends TestCase
         ModelFactory::createImage(type: 'cover', fileSize: 99999999);
         ModelFactory::createImage(site: $site, type: 'photo', fileSize: 99999999);
         ModelFactory::createImage(type: 'other', fileSize: 99999999);
-        ModelFactory::createImage(site: $site, type: 'illustration', fileSize: 99999999);
+        ModelFactory::createImage(
+            post: ModelFactory::createPost(site: $site), site: $site, type: 'illustration', fileSize: 99999999
+        );
+        ModelFactory::createImage(
+            event: ModelFactory::createEvent(site: $site), site: $site, type: 'illustration', fileSize: 99999999
+        );
         ModelFactory::createImage(site: $site, type: 'logo', fileSize: 99999999);
         ModelFactory::createImage(site: $site, type: 'portrait', fileSize: 99999999);
         ModelFactory::createMediaFile(site: $site, fileSize: 99999999);
@@ -65,12 +70,14 @@ class MaintenanceControllerTest extends TestCase
                 "stockItemsSize" => 0.093,
                 "postIllustrationsCount" => 1,
                 "postIllustrationsSize" => 0.093,
+                "eventIllustrationsCount" => 1,
+                "eventIllustrationsSize" => 0.093,
                 "downloadableFilesCount" => 0,
                 "downloadableFilesSize" => 0.0,
                 "mediaFilesCount" => 1,
                 "mediaFilesSize" => 0.093,
-                "totalCount" => 6,
-                "totalSize" => 0.559,
+                "totalCount" => 7,
+                "totalSize" => 0.652,
             ]);
         $this->assertInstanceOf(Response::class, $response);
         $this->assertEquals("response", $response->getContent());
@@ -119,6 +126,8 @@ class MaintenanceControllerTest extends TestCase
                 "publishersSize" => 0.093,
                 "postIllustrationsCount" => 0,
                 "postIllustrationsSize" => 0,
+                "eventIllustrationsCount" => 0,
+                "eventIllustrationsSize" => 0,
                 "downloadableFilesCount" => 1,
                 "downloadableFilesSize" => 0.093,
                 "stockItemsCount" => 0,

--- a/tests/Model/ImageQueryTest.php
+++ b/tests/Model/ImageQueryTest.php
@@ -91,4 +91,21 @@ class ImageQueryTest extends TestCase
         $this->assertEquals($image->getContributor(), $contributor);
     }
 
+
+    /**
+     * @throws PropelException
+     */
+    public function testFilterByModelWithEvent(): void
+    {
+        // given
+        $site = ModelFactory::createSite();
+        $event = ModelFactory::createEvent($site);
+        ModelFactory::createImage(event: $event);
+
+        // when
+        $image = ImageQuery::create()->filterByModel($event)->findOne();
+
+        // then
+        $this->assertEquals($image->getEvent(), $event);
+    }
 }


### PR DESCRIPTION
## 📸 Problème

Aujourd'hui, Biblys n'a pas de moyen de savoir s'il existe une illustration pour un évènement autrement qu'en interrogeant le système de fichiers.

## 😛 Solution

Utiliser la table `images` pour les illustrations d'évènements [comme cela a été fait pour les illustrations de billet de blog](https://github.com/biblys/biblys/pull/98).

## 🎞️ Todo

- [x] Vérifier l'existence une illustration d'évènements à l'aide du `ImagesService`
- [x] Ajouter une illustration d'évènements à l'aide du `ImagesService`
- [x] Obtenir l'url d'une illustration d'évènements à l'aide du `ImagesService`
- [x] Supprimer une illustration d'évènements à l'aide du `ImagesService`
- [x] Permettre d'utiliser `event.model|hasImage` et `event.model|imageUrl` dans les templates
- [x] Remplacer `Media` par `ImagesService` pour les illustrations d'évènements
- [x] Ajouter un script pour charger les illustrations d'évènements déjà existants en base
- [x] Ajouter la catégorie "Évènements" à la page espace disque