### PR TITLE
Déplacer les fichiers téléchargeables dans le répertoire du site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ node_modules
 .phpunit.result.cache
 data/*
 .yarn
+content/downloadable
 
 # IDE config files
 .idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,11 +25,26 @@
   couverture des articles d'une collection précise.
 - Sur la page d'édition d'un exemplaire, un nouveau bouton permet de marquer un
   exemplaire perdu comme retrouvé.
+- Une commande `files:migrate` a été ajoutée pour migrer les fichiers de
+  téléchargement des articles vers le nouveau répertoire.
 
 ### Instructions de mise à jour
 
-Après avoir procédé à l'installation de cette version, les logos d'éditeurs et
-les portraits de contributeur·ices doivent être importés avec les commandes :
+Après avoir procédé à l'installation de cette version…
+
+#### 1. Jouer les migrations
+
+```shell
+composer propel migrate
+```
+
+#### 2. Migrer les fichiers téléchargeables
+
+```shell
+composer files:migrate
+```
+
+#### 3. Importer les logos d'éditeurs, portraits de contributeur·ices et illustrations d'évènements
 
 ```shell
 composer images:import post

--- a/bin/console
+++ b/bin/console
@@ -17,6 +17,7 @@ use Command\CreateSeedsCommand;
 use Command\ExportImagesCommand;
 use Command\ImportImagesCommand;
 use Command\ImportMediaCommand;
+use Command\MigrateFilesCommand;
 use Command\OptimizeImagesCommand;
 use Command\ResetDatabaseCommand;
 use Symfony\Component\Console\Application;
@@ -37,6 +38,7 @@ try {
     $application->add(new ExportImagesCommand($imagesServices));
     $application->add(new OptimizeImagesCommand($config, $filesystem));
     $application->add(new ImportMediaCommand($currentSite, $filesystem));
+    $application->add(new MigrateFilesCommand($filesystem));
 } catch (InvalidSiteIdException) {
 }
 

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
     "images:import": "bin/console images:import",
     "images:export": "bin/console images:export",
     "images:optimize": "bin/console images:optimize",
-    "media:import": "bin/console media:import"
+    "media:import": "bin/console media:import",
+    "files:migrate": "bin/console files:migrate"
   },
   "require": {
     "php": "~8.1",

--- a/controllers/common/php/adm_article_files.php
+++ b/controllers/common/php/adm_article_files.php
@@ -90,6 +90,7 @@ return function (Request $request, CurrentSite $currentSite, CurrentUser $curren
             throw new BadRequestHttpException("Le titre du fichier ne doit pas dépasser 32 caractères.");
         }
 
+        $file->setSite($currentSite->getSite());
         $file->setArticleId($articleId);
         $file->setAxysAccountId($currentUser->getUser()->getId());
         $file->setTitle($title);

--- a/controllers/common/php/adm_article_files.php
+++ b/controllers/common/php/adm_article_files.php
@@ -4,6 +4,7 @@ use Biblys\Isbn\Isbn as Isbn;
 use Biblys\Service\CurrentSite;
 use Biblys\Service\CurrentUser;
 use Model\FileQuery;
+use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -41,6 +42,8 @@ return function (Request $request, CurrentSite $currentSite, CurrentUser $curren
 
     if ($action === "delete") {
         try {
+            $fileSystem = new FileSystem();
+            $fileSystem->remove($file->getFullPath());
             $file->delete();
         } catch (Exception $e) {
             error($e);

--- a/controllers/common/php/adm_article_files.php
+++ b/controllers/common/php/adm_article_files.php
@@ -102,12 +102,9 @@ return function (Request $request, CurrentSite $currentSite, CurrentUser $curren
         $file->setSize($size);
         $file->setUploaded(date('Y-m-d H:i:s'));
 
-        $filePath = $fileEntity->getDir().$file->getHash();
-        if (copy($uploadedFile["tmp_name"], $filePath)) {
-            $file->save();
-        } else {
-            throw new Exception('Copy error');
-        }
+        $fileSystem = new FileSystem();
+        $fileSystem->copy($uploadedFile["tmp_name"], $file->getFullPath());
+        $file->save();
 
         /** @var File $fileEntity */
         $fileEntity = $fm->getById($file->getId());

--- a/generated-migrations/PropelMigration_1730188853.php
+++ b/generated-migrations/PropelMigration_1730188853.php
@@ -1,0 +1,116 @@
+<?php
+use Propel\Generator\Manager\MigrationManager;
+
+/**
+ * Data object containing the SQL and PHP code to migrate the database
+ * up to version 1730188853.
+ * Generated on 2024-10-29 08:00:53 by clement */
+class PropelMigration_1730188853{
+    /**
+     * @var string
+     */
+    public $comment = '';
+
+    /**
+     * @param \Propel\Generator\Manager\MigrationManager $manager
+     *
+     * @return null|false|void
+     */
+    public function preUp(MigrationManager $manager)
+    {
+        // add the pre-migration code here
+    }
+
+    /**
+     * @param \Propel\Generator\Manager\MigrationManager $manager
+     *
+     * @return null|false|void
+     */
+    public function postUp(MigrationManager $manager)
+    {
+        // add the post-migration code here
+    }
+
+    /**
+     * @param \Propel\Generator\Manager\MigrationManager $manager
+     *
+     * @return null|false|void
+     */
+    public function preDown(MigrationManager $manager)
+    {
+        // add the pre-migration code here
+    }
+
+    /**
+     * @param \Propel\Generator\Manager\MigrationManager $manager
+     *
+     * @return null|false|void
+     */
+    public function postDown(MigrationManager $manager)
+    {
+        // add the post-migration code here
+    }
+
+    /**
+     * Get the SQL statements for the Up migration
+     *
+     * @return array list of the SQL strings to execute for the Up migration
+     *               the keys being the datasources
+     */
+    public function getUpSQL(): array
+    {
+        $connection_default = <<< 'EOT'
+
+# This is a fix for InnoDB in MySQL >= 4.1.x
+# It "suspends judgement" for fkey relationships until are tables are set.
+SET FOREIGN_KEY_CHECKS = 0;
+
+ALTER TABLE `downloads` ADD `site_id` int unsigned AFTER `download_id`;
+
+CREATE INDEX `downloads_fi_db3f76` ON `downloads` (`site_id`);
+
+ALTER TABLE `files` ADD `site_id` int unsigned AFTER `file_id`;
+
+CREATE INDEX `files_fi_db3f76` ON `files` (`site_id`);
+
+# This restores the fkey checks, after having unset them earlier
+SET FOREIGN_KEY_CHECKS = 1;
+EOT;
+
+        return [
+            'default' => $connection_default,
+        ];
+    }
+
+    /**
+     * Get the SQL statements for the Down migration
+     *
+     * @return array list of the SQL strings to execute for the Down migration
+     *               the keys being the datasources
+     */
+    public function getDownSQL(): array
+    {
+        $connection_default = <<< 'EOT'
+
+# This is a fix for InnoDB in MySQL >= 4.1.x
+# It "suspends judgement" for fkey relationships until are tables are set.
+SET FOREIGN_KEY_CHECKS = 0;
+
+DROP INDEX `downloads_fi_db3f76` ON `downloads`;
+
+ALTER TABLE `downloads` DROP `site_id`;
+
+DROP INDEX `files_fi_db3f76` ON `files`;
+
+ALTER TABLE `files` DROP `site_id`;
+
+# This restores the fkey checks, after having unset them earlier
+SET FOREIGN_KEY_CHECKS = 1;
+EOT;
+
+        return [
+            'default' => $connection_default,
+        ];
+    }
+
+}

--- a/public/common/js/biblys-admin.js
+++ b/public/common/js/biblys-admin.js
@@ -182,7 +182,7 @@ function reloadAdminEvents() {
         dataType: 'json',
         success: function(r) {
           if (r.error) {
-            _alert('Erreur : ' + r.error);
+            _alert('Erreur : ' + r.error.message);
           } else if (r.success) {
             $('#dlfile_' + file_id).hide();
             notify(r.success);
@@ -215,7 +215,7 @@ function reloadAdminEvents() {
         dataType: 'json',
         success: function(r) {
           if (r.error) {
-            _alert('Erreur : ' + r.error);
+            _alert('Erreur : ' + r.error.message);
           } else if (r.success) {
             notify(r.success);
           }
@@ -277,7 +277,7 @@ function reloadAdminEvents() {
       xhr.onload = function() {
         var r = JSON.parse(xhr.response);
         if (r.error) {
-          _alert('Erreur : ' + r.error);
+          _alert('Erreur : ' + r.error.message);
         } else if (r.success) {
           $('#dlfile_' + file_id).replaceWith(r.new_line);
           notify(r.success);

--- a/schema.xml
+++ b/schema.xml
@@ -469,6 +469,10 @@
   </table>
   <table name="downloads" idMethod="native" phpName="Download">
     <column name="download_id" phpName="Id" type="BIGINT" sqlType="bigint unsigned" primaryKey="true" autoIncrement="true" required="true"/>
+    <column name="site_id" phpName="SiteId" type="INTEGER" sqlType="int unsigned"/>
+    <foreign-key foreignTable="sites" skipSql="true">
+      <reference local="site_id" foreign="site_id"/>
+    </foreign-key>
     <column name="file_id" phpName="FileId" type="INTEGER" sqlType="int unsigned"/>
     <column name="article_id" phpName="ArticleId" type="INTEGER" sqlType="int unsigned"/>
     <column name="book_id" phpName="BookId" type="INTEGER" sqlType="int unsigned"/>
@@ -526,6 +530,10 @@
   </table>
   <table name="files" idMethod="native" phpName="File">
     <column name="file_id" phpName="Id" type="INTEGER" sqlType="int unsigned" primaryKey="true" autoIncrement="true" required="true"/>
+    <column name="site_id" phpName="SiteId" type="INTEGER" sqlType="int unsigned"/>
+    <foreign-key foreignTable="sites" skipSql="true">
+      <reference local="site_id" foreign="site_id"/>
+    </foreign-key>
     <column name="article_id" phpName="ArticleId" type="INTEGER" sqlType="int unsigned"/>
     <foreign-key foreignTable="articles" skipSql="true">
       <reference local="article_id" foreign="article_id"/>

--- a/src/AppBundle/Controller/FileController.php
+++ b/src/AppBundle/Controller/FileController.php
@@ -8,6 +8,7 @@ use File;
 use FileManager;
 use Framework\Controller;
 use StockManager;
+use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\Routing\Exception\ResourceNotFoundException as NotFoundException;
@@ -68,6 +69,13 @@ class FileController extends Controller
             $sm->update($copy);
         }
 
+        $filesystem = new FileSystem();
+        if (!$filesystem->exists($file->getPath())) {
+            throw new NotFoundException("No content found for file $id.");
+        }
+
+        $fileContent = file_get_contents($file->getPath());
+
         $response = new Response();
 
         // Force download only if non-public file
@@ -81,7 +89,7 @@ class FileController extends Controller
         $response->headers->set('Cache-Control', 'must-revalidate, post-check=0, pre-check=0, public');
         $response->headers->set('Expires', '0');
 
-        $response->setContent(file_get_contents($file->getPath()));
+        $response->setContent($fileContent);
 
         $response->send();
         die();

--- a/src/Command/MigrateFilesCommand.php
+++ b/src/Command/MigrateFilesCommand.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace Command;
+
+use Biblys\Service\LoggerService;
+use Exception;
+use Model\File;
+use Model\FileQuery;
+use Model\OptionQuery;
+use Model\Site;
+use Model\SiteQuery;
+use Propel\Runtime\ActiveQuery\Criteria;
+use Propel\Runtime\Exception\PropelException;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Filesystem\Filesystem;
+
+class MigrateFilesCommand extends Command
+{
+    protected static $defaultName = "files:migrate";
+
+    public function __construct(
+        private readonly Filesystem    $filesystem,
+        string                         $name = null,
+    )
+    {
+        parent::__construct($name);
+    }
+
+    protected function configure(): void
+    {
+        $this->setDescription("Optimizes images found in the images directory");
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $filesToMigrate = FileQuery::create()
+            ->filterBySiteId(null, Criteria::ISNULL)
+            ->leftJoinWithArticle()
+            ->limit(10)
+            ->find();
+
+        $progressBar = new ProgressBar($output, $filesToMigrate->count());
+        $progressBar->setFormat("%current%/%max% [%bar%] %percent:3s%% (%remaining:6s%) %message%");
+        $progressBar->start();
+
+        $filesMigrated = 0;
+        $filesSkipped = 0;
+
+        $oldBasePath = __DIR__ . "/../../../../dl/files";
+
+        $loggerService = new LoggerService();
+
+        $sitesForPublisherIds = $this->_getSitesForPublishers();
+
+        /** @var File $file */
+        foreach ($filesToMigrate as $file) {
+
+            $padDirectory = str_pad(substr($file->getId(), -2, 2), 2, "0", STR_PAD_LEFT);
+            $articleDirectory = $file->getId();
+            $oldFilePath = "$oldBasePath/$padDirectory/$articleDirectory/{$file->getHash()}";
+
+            if (!$this->filesystem->exists($oldFilePath)) {
+                $logMessage = "Skipped file not found on filesystem {$file->getId()}";
+                $loggerService->log("files-migrate", "info", $logMessage);
+                $progressBar->setMessage($logMessage);
+                $progressBar->advance();
+                $filesSkipped++;
+                continue;
+            }
+
+            $article = $file->getArticle();
+            if (!$article) {
+                $logMessage = "Skipped file {$file->getId()} for non existent article {$file->getArticleId()}";
+                $loggerService->log("files-migrate", "info", $logMessage);
+                $progressBar->setMessage($logMessage);
+                $progressBar->advance();
+                $filesSkipped++;
+                continue;
+            }
+
+            $publisherId = $article->getPublisherId();
+            $targetSite = $this->_getSiteForPublisher($publisherId, $sitesForPublisherIds);
+
+            if (!$targetSite) {
+                $logMessage = "No target site found for file {$file->getId()} with publisher $publisherId";
+                $loggerService->log("files-migrate", "info", $logMessage);
+                $progressBar->setMessage($logMessage);
+                $progressBar->advance();
+                $filesSkipped++;
+                continue;
+            }
+
+            $file->setSite($targetSite);
+            $file->save();
+
+            $targetSiteName = $targetSite->getName();
+
+            $targetBasePath = realpath(__DIR__ . "/../../../");
+            $targetFilePath = "/$targetSiteName/content/downloadable/{$article->getId()}/{$file->getHash()}";
+            $targetFullPath = $targetBasePath . $targetFilePath;
+
+            $this->filesystem->copy($oldFilePath, $targetFullPath);
+
+            $successMessage = "Migrated file {$file->getId()} to new path $targetFullPath";
+            $loggerService->log("files-migrate", "info", $successMessage);
+            $progressBar->setMessage($successMessage);
+
+            $progressBar->advance();
+            $filesMigrated++;
+        }
+
+        $progressBar->finish();
+        $logMessage = "\n$filesMigrated files migrated to new path and $filesSkipped files skipped";
+        $loggerService->log("files-migrate", "info", $logMessage);
+        $output->writeln($logMessage);
+
+        return 0;
+    }
+
+    /**
+     * @throws PropelException
+     */
+    private function _getSitesForPublishers(): array
+    {
+        $sitesForPublisherIds = [];
+        $sites = SiteQuery::create()->find();
+
+        /** @var Site $site */
+        foreach ($sites as $site) {
+            $sitesForPublisherIds[$site->getPublisherId()] = $site;
+        }
+
+        $publisherFilterOptions = OptionQuery::create()
+            ->filterByKey("publisher_filter")
+            ->find();
+        foreach ($publisherFilterOptions as $publisherFilterOption) {
+            $publisherIds = explode(",", $publisherFilterOption->getValue());
+            foreach ($publisherIds as $publisherId) {
+                $sitesForPublisherIds[$publisherId] = $publisherFilterOption->getSite();
+            }
+        }
+
+        return $sitesForPublisherIds;
+    }
+
+    private function _getSiteForPublisher(int $publisherId, array $sitesForPublisherIds): ?Site
+    {
+        if (!isset($sitesForPublisherIds[$publisherId])) {
+            return null;
+        }
+
+        return $sitesForPublisherIds[$publisherId];
+    }
+}

--- a/src/Model/Base/Article.php
+++ b/src/Model/Base/Article.php
@@ -6880,6 +6880,32 @@ abstract class Article implements ActiveRecordInterface
      * @return ObjectCollection|ChildFile[] List of ChildFile objects
      * @phpstan-return ObjectCollection&\Traversable<ChildFile}> List of ChildFile objects
      */
+    public function getFilesJoinSite(?Criteria $criteria = null, ?ConnectionInterface $con = null, $joinBehavior = Criteria::LEFT_JOIN)
+    {
+        $query = ChildFileQuery::create(null, $criteria);
+        $query->joinWith('Site', $joinBehavior);
+
+        return $this->getFiles($query, $con);
+    }
+
+
+    /**
+     * If this collection has already been initialized with
+     * an identical criteria, it returns the collection.
+     * Otherwise if this Article is new, it will return
+     * an empty collection; or if this Article has previously
+     * been saved, it will retrieve related Files from storage.
+     *
+     * This method is protected by default in order to keep the public
+     * api reasonable.  You can provide public methods for those you
+     * actually need in Article.
+     *
+     * @param Criteria $criteria optional Criteria object to narrow the query
+     * @param ConnectionInterface $con optional connection object
+     * @param string $joinBehavior optional join type to use (defaults to Criteria::LEFT_JOIN)
+     * @return ObjectCollection|ChildFile[] List of ChildFile objects
+     * @phpstan-return ObjectCollection&\Traversable<ChildFile}> List of ChildFile objects
+     */
     public function getFilesJoinUser(?Criteria $criteria = null, ?ConnectionInterface $con = null, $joinBehavior = Criteria::LEFT_JOIN)
     {
         $query = ChildFileQuery::create(null, $criteria);

--- a/src/Model/Base/Download.php
+++ b/src/Model/Base/Download.php
@@ -6,6 +6,8 @@ use \DateTime;
 use \Exception;
 use \PDO;
 use Model\DownloadQuery as ChildDownloadQuery;
+use Model\Site as ChildSite;
+use Model\SiteQuery as ChildSiteQuery;
 use Model\User as ChildUser;
 use Model\UserQuery as ChildUserQuery;
 use Model\Map\DownloadTableMap;
@@ -71,6 +73,13 @@ abstract class Download implements ActiveRecordInterface
      * @var        string
      */
     protected $download_id;
+
+    /**
+     * The value for the site_id field.
+     *
+     * @var        int|null
+     */
+    protected $site_id;
 
     /**
      * The value for the file_id field.
@@ -148,6 +157,11 @@ abstract class Download implements ActiveRecordInterface
      * @var        DateTime|null
      */
     protected $download_updated;
+
+    /**
+     * @var        ChildSite
+     */
+    protected $aSite;
 
     /**
      * @var        ChildUser
@@ -399,6 +413,16 @@ abstract class Download implements ActiveRecordInterface
     }
 
     /**
+     * Get the [site_id] column value.
+     *
+     * @return int|null
+     */
+    public function getSiteId()
+    {
+        return $this->site_id;
+    }
+
+    /**
      * Get the [file_id] column value.
      *
      * @return int|null
@@ -559,6 +583,30 @@ abstract class Download implements ActiveRecordInterface
         if ($this->download_id !== $v) {
             $this->download_id = $v;
             $this->modifiedColumns[DownloadTableMap::COL_DOWNLOAD_ID] = true;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Set the value of [site_id] column.
+     *
+     * @param int|null $v New value
+     * @return $this The current object (for fluent API support)
+     */
+    public function setSiteId($v)
+    {
+        if ($v !== null) {
+            $v = (int) $v;
+        }
+
+        if ($this->site_id !== $v) {
+            $this->site_id = $v;
+            $this->modifiedColumns[DownloadTableMap::COL_SITE_ID] = true;
+        }
+
+        if ($this->aSite !== null && $this->aSite->getId() !== $v) {
+            $this->aSite = null;
         }
 
         return $this;
@@ -827,43 +875,46 @@ abstract class Download implements ActiveRecordInterface
             $col = $row[TableMap::TYPE_NUM == $indexType ? 0 + $startcol : DownloadTableMap::translateFieldName('Id', TableMap::TYPE_PHPNAME, $indexType)];
             $this->download_id = (null !== $col) ? (string) $col : null;
 
-            $col = $row[TableMap::TYPE_NUM == $indexType ? 1 + $startcol : DownloadTableMap::translateFieldName('FileId', TableMap::TYPE_PHPNAME, $indexType)];
+            $col = $row[TableMap::TYPE_NUM == $indexType ? 1 + $startcol : DownloadTableMap::translateFieldName('SiteId', TableMap::TYPE_PHPNAME, $indexType)];
+            $this->site_id = (null !== $col) ? (int) $col : null;
+
+            $col = $row[TableMap::TYPE_NUM == $indexType ? 2 + $startcol : DownloadTableMap::translateFieldName('FileId', TableMap::TYPE_PHPNAME, $indexType)];
             $this->file_id = (null !== $col) ? (int) $col : null;
 
-            $col = $row[TableMap::TYPE_NUM == $indexType ? 2 + $startcol : DownloadTableMap::translateFieldName('ArticleId', TableMap::TYPE_PHPNAME, $indexType)];
+            $col = $row[TableMap::TYPE_NUM == $indexType ? 3 + $startcol : DownloadTableMap::translateFieldName('ArticleId', TableMap::TYPE_PHPNAME, $indexType)];
             $this->article_id = (null !== $col) ? (int) $col : null;
 
-            $col = $row[TableMap::TYPE_NUM == $indexType ? 3 + $startcol : DownloadTableMap::translateFieldName('BookId', TableMap::TYPE_PHPNAME, $indexType)];
+            $col = $row[TableMap::TYPE_NUM == $indexType ? 4 + $startcol : DownloadTableMap::translateFieldName('BookId', TableMap::TYPE_PHPNAME, $indexType)];
             $this->book_id = (null !== $col) ? (int) $col : null;
 
-            $col = $row[TableMap::TYPE_NUM == $indexType ? 4 + $startcol : DownloadTableMap::translateFieldName('AxysAccountId', TableMap::TYPE_PHPNAME, $indexType)];
+            $col = $row[TableMap::TYPE_NUM == $indexType ? 5 + $startcol : DownloadTableMap::translateFieldName('AxysAccountId', TableMap::TYPE_PHPNAME, $indexType)];
             $this->axys_account_id = (null !== $col) ? (int) $col : null;
 
-            $col = $row[TableMap::TYPE_NUM == $indexType ? 5 + $startcol : DownloadTableMap::translateFieldName('UserId', TableMap::TYPE_PHPNAME, $indexType)];
+            $col = $row[TableMap::TYPE_NUM == $indexType ? 6 + $startcol : DownloadTableMap::translateFieldName('UserId', TableMap::TYPE_PHPNAME, $indexType)];
             $this->user_id = (null !== $col) ? (int) $col : null;
 
-            $col = $row[TableMap::TYPE_NUM == $indexType ? 6 + $startcol : DownloadTableMap::translateFieldName('Filetype', TableMap::TYPE_PHPNAME, $indexType)];
+            $col = $row[TableMap::TYPE_NUM == $indexType ? 7 + $startcol : DownloadTableMap::translateFieldName('Filetype', TableMap::TYPE_PHPNAME, $indexType)];
             $this->download_filetype = (null !== $col) ? (string) $col : null;
 
-            $col = $row[TableMap::TYPE_NUM == $indexType ? 7 + $startcol : DownloadTableMap::translateFieldName('Version', TableMap::TYPE_PHPNAME, $indexType)];
+            $col = $row[TableMap::TYPE_NUM == $indexType ? 8 + $startcol : DownloadTableMap::translateFieldName('Version', TableMap::TYPE_PHPNAME, $indexType)];
             $this->download_version = (null !== $col) ? (string) $col : null;
 
-            $col = $row[TableMap::TYPE_NUM == $indexType ? 8 + $startcol : DownloadTableMap::translateFieldName('Ip', TableMap::TYPE_PHPNAME, $indexType)];
+            $col = $row[TableMap::TYPE_NUM == $indexType ? 9 + $startcol : DownloadTableMap::translateFieldName('Ip', TableMap::TYPE_PHPNAME, $indexType)];
             $this->download_ip = (null !== $col) ? (string) $col : null;
 
-            $col = $row[TableMap::TYPE_NUM == $indexType ? 9 + $startcol : DownloadTableMap::translateFieldName('Date', TableMap::TYPE_PHPNAME, $indexType)];
+            $col = $row[TableMap::TYPE_NUM == $indexType ? 10 + $startcol : DownloadTableMap::translateFieldName('Date', TableMap::TYPE_PHPNAME, $indexType)];
             if ($col === '0000-00-00 00:00:00') {
                 $col = null;
             }
             $this->download_date = (null !== $col) ? PropelDateTime::newInstance($col, null, 'DateTime') : null;
 
-            $col = $row[TableMap::TYPE_NUM == $indexType ? 10 + $startcol : DownloadTableMap::translateFieldName('CreatedAt', TableMap::TYPE_PHPNAME, $indexType)];
+            $col = $row[TableMap::TYPE_NUM == $indexType ? 11 + $startcol : DownloadTableMap::translateFieldName('CreatedAt', TableMap::TYPE_PHPNAME, $indexType)];
             if ($col === '0000-00-00 00:00:00') {
                 $col = null;
             }
             $this->download_created = (null !== $col) ? PropelDateTime::newInstance($col, null, 'DateTime') : null;
 
-            $col = $row[TableMap::TYPE_NUM == $indexType ? 11 + $startcol : DownloadTableMap::translateFieldName('UpdatedAt', TableMap::TYPE_PHPNAME, $indexType)];
+            $col = $row[TableMap::TYPE_NUM == $indexType ? 12 + $startcol : DownloadTableMap::translateFieldName('UpdatedAt', TableMap::TYPE_PHPNAME, $indexType)];
             if ($col === '0000-00-00 00:00:00') {
                 $col = null;
             }
@@ -876,7 +927,7 @@ abstract class Download implements ActiveRecordInterface
                 $this->ensureConsistency();
             }
 
-            return $startcol + 12; // 12 = DownloadTableMap::NUM_HYDRATE_COLUMNS.
+            return $startcol + 13; // 13 = DownloadTableMap::NUM_HYDRATE_COLUMNS.
 
         } catch (Exception $e) {
             throw new PropelException(sprintf('Error populating %s object', '\\Model\\Download'), 0, $e);
@@ -899,6 +950,9 @@ abstract class Download implements ActiveRecordInterface
      */
     public function ensureConsistency(): void
     {
+        if ($this->aSite !== null && $this->site_id !== $this->aSite->getId()) {
+            $this->aSite = null;
+        }
         if ($this->aUser !== null && $this->user_id !== $this->aUser->getId()) {
             $this->aUser = null;
         }
@@ -941,6 +995,7 @@ abstract class Download implements ActiveRecordInterface
 
         if ($deep) {  // also de-associate any related objects?
 
+            $this->aSite = null;
             $this->aUser = null;
         } // if (deep)
     }
@@ -1063,6 +1118,13 @@ abstract class Download implements ActiveRecordInterface
             // method.  This object relates to these object(s) by a
             // foreign key reference.
 
+            if ($this->aSite !== null) {
+                if ($this->aSite->isModified() || $this->aSite->isNew()) {
+                    $affectedRows += $this->aSite->save($con);
+                }
+                $this->setSite($this->aSite);
+            }
+
             if ($this->aUser !== null) {
                 if ($this->aUser->isModified() || $this->aUser->isNew()) {
                     $affectedRows += $this->aUser->save($con);
@@ -1110,6 +1172,9 @@ abstract class Download implements ActiveRecordInterface
         if ($this->isColumnModified(DownloadTableMap::COL_DOWNLOAD_ID)) {
             $modifiedColumns[':p' . $index++]  = 'download_id';
         }
+        if ($this->isColumnModified(DownloadTableMap::COL_SITE_ID)) {
+            $modifiedColumns[':p' . $index++]  = 'site_id';
+        }
         if ($this->isColumnModified(DownloadTableMap::COL_FILE_ID)) {
             $modifiedColumns[':p' . $index++]  = 'file_id';
         }
@@ -1156,6 +1221,10 @@ abstract class Download implements ActiveRecordInterface
                 switch ($columnName) {
                     case 'download_id':
                         $stmt->bindValue($identifier, $this->download_id, PDO::PARAM_INT);
+
+                        break;
+                    case 'site_id':
+                        $stmt->bindValue($identifier, $this->site_id, PDO::PARAM_INT);
 
                         break;
                     case 'file_id':
@@ -1268,36 +1337,39 @@ abstract class Download implements ActiveRecordInterface
                 return $this->getId();
 
             case 1:
-                return $this->getFileId();
+                return $this->getSiteId();
 
             case 2:
-                return $this->getArticleId();
+                return $this->getFileId();
 
             case 3:
-                return $this->getBookId();
+                return $this->getArticleId();
 
             case 4:
-                return $this->getAxysAccountId();
+                return $this->getBookId();
 
             case 5:
-                return $this->getUserId();
+                return $this->getAxysAccountId();
 
             case 6:
-                return $this->getFiletype();
+                return $this->getUserId();
 
             case 7:
-                return $this->getVersion();
+                return $this->getFiletype();
 
             case 8:
-                return $this->getIp();
+                return $this->getVersion();
 
             case 9:
-                return $this->getDate();
+                return $this->getIp();
 
             case 10:
-                return $this->getCreatedAt();
+                return $this->getDate();
 
             case 11:
+                return $this->getCreatedAt();
+
+            case 12:
                 return $this->getUpdatedAt();
 
             default:
@@ -1329,22 +1401,19 @@ abstract class Download implements ActiveRecordInterface
         $keys = DownloadTableMap::getFieldNames($keyType);
         $result = [
             $keys[0] => $this->getId(),
-            $keys[1] => $this->getFileId(),
-            $keys[2] => $this->getArticleId(),
-            $keys[3] => $this->getBookId(),
-            $keys[4] => $this->getAxysAccountId(),
-            $keys[5] => $this->getUserId(),
-            $keys[6] => $this->getFiletype(),
-            $keys[7] => $this->getVersion(),
-            $keys[8] => $this->getIp(),
-            $keys[9] => $this->getDate(),
-            $keys[10] => $this->getCreatedAt(),
-            $keys[11] => $this->getUpdatedAt(),
+            $keys[1] => $this->getSiteId(),
+            $keys[2] => $this->getFileId(),
+            $keys[3] => $this->getArticleId(),
+            $keys[4] => $this->getBookId(),
+            $keys[5] => $this->getAxysAccountId(),
+            $keys[6] => $this->getUserId(),
+            $keys[7] => $this->getFiletype(),
+            $keys[8] => $this->getVersion(),
+            $keys[9] => $this->getIp(),
+            $keys[10] => $this->getDate(),
+            $keys[11] => $this->getCreatedAt(),
+            $keys[12] => $this->getUpdatedAt(),
         ];
-        if ($result[$keys[9]] instanceof \DateTimeInterface) {
-            $result[$keys[9]] = $result[$keys[9]]->format('Y-m-d H:i:s.u');
-        }
-
         if ($result[$keys[10]] instanceof \DateTimeInterface) {
             $result[$keys[10]] = $result[$keys[10]]->format('Y-m-d H:i:s.u');
         }
@@ -1353,12 +1422,31 @@ abstract class Download implements ActiveRecordInterface
             $result[$keys[11]] = $result[$keys[11]]->format('Y-m-d H:i:s.u');
         }
 
+        if ($result[$keys[12]] instanceof \DateTimeInterface) {
+            $result[$keys[12]] = $result[$keys[12]]->format('Y-m-d H:i:s.u');
+        }
+
         $virtualColumns = $this->virtualColumns;
         foreach ($virtualColumns as $key => $virtualColumn) {
             $result[$key] = $virtualColumn;
         }
 
         if ($includeForeignObjects) {
+            if (null !== $this->aSite) {
+
+                switch ($keyType) {
+                    case TableMap::TYPE_CAMELNAME:
+                        $key = 'site';
+                        break;
+                    case TableMap::TYPE_FIELDNAME:
+                        $key = 'sites';
+                        break;
+                    default:
+                        $key = 'Site';
+                }
+
+                $result[$key] = $this->aSite->toArray($keyType, $includeLazyLoadColumns,  $alreadyDumpedObjects, true);
+            }
             if (null !== $this->aUser) {
 
                 switch ($keyType) {
@@ -1414,36 +1502,39 @@ abstract class Download implements ActiveRecordInterface
                 $this->setId($value);
                 break;
             case 1:
-                $this->setFileId($value);
+                $this->setSiteId($value);
                 break;
             case 2:
-                $this->setArticleId($value);
+                $this->setFileId($value);
                 break;
             case 3:
-                $this->setBookId($value);
+                $this->setArticleId($value);
                 break;
             case 4:
-                $this->setAxysAccountId($value);
+                $this->setBookId($value);
                 break;
             case 5:
-                $this->setUserId($value);
+                $this->setAxysAccountId($value);
                 break;
             case 6:
-                $this->setFiletype($value);
+                $this->setUserId($value);
                 break;
             case 7:
-                $this->setVersion($value);
+                $this->setFiletype($value);
                 break;
             case 8:
-                $this->setIp($value);
+                $this->setVersion($value);
                 break;
             case 9:
-                $this->setDate($value);
+                $this->setIp($value);
                 break;
             case 10:
-                $this->setCreatedAt($value);
+                $this->setDate($value);
                 break;
             case 11:
+                $this->setCreatedAt($value);
+                break;
+            case 12:
                 $this->setUpdatedAt($value);
                 break;
         } // switch()
@@ -1476,37 +1567,40 @@ abstract class Download implements ActiveRecordInterface
             $this->setId($arr[$keys[0]]);
         }
         if (array_key_exists($keys[1], $arr)) {
-            $this->setFileId($arr[$keys[1]]);
+            $this->setSiteId($arr[$keys[1]]);
         }
         if (array_key_exists($keys[2], $arr)) {
-            $this->setArticleId($arr[$keys[2]]);
+            $this->setFileId($arr[$keys[2]]);
         }
         if (array_key_exists($keys[3], $arr)) {
-            $this->setBookId($arr[$keys[3]]);
+            $this->setArticleId($arr[$keys[3]]);
         }
         if (array_key_exists($keys[4], $arr)) {
-            $this->setAxysAccountId($arr[$keys[4]]);
+            $this->setBookId($arr[$keys[4]]);
         }
         if (array_key_exists($keys[5], $arr)) {
-            $this->setUserId($arr[$keys[5]]);
+            $this->setAxysAccountId($arr[$keys[5]]);
         }
         if (array_key_exists($keys[6], $arr)) {
-            $this->setFiletype($arr[$keys[6]]);
+            $this->setUserId($arr[$keys[6]]);
         }
         if (array_key_exists($keys[7], $arr)) {
-            $this->setVersion($arr[$keys[7]]);
+            $this->setFiletype($arr[$keys[7]]);
         }
         if (array_key_exists($keys[8], $arr)) {
-            $this->setIp($arr[$keys[8]]);
+            $this->setVersion($arr[$keys[8]]);
         }
         if (array_key_exists($keys[9], $arr)) {
-            $this->setDate($arr[$keys[9]]);
+            $this->setIp($arr[$keys[9]]);
         }
         if (array_key_exists($keys[10], $arr)) {
-            $this->setCreatedAt($arr[$keys[10]]);
+            $this->setDate($arr[$keys[10]]);
         }
         if (array_key_exists($keys[11], $arr)) {
-            $this->setUpdatedAt($arr[$keys[11]]);
+            $this->setCreatedAt($arr[$keys[11]]);
+        }
+        if (array_key_exists($keys[12], $arr)) {
+            $this->setUpdatedAt($arr[$keys[12]]);
         }
 
         return $this;
@@ -1553,6 +1647,9 @@ abstract class Download implements ActiveRecordInterface
 
         if ($this->isColumnModified(DownloadTableMap::COL_DOWNLOAD_ID)) {
             $criteria->add(DownloadTableMap::COL_DOWNLOAD_ID, $this->download_id);
+        }
+        if ($this->isColumnModified(DownloadTableMap::COL_SITE_ID)) {
+            $criteria->add(DownloadTableMap::COL_SITE_ID, $this->site_id);
         }
         if ($this->isColumnModified(DownloadTableMap::COL_FILE_ID)) {
             $criteria->add(DownloadTableMap::COL_FILE_ID, $this->file_id);
@@ -1675,6 +1772,7 @@ abstract class Download implements ActiveRecordInterface
      */
     public function copyInto(object $copyObj, bool $deepCopy = false, bool $makeNew = true): void
     {
+        $copyObj->setSiteId($this->getSiteId());
         $copyObj->setFileId($this->getFileId());
         $copyObj->setArticleId($this->getArticleId());
         $copyObj->setBookId($this->getBookId());
@@ -1712,6 +1810,57 @@ abstract class Download implements ActiveRecordInterface
         $this->copyInto($copyObj, $deepCopy);
 
         return $copyObj;
+    }
+
+    /**
+     * Declares an association between this object and a ChildSite object.
+     *
+     * @param ChildSite|null $v
+     * @return $this The current object (for fluent API support)
+     * @throws \Propel\Runtime\Exception\PropelException
+     */
+    public function setSite(ChildSite $v = null)
+    {
+        if ($v === null) {
+            $this->setSiteId(NULL);
+        } else {
+            $this->setSiteId($v->getId());
+        }
+
+        $this->aSite = $v;
+
+        // Add binding for other direction of this n:n relationship.
+        // If this object has already been added to the ChildSite object, it will not be re-added.
+        if ($v !== null) {
+            $v->addDownload($this);
+        }
+
+
+        return $this;
+    }
+
+
+    /**
+     * Get the associated ChildSite object
+     *
+     * @param ConnectionInterface $con Optional Connection object.
+     * @return ChildSite|null The associated ChildSite object.
+     * @throws \Propel\Runtime\Exception\PropelException
+     */
+    public function getSite(?ConnectionInterface $con = null)
+    {
+        if ($this->aSite === null && ($this->site_id != 0)) {
+            $this->aSite = ChildSiteQuery::create()->findPk($this->site_id, $con);
+            /* The following can be used additionally to
+                guarantee the related object contains a reference
+                to this object.  This level of coupling may, however, be
+                undesirable since it could result in an only partially populated collection
+                in the referenced object.
+                $this->aSite->addDownloads($this);
+             */
+        }
+
+        return $this->aSite;
     }
 
     /**
@@ -1774,10 +1923,14 @@ abstract class Download implements ActiveRecordInterface
      */
     public function clear()
     {
+        if (null !== $this->aSite) {
+            $this->aSite->removeDownload($this);
+        }
         if (null !== $this->aUser) {
             $this->aUser->removeDownload($this);
         }
         $this->download_id = null;
+        $this->site_id = null;
         $this->file_id = null;
         $this->article_id = null;
         $this->book_id = null;
@@ -1812,6 +1965,7 @@ abstract class Download implements ActiveRecordInterface
         if ($deep) {
         } // if ($deep)
 
+        $this->aSite = null;
         $this->aUser = null;
         return $this;
     }

--- a/src/Model/Base/DownloadQuery.php
+++ b/src/Model/Base/DownloadQuery.php
@@ -20,6 +20,7 @@ use Propel\Runtime\Exception\PropelException;
  * Base class that represents a query for the `downloads` table.
  *
  * @method     ChildDownloadQuery orderById($order = Criteria::ASC) Order by the download_id column
+ * @method     ChildDownloadQuery orderBySiteId($order = Criteria::ASC) Order by the site_id column
  * @method     ChildDownloadQuery orderByFileId($order = Criteria::ASC) Order by the file_id column
  * @method     ChildDownloadQuery orderByArticleId($order = Criteria::ASC) Order by the article_id column
  * @method     ChildDownloadQuery orderByBookId($order = Criteria::ASC) Order by the book_id column
@@ -33,6 +34,7 @@ use Propel\Runtime\Exception\PropelException;
  * @method     ChildDownloadQuery orderByUpdatedAt($order = Criteria::ASC) Order by the download_updated column
  *
  * @method     ChildDownloadQuery groupById() Group by the download_id column
+ * @method     ChildDownloadQuery groupBySiteId() Group by the site_id column
  * @method     ChildDownloadQuery groupByFileId() Group by the file_id column
  * @method     ChildDownloadQuery groupByArticleId() Group by the article_id column
  * @method     ChildDownloadQuery groupByBookId() Group by the book_id column
@@ -53,6 +55,16 @@ use Propel\Runtime\Exception\PropelException;
  * @method     ChildDownloadQuery rightJoinWith($relation) Adds a RIGHT JOIN clause and with to the query
  * @method     ChildDownloadQuery innerJoinWith($relation) Adds a INNER JOIN clause and with to the query
  *
+ * @method     ChildDownloadQuery leftJoinSite($relationAlias = null) Adds a LEFT JOIN clause to the query using the Site relation
+ * @method     ChildDownloadQuery rightJoinSite($relationAlias = null) Adds a RIGHT JOIN clause to the query using the Site relation
+ * @method     ChildDownloadQuery innerJoinSite($relationAlias = null) Adds a INNER JOIN clause to the query using the Site relation
+ *
+ * @method     ChildDownloadQuery joinWithSite($joinType = Criteria::INNER_JOIN) Adds a join clause and with to the query using the Site relation
+ *
+ * @method     ChildDownloadQuery leftJoinWithSite() Adds a LEFT JOIN clause and with to the query using the Site relation
+ * @method     ChildDownloadQuery rightJoinWithSite() Adds a RIGHT JOIN clause and with to the query using the Site relation
+ * @method     ChildDownloadQuery innerJoinWithSite() Adds a INNER JOIN clause and with to the query using the Site relation
+ *
  * @method     ChildDownloadQuery leftJoinUser($relationAlias = null) Adds a LEFT JOIN clause to the query using the User relation
  * @method     ChildDownloadQuery rightJoinUser($relationAlias = null) Adds a RIGHT JOIN clause to the query using the User relation
  * @method     ChildDownloadQuery innerJoinUser($relationAlias = null) Adds a INNER JOIN clause to the query using the User relation
@@ -63,12 +75,13 @@ use Propel\Runtime\Exception\PropelException;
  * @method     ChildDownloadQuery rightJoinWithUser() Adds a RIGHT JOIN clause and with to the query using the User relation
  * @method     ChildDownloadQuery innerJoinWithUser() Adds a INNER JOIN clause and with to the query using the User relation
  *
- * @method     \Model\UserQuery endUse() Finalizes a secondary criteria and merges it with its primary Criteria
+ * @method     \Model\SiteQuery|\Model\UserQuery endUse() Finalizes a secondary criteria and merges it with its primary Criteria
  *
  * @method     ChildDownload|null findOne(?ConnectionInterface $con = null) Return the first ChildDownload matching the query
  * @method     ChildDownload findOneOrCreate(?ConnectionInterface $con = null) Return the first ChildDownload matching the query, or a new ChildDownload object populated from the query conditions when no match is found
  *
  * @method     ChildDownload|null findOneById(string $download_id) Return the first ChildDownload filtered by the download_id column
+ * @method     ChildDownload|null findOneBySiteId(int $site_id) Return the first ChildDownload filtered by the site_id column
  * @method     ChildDownload|null findOneByFileId(int $file_id) Return the first ChildDownload filtered by the file_id column
  * @method     ChildDownload|null findOneByArticleId(int $article_id) Return the first ChildDownload filtered by the article_id column
  * @method     ChildDownload|null findOneByBookId(int $book_id) Return the first ChildDownload filtered by the book_id column
@@ -85,6 +98,7 @@ use Propel\Runtime\Exception\PropelException;
  * @method     ChildDownload requireOne(?ConnectionInterface $con = null) Return the first ChildDownload matching the query and throws \Propel\Runtime\Exception\EntityNotFoundException when not found
  *
  * @method     ChildDownload requireOneById(string $download_id) Return the first ChildDownload filtered by the download_id column and throws \Propel\Runtime\Exception\EntityNotFoundException when not found
+ * @method     ChildDownload requireOneBySiteId(int $site_id) Return the first ChildDownload filtered by the site_id column and throws \Propel\Runtime\Exception\EntityNotFoundException when not found
  * @method     ChildDownload requireOneByFileId(int $file_id) Return the first ChildDownload filtered by the file_id column and throws \Propel\Runtime\Exception\EntityNotFoundException when not found
  * @method     ChildDownload requireOneByArticleId(int $article_id) Return the first ChildDownload filtered by the article_id column and throws \Propel\Runtime\Exception\EntityNotFoundException when not found
  * @method     ChildDownload requireOneByBookId(int $book_id) Return the first ChildDownload filtered by the book_id column and throws \Propel\Runtime\Exception\EntityNotFoundException when not found
@@ -102,6 +116,8 @@ use Propel\Runtime\Exception\PropelException;
  *
  * @method     ChildDownload[]|Collection findById(string|array<string> $download_id) Return ChildDownload objects filtered by the download_id column
  * @psalm-method Collection&\Traversable<ChildDownload> findById(string|array<string> $download_id) Return ChildDownload objects filtered by the download_id column
+ * @method     ChildDownload[]|Collection findBySiteId(int|array<int> $site_id) Return ChildDownload objects filtered by the site_id column
+ * @psalm-method Collection&\Traversable<ChildDownload> findBySiteId(int|array<int> $site_id) Return ChildDownload objects filtered by the site_id column
  * @method     ChildDownload[]|Collection findByFileId(int|array<int> $file_id) Return ChildDownload objects filtered by the file_id column
  * @psalm-method Collection&\Traversable<ChildDownload> findByFileId(int|array<int> $file_id) Return ChildDownload objects filtered by the file_id column
  * @method     ChildDownload[]|Collection findByArticleId(int|array<int> $article_id) Return ChildDownload objects filtered by the article_id column
@@ -223,7 +239,7 @@ abstract class DownloadQuery extends ModelCriteria
      */
     protected function findPkSimple($key, ConnectionInterface $con)
     {
-        $sql = 'SELECT download_id, file_id, article_id, book_id, axys_account_id, user_id, download_filetype, download_version, download_ip, download_date, download_created, download_updated FROM downloads WHERE download_id = :p0';
+        $sql = 'SELECT download_id, site_id, file_id, article_id, book_id, axys_account_id, user_id, download_filetype, download_version, download_ip, download_date, download_created, download_updated FROM downloads WHERE download_id = :p0';
         try {
             $stmt = $con->prepare($sql);
             $stmt->bindValue(':p0', $key, PDO::PARAM_INT);
@@ -356,6 +372,51 @@ abstract class DownloadQuery extends ModelCriteria
         }
 
         $this->addUsingAlias(DownloadTableMap::COL_DOWNLOAD_ID, $id, $comparison);
+
+        return $this;
+    }
+
+    /**
+     * Filter the query on the site_id column
+     *
+     * Example usage:
+     * <code>
+     * $query->filterBySiteId(1234); // WHERE site_id = 1234
+     * $query->filterBySiteId(array(12, 34)); // WHERE site_id IN (12, 34)
+     * $query->filterBySiteId(array('min' => 12)); // WHERE site_id > 12
+     * </code>
+     *
+     * @see       filterBySite()
+     *
+     * @param mixed $siteId The value to use as filter.
+     *              Use scalar values for equality.
+     *              Use array values for in_array() equivalent.
+     *              Use associative array('min' => $minValue, 'max' => $maxValue) for intervals.
+     * @param string|null $comparison Operator to use for the column comparison, defaults to Criteria::EQUAL
+     *
+     * @return $this The current query, for fluid interface
+     */
+    public function filterBySiteId($siteId = null, ?string $comparison = null)
+    {
+        if (is_array($siteId)) {
+            $useMinMax = false;
+            if (isset($siteId['min'])) {
+                $this->addUsingAlias(DownloadTableMap::COL_SITE_ID, $siteId['min'], Criteria::GREATER_EQUAL);
+                $useMinMax = true;
+            }
+            if (isset($siteId['max'])) {
+                $this->addUsingAlias(DownloadTableMap::COL_SITE_ID, $siteId['max'], Criteria::LESS_EQUAL);
+                $useMinMax = true;
+            }
+            if ($useMinMax) {
+                return $this;
+            }
+            if (null === $comparison) {
+                $comparison = Criteria::IN;
+            }
+        }
+
+        $this->addUsingAlias(DownloadTableMap::COL_SITE_ID, $siteId, $comparison);
 
         return $this;
     }
@@ -794,6 +855,181 @@ abstract class DownloadQuery extends ModelCriteria
         $this->addUsingAlias(DownloadTableMap::COL_DOWNLOAD_UPDATED, $updatedAt, $comparison);
 
         return $this;
+    }
+
+    /**
+     * Filter the query by a related \Model\Site object
+     *
+     * @param \Model\Site|ObjectCollection $site The related object(s) to use as filter
+     * @param string|null $comparison Operator to use for the column comparison, defaults to Criteria::EQUAL
+     *
+     * @throws \Propel\Runtime\Exception\PropelException
+     *
+     * @return $this The current query, for fluid interface
+     */
+    public function filterBySite($site, ?string $comparison = null)
+    {
+        if ($site instanceof \Model\Site) {
+            return $this
+                ->addUsingAlias(DownloadTableMap::COL_SITE_ID, $site->getId(), $comparison);
+        } elseif ($site instanceof ObjectCollection) {
+            if (null === $comparison) {
+                $comparison = Criteria::IN;
+            }
+
+            $this
+                ->addUsingAlias(DownloadTableMap::COL_SITE_ID, $site->toKeyValue('PrimaryKey', 'Id'), $comparison);
+
+            return $this;
+        } else {
+            throw new PropelException('filterBySite() only accepts arguments of type \Model\Site or Collection');
+        }
+    }
+
+    /**
+     * Adds a JOIN clause to the query using the Site relation
+     *
+     * @param string|null $relationAlias Optional alias for the relation
+     * @param string|null $joinType Accepted values are null, 'left join', 'right join', 'inner join'
+     *
+     * @return $this The current query, for fluid interface
+     */
+    public function joinSite(?string $relationAlias = null, ?string $joinType = Criteria::LEFT_JOIN)
+    {
+        $tableMap = $this->getTableMap();
+        $relationMap = $tableMap->getRelation('Site');
+
+        // create a ModelJoin object for this join
+        $join = new ModelJoin();
+        $join->setJoinType($joinType);
+        $join->setRelationMap($relationMap, $this->useAliasInSQL ? $this->getModelAlias() : null, $relationAlias);
+        if ($previousJoin = $this->getPreviousJoin()) {
+            $join->setPreviousJoin($previousJoin);
+        }
+
+        // add the ModelJoin to the current object
+        if ($relationAlias) {
+            $this->addAlias($relationAlias, $relationMap->getRightTable()->getName());
+            $this->addJoinObject($join, $relationAlias);
+        } else {
+            $this->addJoinObject($join, 'Site');
+        }
+
+        return $this;
+    }
+
+    /**
+     * Use the Site relation Site object
+     *
+     * @see useQuery()
+     *
+     * @param string $relationAlias optional alias for the relation,
+     *                                   to be used as main alias in the secondary query
+     * @param string $joinType Accepted values are null, 'left join', 'right join', 'inner join'
+     *
+     * @return \Model\SiteQuery A secondary query class using the current class as primary query
+     */
+    public function useSiteQuery($relationAlias = null, $joinType = Criteria::LEFT_JOIN)
+    {
+        return $this
+            ->joinSite($relationAlias, $joinType)
+            ->useQuery($relationAlias ? $relationAlias : 'Site', '\Model\SiteQuery');
+    }
+
+    /**
+     * Use the Site relation Site object
+     *
+     * @param callable(\Model\SiteQuery):\Model\SiteQuery $callable A function working on the related query
+     *
+     * @param string|null $relationAlias optional alias for the relation
+     *
+     * @param string|null $joinType Accepted values are null, 'left join', 'right join', 'inner join'
+     *
+     * @return $this
+     */
+    public function withSiteQuery(
+        callable $callable,
+        string $relationAlias = null,
+        ?string $joinType = Criteria::LEFT_JOIN
+    ) {
+        $relatedQuery = $this->useSiteQuery(
+            $relationAlias,
+            $joinType
+        );
+        $callable($relatedQuery);
+        $relatedQuery->endUse();
+
+        return $this;
+    }
+
+    /**
+     * Use the relation to Site table for an EXISTS query.
+     *
+     * @see \Propel\Runtime\ActiveQuery\ModelCriteria::useExistsQuery()
+     *
+     * @param string|null $modelAlias sets an alias for the nested query
+     * @param string|null $queryClass Allows to use a custom query class for the exists query, like ExtendedBookQuery::class
+     * @param string $typeOfExists Either ExistsQueryCriterion::TYPE_EXISTS or ExistsQueryCriterion::TYPE_NOT_EXISTS
+     *
+     * @return \Model\SiteQuery The inner query object of the EXISTS statement
+     */
+    public function useSiteExistsQuery($modelAlias = null, $queryClass = null, $typeOfExists = 'EXISTS')
+    {
+        /** @var $q \Model\SiteQuery */
+        $q = $this->useExistsQuery('Site', $modelAlias, $queryClass, $typeOfExists);
+        return $q;
+    }
+
+    /**
+     * Use the relation to Site table for a NOT EXISTS query.
+     *
+     * @see useSiteExistsQuery()
+     *
+     * @param string|null $modelAlias sets an alias for the nested query
+     * @param string|null $queryClass Allows to use a custom query class for the exists query, like ExtendedBookQuery::class
+     *
+     * @return \Model\SiteQuery The inner query object of the NOT EXISTS statement
+     */
+    public function useSiteNotExistsQuery($modelAlias = null, $queryClass = null)
+    {
+        /** @var $q \Model\SiteQuery */
+        $q = $this->useExistsQuery('Site', $modelAlias, $queryClass, 'NOT EXISTS');
+        return $q;
+    }
+
+    /**
+     * Use the relation to Site table for an IN query.
+     *
+     * @see \Propel\Runtime\ActiveQuery\ModelCriteria::useInQuery()
+     *
+     * @param string|null $modelAlias sets an alias for the nested query
+     * @param string|null $queryClass Allows to use a custom query class for the IN query, like ExtendedBookQuery::class
+     * @param string $typeOfIn Criteria::IN or Criteria::NOT_IN
+     *
+     * @return \Model\SiteQuery The inner query object of the IN statement
+     */
+    public function useInSiteQuery($modelAlias = null, $queryClass = null, $typeOfIn = 'IN')
+    {
+        /** @var $q \Model\SiteQuery */
+        $q = $this->useInQuery('Site', $modelAlias, $queryClass, $typeOfIn);
+        return $q;
+    }
+
+    /**
+     * Use the relation to Site table for a NOT IN query.
+     *
+     * @see useSiteInQuery()
+     *
+     * @param string|null $modelAlias sets an alias for the nested query
+     * @param string|null $queryClass Allows to use a custom query class for the NOT IN query, like ExtendedBookQuery::class
+     *
+     * @return \Model\SiteQuery The inner query object of the NOT IN statement
+     */
+    public function useNotInSiteQuery($modelAlias = null, $queryClass = null)
+    {
+        /** @var $q \Model\SiteQuery */
+        $q = $this->useInQuery('Site', $modelAlias, $queryClass, 'NOT IN');
+        return $q;
     }
 
     /**

--- a/src/Model/Base/File.php
+++ b/src/Model/Base/File.php
@@ -8,6 +8,8 @@ use \PDO;
 use Model\Article as ChildArticle;
 use Model\ArticleQuery as ChildArticleQuery;
 use Model\FileQuery as ChildFileQuery;
+use Model\Site as ChildSite;
+use Model\SiteQuery as ChildSiteQuery;
 use Model\User as ChildUser;
 use Model\UserQuery as ChildUserQuery;
 use Model\Map\FileTableMap;
@@ -73,6 +75,13 @@ abstract class File implements ActiveRecordInterface
      * @var        int
      */
     protected $file_id;
+
+    /**
+     * The value for the site_id field.
+     *
+     * @var        int|null
+     */
+    protected $site_id;
 
     /**
      * The value for the article_id field.
@@ -174,6 +183,11 @@ abstract class File implements ActiveRecordInterface
      * @var        DateTime|null
      */
     protected $file_created;
+
+    /**
+     * @var        ChildSite
+     */
+    protected $aSite;
 
     /**
      * @var        ChildArticle
@@ -445,6 +459,16 @@ abstract class File implements ActiveRecordInterface
     }
 
     /**
+     * Get the [site_id] column value.
+     *
+     * @return int|null
+     */
+    public function getSiteId()
+    {
+        return $this->site_id;
+    }
+
+    /**
      * Get the [article_id] column value.
      *
      * @return int|null
@@ -657,6 +681,30 @@ abstract class File implements ActiveRecordInterface
         if ($this->file_id !== $v) {
             $this->file_id = $v;
             $this->modifiedColumns[FileTableMap::COL_FILE_ID] = true;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Set the value of [site_id] column.
+     *
+     * @param int|null $v New value
+     * @return $this The current object (for fluent API support)
+     */
+    public function setSiteId($v)
+    {
+        if ($v !== null) {
+            $v = (int) $v;
+        }
+
+        if ($this->site_id !== $v) {
+            $this->site_id = $v;
+            $this->modifiedColumns[FileTableMap::COL_SITE_ID] = true;
+        }
+
+        if ($this->aSite !== null && $this->aSite->getId() !== $v) {
+            $this->aSite = null;
         }
 
         return $this;
@@ -1009,55 +1057,58 @@ abstract class File implements ActiveRecordInterface
             $col = $row[TableMap::TYPE_NUM == $indexType ? 0 + $startcol : FileTableMap::translateFieldName('Id', TableMap::TYPE_PHPNAME, $indexType)];
             $this->file_id = (null !== $col) ? (int) $col : null;
 
-            $col = $row[TableMap::TYPE_NUM == $indexType ? 1 + $startcol : FileTableMap::translateFieldName('ArticleId', TableMap::TYPE_PHPNAME, $indexType)];
+            $col = $row[TableMap::TYPE_NUM == $indexType ? 1 + $startcol : FileTableMap::translateFieldName('SiteId', TableMap::TYPE_PHPNAME, $indexType)];
+            $this->site_id = (null !== $col) ? (int) $col : null;
+
+            $col = $row[TableMap::TYPE_NUM == $indexType ? 2 + $startcol : FileTableMap::translateFieldName('ArticleId', TableMap::TYPE_PHPNAME, $indexType)];
             $this->article_id = (null !== $col) ? (int) $col : null;
 
-            $col = $row[TableMap::TYPE_NUM == $indexType ? 2 + $startcol : FileTableMap::translateFieldName('AxysAccountId', TableMap::TYPE_PHPNAME, $indexType)];
+            $col = $row[TableMap::TYPE_NUM == $indexType ? 3 + $startcol : FileTableMap::translateFieldName('AxysAccountId', TableMap::TYPE_PHPNAME, $indexType)];
             $this->axys_account_id = (null !== $col) ? (int) $col : null;
 
-            $col = $row[TableMap::TYPE_NUM == $indexType ? 3 + $startcol : FileTableMap::translateFieldName('UserId', TableMap::TYPE_PHPNAME, $indexType)];
+            $col = $row[TableMap::TYPE_NUM == $indexType ? 4 + $startcol : FileTableMap::translateFieldName('UserId', TableMap::TYPE_PHPNAME, $indexType)];
             $this->user_id = (null !== $col) ? (int) $col : null;
 
-            $col = $row[TableMap::TYPE_NUM == $indexType ? 4 + $startcol : FileTableMap::translateFieldName('Title', TableMap::TYPE_PHPNAME, $indexType)];
+            $col = $row[TableMap::TYPE_NUM == $indexType ? 5 + $startcol : FileTableMap::translateFieldName('Title', TableMap::TYPE_PHPNAME, $indexType)];
             $this->file_title = (null !== $col) ? (string) $col : null;
 
-            $col = $row[TableMap::TYPE_NUM == $indexType ? 5 + $startcol : FileTableMap::translateFieldName('Type', TableMap::TYPE_PHPNAME, $indexType)];
+            $col = $row[TableMap::TYPE_NUM == $indexType ? 6 + $startcol : FileTableMap::translateFieldName('Type', TableMap::TYPE_PHPNAME, $indexType)];
             $this->file_type = (null !== $col) ? (string) $col : null;
 
-            $col = $row[TableMap::TYPE_NUM == $indexType ? 6 + $startcol : FileTableMap::translateFieldName('Access', TableMap::TYPE_PHPNAME, $indexType)];
+            $col = $row[TableMap::TYPE_NUM == $indexType ? 7 + $startcol : FileTableMap::translateFieldName('Access', TableMap::TYPE_PHPNAME, $indexType)];
             $this->file_access = (null !== $col) ? (boolean) $col : null;
 
-            $col = $row[TableMap::TYPE_NUM == $indexType ? 7 + $startcol : FileTableMap::translateFieldName('Version', TableMap::TYPE_PHPNAME, $indexType)];
+            $col = $row[TableMap::TYPE_NUM == $indexType ? 8 + $startcol : FileTableMap::translateFieldName('Version', TableMap::TYPE_PHPNAME, $indexType)];
             $this->file_version = (null !== $col) ? (string) $col : null;
 
-            $col = $row[TableMap::TYPE_NUM == $indexType ? 8 + $startcol : FileTableMap::translateFieldName('Hash', TableMap::TYPE_PHPNAME, $indexType)];
+            $col = $row[TableMap::TYPE_NUM == $indexType ? 9 + $startcol : FileTableMap::translateFieldName('Hash', TableMap::TYPE_PHPNAME, $indexType)];
             $this->file_hash = (null !== $col) ? (string) $col : null;
 
-            $col = $row[TableMap::TYPE_NUM == $indexType ? 9 + $startcol : FileTableMap::translateFieldName('Size', TableMap::TYPE_PHPNAME, $indexType)];
+            $col = $row[TableMap::TYPE_NUM == $indexType ? 10 + $startcol : FileTableMap::translateFieldName('Size', TableMap::TYPE_PHPNAME, $indexType)];
             $this->file_size = (null !== $col) ? (string) $col : null;
 
-            $col = $row[TableMap::TYPE_NUM == $indexType ? 10 + $startcol : FileTableMap::translateFieldName('Ean', TableMap::TYPE_PHPNAME, $indexType)];
+            $col = $row[TableMap::TYPE_NUM == $indexType ? 11 + $startcol : FileTableMap::translateFieldName('Ean', TableMap::TYPE_PHPNAME, $indexType)];
             $this->file_ean = (null !== $col) ? (string) $col : null;
 
-            $col = $row[TableMap::TYPE_NUM == $indexType ? 11 + $startcol : FileTableMap::translateFieldName('Inserted', TableMap::TYPE_PHPNAME, $indexType)];
+            $col = $row[TableMap::TYPE_NUM == $indexType ? 12 + $startcol : FileTableMap::translateFieldName('Inserted', TableMap::TYPE_PHPNAME, $indexType)];
             if ($col === '0000-00-00 00:00:00') {
                 $col = null;
             }
             $this->file_inserted = (null !== $col) ? PropelDateTime::newInstance($col, null, 'DateTime') : null;
 
-            $col = $row[TableMap::TYPE_NUM == $indexType ? 12 + $startcol : FileTableMap::translateFieldName('Uploaded', TableMap::TYPE_PHPNAME, $indexType)];
+            $col = $row[TableMap::TYPE_NUM == $indexType ? 13 + $startcol : FileTableMap::translateFieldName('Uploaded', TableMap::TYPE_PHPNAME, $indexType)];
             if ($col === '0000-00-00 00:00:00') {
                 $col = null;
             }
             $this->file_uploaded = (null !== $col) ? PropelDateTime::newInstance($col, null, 'DateTime') : null;
 
-            $col = $row[TableMap::TYPE_NUM == $indexType ? 13 + $startcol : FileTableMap::translateFieldName('UpdatedAt', TableMap::TYPE_PHPNAME, $indexType)];
+            $col = $row[TableMap::TYPE_NUM == $indexType ? 14 + $startcol : FileTableMap::translateFieldName('UpdatedAt', TableMap::TYPE_PHPNAME, $indexType)];
             if ($col === '0000-00-00 00:00:00') {
                 $col = null;
             }
             $this->file_updated = (null !== $col) ? PropelDateTime::newInstance($col, null, 'DateTime') : null;
 
-            $col = $row[TableMap::TYPE_NUM == $indexType ? 14 + $startcol : FileTableMap::translateFieldName('CreatedAt', TableMap::TYPE_PHPNAME, $indexType)];
+            $col = $row[TableMap::TYPE_NUM == $indexType ? 15 + $startcol : FileTableMap::translateFieldName('CreatedAt', TableMap::TYPE_PHPNAME, $indexType)];
             if ($col === '0000-00-00 00:00:00') {
                 $col = null;
             }
@@ -1070,7 +1121,7 @@ abstract class File implements ActiveRecordInterface
                 $this->ensureConsistency();
             }
 
-            return $startcol + 15; // 15 = FileTableMap::NUM_HYDRATE_COLUMNS.
+            return $startcol + 16; // 16 = FileTableMap::NUM_HYDRATE_COLUMNS.
 
         } catch (Exception $e) {
             throw new PropelException(sprintf('Error populating %s object', '\\Model\\File'), 0, $e);
@@ -1093,6 +1144,9 @@ abstract class File implements ActiveRecordInterface
      */
     public function ensureConsistency(): void
     {
+        if ($this->aSite !== null && $this->site_id !== $this->aSite->getId()) {
+            $this->aSite = null;
+        }
         if ($this->aArticle !== null && $this->article_id !== $this->aArticle->getId()) {
             $this->aArticle = null;
         }
@@ -1138,6 +1192,7 @@ abstract class File implements ActiveRecordInterface
 
         if ($deep) {  // also de-associate any related objects?
 
+            $this->aSite = null;
             $this->aArticle = null;
             $this->aUser = null;
         } // if (deep)
@@ -1261,6 +1316,13 @@ abstract class File implements ActiveRecordInterface
             // method.  This object relates to these object(s) by a
             // foreign key reference.
 
+            if ($this->aSite !== null) {
+                if ($this->aSite->isModified() || $this->aSite->isNew()) {
+                    $affectedRows += $this->aSite->save($con);
+                }
+                $this->setSite($this->aSite);
+            }
+
             if ($this->aArticle !== null) {
                 if ($this->aArticle->isModified() || $this->aArticle->isNew()) {
                     $affectedRows += $this->aArticle->save($con);
@@ -1314,6 +1376,9 @@ abstract class File implements ActiveRecordInterface
          // check the columns in natural order for more readable SQL queries
         if ($this->isColumnModified(FileTableMap::COL_FILE_ID)) {
             $modifiedColumns[':p' . $index++]  = 'file_id';
+        }
+        if ($this->isColumnModified(FileTableMap::COL_SITE_ID)) {
+            $modifiedColumns[':p' . $index++]  = 'site_id';
         }
         if ($this->isColumnModified(FileTableMap::COL_ARTICLE_ID)) {
             $modifiedColumns[':p' . $index++]  = 'article_id';
@@ -1370,6 +1435,10 @@ abstract class File implements ActiveRecordInterface
                 switch ($columnName) {
                     case 'file_id':
                         $stmt->bindValue($identifier, $this->file_id, PDO::PARAM_INT);
+
+                        break;
+                    case 'site_id':
+                        $stmt->bindValue($identifier, $this->site_id, PDO::PARAM_INT);
 
                         break;
                     case 'article_id':
@@ -1494,45 +1563,48 @@ abstract class File implements ActiveRecordInterface
                 return $this->getId();
 
             case 1:
-                return $this->getArticleId();
+                return $this->getSiteId();
 
             case 2:
-                return $this->getAxysAccountId();
+                return $this->getArticleId();
 
             case 3:
-                return $this->getUserId();
+                return $this->getAxysAccountId();
 
             case 4:
-                return $this->getTitle();
+                return $this->getUserId();
 
             case 5:
-                return $this->getType();
+                return $this->getTitle();
 
             case 6:
-                return $this->getAccess();
+                return $this->getType();
 
             case 7:
-                return $this->getVersion();
+                return $this->getAccess();
 
             case 8:
-                return $this->getHash();
+                return $this->getVersion();
 
             case 9:
-                return $this->getSize();
+                return $this->getHash();
 
             case 10:
-                return $this->getEan();
+                return $this->getSize();
 
             case 11:
-                return $this->getInserted();
+                return $this->getEan();
 
             case 12:
-                return $this->getUploaded();
+                return $this->getInserted();
 
             case 13:
-                return $this->getUpdatedAt();
+                return $this->getUploaded();
 
             case 14:
+                return $this->getUpdatedAt();
+
+            case 15:
                 return $this->getCreatedAt();
 
             default:
@@ -1564,25 +1636,22 @@ abstract class File implements ActiveRecordInterface
         $keys = FileTableMap::getFieldNames($keyType);
         $result = [
             $keys[0] => $this->getId(),
-            $keys[1] => $this->getArticleId(),
-            $keys[2] => $this->getAxysAccountId(),
-            $keys[3] => $this->getUserId(),
-            $keys[4] => $this->getTitle(),
-            $keys[5] => $this->getType(),
-            $keys[6] => $this->getAccess(),
-            $keys[7] => $this->getVersion(),
-            $keys[8] => $this->getHash(),
-            $keys[9] => $this->getSize(),
-            $keys[10] => $this->getEan(),
-            $keys[11] => $this->getInserted(),
-            $keys[12] => $this->getUploaded(),
-            $keys[13] => $this->getUpdatedAt(),
-            $keys[14] => $this->getCreatedAt(),
+            $keys[1] => $this->getSiteId(),
+            $keys[2] => $this->getArticleId(),
+            $keys[3] => $this->getAxysAccountId(),
+            $keys[4] => $this->getUserId(),
+            $keys[5] => $this->getTitle(),
+            $keys[6] => $this->getType(),
+            $keys[7] => $this->getAccess(),
+            $keys[8] => $this->getVersion(),
+            $keys[9] => $this->getHash(),
+            $keys[10] => $this->getSize(),
+            $keys[11] => $this->getEan(),
+            $keys[12] => $this->getInserted(),
+            $keys[13] => $this->getUploaded(),
+            $keys[14] => $this->getUpdatedAt(),
+            $keys[15] => $this->getCreatedAt(),
         ];
-        if ($result[$keys[11]] instanceof \DateTimeInterface) {
-            $result[$keys[11]] = $result[$keys[11]]->format('Y-m-d H:i:s.u');
-        }
-
         if ($result[$keys[12]] instanceof \DateTimeInterface) {
             $result[$keys[12]] = $result[$keys[12]]->format('Y-m-d H:i:s.u');
         }
@@ -1595,12 +1664,31 @@ abstract class File implements ActiveRecordInterface
             $result[$keys[14]] = $result[$keys[14]]->format('Y-m-d H:i:s.u');
         }
 
+        if ($result[$keys[15]] instanceof \DateTimeInterface) {
+            $result[$keys[15]] = $result[$keys[15]]->format('Y-m-d H:i:s.u');
+        }
+
         $virtualColumns = $this->virtualColumns;
         foreach ($virtualColumns as $key => $virtualColumn) {
             $result[$key] = $virtualColumn;
         }
 
         if ($includeForeignObjects) {
+            if (null !== $this->aSite) {
+
+                switch ($keyType) {
+                    case TableMap::TYPE_CAMELNAME:
+                        $key = 'site';
+                        break;
+                    case TableMap::TYPE_FIELDNAME:
+                        $key = 'sites';
+                        break;
+                    default:
+                        $key = 'Site';
+                }
+
+                $result[$key] = $this->aSite->toArray($keyType, $includeLazyLoadColumns,  $alreadyDumpedObjects, true);
+            }
             if (null !== $this->aArticle) {
 
                 switch ($keyType) {
@@ -1671,45 +1759,48 @@ abstract class File implements ActiveRecordInterface
                 $this->setId($value);
                 break;
             case 1:
-                $this->setArticleId($value);
+                $this->setSiteId($value);
                 break;
             case 2:
-                $this->setAxysAccountId($value);
+                $this->setArticleId($value);
                 break;
             case 3:
-                $this->setUserId($value);
+                $this->setAxysAccountId($value);
                 break;
             case 4:
-                $this->setTitle($value);
+                $this->setUserId($value);
                 break;
             case 5:
-                $this->setType($value);
+                $this->setTitle($value);
                 break;
             case 6:
-                $this->setAccess($value);
+                $this->setType($value);
                 break;
             case 7:
-                $this->setVersion($value);
+                $this->setAccess($value);
                 break;
             case 8:
-                $this->setHash($value);
+                $this->setVersion($value);
                 break;
             case 9:
-                $this->setSize($value);
+                $this->setHash($value);
                 break;
             case 10:
-                $this->setEan($value);
+                $this->setSize($value);
                 break;
             case 11:
-                $this->setInserted($value);
+                $this->setEan($value);
                 break;
             case 12:
-                $this->setUploaded($value);
+                $this->setInserted($value);
                 break;
             case 13:
-                $this->setUpdatedAt($value);
+                $this->setUploaded($value);
                 break;
             case 14:
+                $this->setUpdatedAt($value);
+                break;
+            case 15:
                 $this->setCreatedAt($value);
                 break;
         } // switch()
@@ -1742,46 +1833,49 @@ abstract class File implements ActiveRecordInterface
             $this->setId($arr[$keys[0]]);
         }
         if (array_key_exists($keys[1], $arr)) {
-            $this->setArticleId($arr[$keys[1]]);
+            $this->setSiteId($arr[$keys[1]]);
         }
         if (array_key_exists($keys[2], $arr)) {
-            $this->setAxysAccountId($arr[$keys[2]]);
+            $this->setArticleId($arr[$keys[2]]);
         }
         if (array_key_exists($keys[3], $arr)) {
-            $this->setUserId($arr[$keys[3]]);
+            $this->setAxysAccountId($arr[$keys[3]]);
         }
         if (array_key_exists($keys[4], $arr)) {
-            $this->setTitle($arr[$keys[4]]);
+            $this->setUserId($arr[$keys[4]]);
         }
         if (array_key_exists($keys[5], $arr)) {
-            $this->setType($arr[$keys[5]]);
+            $this->setTitle($arr[$keys[5]]);
         }
         if (array_key_exists($keys[6], $arr)) {
-            $this->setAccess($arr[$keys[6]]);
+            $this->setType($arr[$keys[6]]);
         }
         if (array_key_exists($keys[7], $arr)) {
-            $this->setVersion($arr[$keys[7]]);
+            $this->setAccess($arr[$keys[7]]);
         }
         if (array_key_exists($keys[8], $arr)) {
-            $this->setHash($arr[$keys[8]]);
+            $this->setVersion($arr[$keys[8]]);
         }
         if (array_key_exists($keys[9], $arr)) {
-            $this->setSize($arr[$keys[9]]);
+            $this->setHash($arr[$keys[9]]);
         }
         if (array_key_exists($keys[10], $arr)) {
-            $this->setEan($arr[$keys[10]]);
+            $this->setSize($arr[$keys[10]]);
         }
         if (array_key_exists($keys[11], $arr)) {
-            $this->setInserted($arr[$keys[11]]);
+            $this->setEan($arr[$keys[11]]);
         }
         if (array_key_exists($keys[12], $arr)) {
-            $this->setUploaded($arr[$keys[12]]);
+            $this->setInserted($arr[$keys[12]]);
         }
         if (array_key_exists($keys[13], $arr)) {
-            $this->setUpdatedAt($arr[$keys[13]]);
+            $this->setUploaded($arr[$keys[13]]);
         }
         if (array_key_exists($keys[14], $arr)) {
-            $this->setCreatedAt($arr[$keys[14]]);
+            $this->setUpdatedAt($arr[$keys[14]]);
+        }
+        if (array_key_exists($keys[15], $arr)) {
+            $this->setCreatedAt($arr[$keys[15]]);
         }
 
         return $this;
@@ -1828,6 +1922,9 @@ abstract class File implements ActiveRecordInterface
 
         if ($this->isColumnModified(FileTableMap::COL_FILE_ID)) {
             $criteria->add(FileTableMap::COL_FILE_ID, $this->file_id);
+        }
+        if ($this->isColumnModified(FileTableMap::COL_SITE_ID)) {
+            $criteria->add(FileTableMap::COL_SITE_ID, $this->site_id);
         }
         if ($this->isColumnModified(FileTableMap::COL_ARTICLE_ID)) {
             $criteria->add(FileTableMap::COL_ARTICLE_ID, $this->article_id);
@@ -1959,6 +2056,7 @@ abstract class File implements ActiveRecordInterface
      */
     public function copyInto(object $copyObj, bool $deepCopy = false, bool $makeNew = true): void
     {
+        $copyObj->setSiteId($this->getSiteId());
         $copyObj->setArticleId($this->getArticleId());
         $copyObj->setAxysAccountId($this->getAxysAccountId());
         $copyObj->setUserId($this->getUserId());
@@ -1999,6 +2097,57 @@ abstract class File implements ActiveRecordInterface
         $this->copyInto($copyObj, $deepCopy);
 
         return $copyObj;
+    }
+
+    /**
+     * Declares an association between this object and a ChildSite object.
+     *
+     * @param ChildSite|null $v
+     * @return $this The current object (for fluent API support)
+     * @throws \Propel\Runtime\Exception\PropelException
+     */
+    public function setSite(ChildSite $v = null)
+    {
+        if ($v === null) {
+            $this->setSiteId(NULL);
+        } else {
+            $this->setSiteId($v->getId());
+        }
+
+        $this->aSite = $v;
+
+        // Add binding for other direction of this n:n relationship.
+        // If this object has already been added to the ChildSite object, it will not be re-added.
+        if ($v !== null) {
+            $v->addFile($this);
+        }
+
+
+        return $this;
+    }
+
+
+    /**
+     * Get the associated ChildSite object
+     *
+     * @param ConnectionInterface $con Optional Connection object.
+     * @return ChildSite|null The associated ChildSite object.
+     * @throws \Propel\Runtime\Exception\PropelException
+     */
+    public function getSite(?ConnectionInterface $con = null)
+    {
+        if ($this->aSite === null && ($this->site_id != 0)) {
+            $this->aSite = ChildSiteQuery::create()->findPk($this->site_id, $con);
+            /* The following can be used additionally to
+                guarantee the related object contains a reference
+                to this object.  This level of coupling may, however, be
+                undesirable since it could result in an only partially populated collection
+                in the referenced object.
+                $this->aSite->addFiles($this);
+             */
+        }
+
+        return $this->aSite;
     }
 
     /**
@@ -2112,6 +2261,9 @@ abstract class File implements ActiveRecordInterface
      */
     public function clear()
     {
+        if (null !== $this->aSite) {
+            $this->aSite->removeFile($this);
+        }
         if (null !== $this->aArticle) {
             $this->aArticle->removeFile($this);
         }
@@ -2119,6 +2271,7 @@ abstract class File implements ActiveRecordInterface
             $this->aUser->removeFile($this);
         }
         $this->file_id = null;
+        $this->site_id = null;
         $this->article_id = null;
         $this->axys_account_id = null;
         $this->user_id = null;
@@ -2157,6 +2310,7 @@ abstract class File implements ActiveRecordInterface
         if ($deep) {
         } // if ($deep)
 
+        $this->aSite = null;
         $this->aArticle = null;
         $this->aUser = null;
         return $this;

--- a/src/Model/Base/FileQuery.php
+++ b/src/Model/Base/FileQuery.php
@@ -20,6 +20,7 @@ use Propel\Runtime\Exception\PropelException;
  * Base class that represents a query for the `files` table.
  *
  * @method     ChildFileQuery orderById($order = Criteria::ASC) Order by the file_id column
+ * @method     ChildFileQuery orderBySiteId($order = Criteria::ASC) Order by the site_id column
  * @method     ChildFileQuery orderByArticleId($order = Criteria::ASC) Order by the article_id column
  * @method     ChildFileQuery orderByAxysAccountId($order = Criteria::ASC) Order by the axys_account_id column
  * @method     ChildFileQuery orderByUserId($order = Criteria::ASC) Order by the user_id column
@@ -36,6 +37,7 @@ use Propel\Runtime\Exception\PropelException;
  * @method     ChildFileQuery orderByCreatedAt($order = Criteria::ASC) Order by the file_created column
  *
  * @method     ChildFileQuery groupById() Group by the file_id column
+ * @method     ChildFileQuery groupBySiteId() Group by the site_id column
  * @method     ChildFileQuery groupByArticleId() Group by the article_id column
  * @method     ChildFileQuery groupByAxysAccountId() Group by the axys_account_id column
  * @method     ChildFileQuery groupByUserId() Group by the user_id column
@@ -59,6 +61,16 @@ use Propel\Runtime\Exception\PropelException;
  * @method     ChildFileQuery rightJoinWith($relation) Adds a RIGHT JOIN clause and with to the query
  * @method     ChildFileQuery innerJoinWith($relation) Adds a INNER JOIN clause and with to the query
  *
+ * @method     ChildFileQuery leftJoinSite($relationAlias = null) Adds a LEFT JOIN clause to the query using the Site relation
+ * @method     ChildFileQuery rightJoinSite($relationAlias = null) Adds a RIGHT JOIN clause to the query using the Site relation
+ * @method     ChildFileQuery innerJoinSite($relationAlias = null) Adds a INNER JOIN clause to the query using the Site relation
+ *
+ * @method     ChildFileQuery joinWithSite($joinType = Criteria::INNER_JOIN) Adds a join clause and with to the query using the Site relation
+ *
+ * @method     ChildFileQuery leftJoinWithSite() Adds a LEFT JOIN clause and with to the query using the Site relation
+ * @method     ChildFileQuery rightJoinWithSite() Adds a RIGHT JOIN clause and with to the query using the Site relation
+ * @method     ChildFileQuery innerJoinWithSite() Adds a INNER JOIN clause and with to the query using the Site relation
+ *
  * @method     ChildFileQuery leftJoinArticle($relationAlias = null) Adds a LEFT JOIN clause to the query using the Article relation
  * @method     ChildFileQuery rightJoinArticle($relationAlias = null) Adds a RIGHT JOIN clause to the query using the Article relation
  * @method     ChildFileQuery innerJoinArticle($relationAlias = null) Adds a INNER JOIN clause to the query using the Article relation
@@ -79,12 +91,13 @@ use Propel\Runtime\Exception\PropelException;
  * @method     ChildFileQuery rightJoinWithUser() Adds a RIGHT JOIN clause and with to the query using the User relation
  * @method     ChildFileQuery innerJoinWithUser() Adds a INNER JOIN clause and with to the query using the User relation
  *
- * @method     \Model\ArticleQuery|\Model\UserQuery endUse() Finalizes a secondary criteria and merges it with its primary Criteria
+ * @method     \Model\SiteQuery|\Model\ArticleQuery|\Model\UserQuery endUse() Finalizes a secondary criteria and merges it with its primary Criteria
  *
  * @method     ChildFile|null findOne(?ConnectionInterface $con = null) Return the first ChildFile matching the query
  * @method     ChildFile findOneOrCreate(?ConnectionInterface $con = null) Return the first ChildFile matching the query, or a new ChildFile object populated from the query conditions when no match is found
  *
  * @method     ChildFile|null findOneById(int $file_id) Return the first ChildFile filtered by the file_id column
+ * @method     ChildFile|null findOneBySiteId(int $site_id) Return the first ChildFile filtered by the site_id column
  * @method     ChildFile|null findOneByArticleId(int $article_id) Return the first ChildFile filtered by the article_id column
  * @method     ChildFile|null findOneByAxysAccountId(int $axys_account_id) Return the first ChildFile filtered by the axys_account_id column
  * @method     ChildFile|null findOneByUserId(int $user_id) Return the first ChildFile filtered by the user_id column
@@ -104,6 +117,7 @@ use Propel\Runtime\Exception\PropelException;
  * @method     ChildFile requireOne(?ConnectionInterface $con = null) Return the first ChildFile matching the query and throws \Propel\Runtime\Exception\EntityNotFoundException when not found
  *
  * @method     ChildFile requireOneById(int $file_id) Return the first ChildFile filtered by the file_id column and throws \Propel\Runtime\Exception\EntityNotFoundException when not found
+ * @method     ChildFile requireOneBySiteId(int $site_id) Return the first ChildFile filtered by the site_id column and throws \Propel\Runtime\Exception\EntityNotFoundException when not found
  * @method     ChildFile requireOneByArticleId(int $article_id) Return the first ChildFile filtered by the article_id column and throws \Propel\Runtime\Exception\EntityNotFoundException when not found
  * @method     ChildFile requireOneByAxysAccountId(int $axys_account_id) Return the first ChildFile filtered by the axys_account_id column and throws \Propel\Runtime\Exception\EntityNotFoundException when not found
  * @method     ChildFile requireOneByUserId(int $user_id) Return the first ChildFile filtered by the user_id column and throws \Propel\Runtime\Exception\EntityNotFoundException when not found
@@ -124,6 +138,8 @@ use Propel\Runtime\Exception\PropelException;
  *
  * @method     ChildFile[]|Collection findById(int|array<int> $file_id) Return ChildFile objects filtered by the file_id column
  * @psalm-method Collection&\Traversable<ChildFile> findById(int|array<int> $file_id) Return ChildFile objects filtered by the file_id column
+ * @method     ChildFile[]|Collection findBySiteId(int|array<int> $site_id) Return ChildFile objects filtered by the site_id column
+ * @psalm-method Collection&\Traversable<ChildFile> findBySiteId(int|array<int> $site_id) Return ChildFile objects filtered by the site_id column
  * @method     ChildFile[]|Collection findByArticleId(int|array<int> $article_id) Return ChildFile objects filtered by the article_id column
  * @psalm-method Collection&\Traversable<ChildFile> findByArticleId(int|array<int> $article_id) Return ChildFile objects filtered by the article_id column
  * @method     ChildFile[]|Collection findByAxysAccountId(int|array<int> $axys_account_id) Return ChildFile objects filtered by the axys_account_id column
@@ -251,7 +267,7 @@ abstract class FileQuery extends ModelCriteria
      */
     protected function findPkSimple($key, ConnectionInterface $con)
     {
-        $sql = 'SELECT file_id, article_id, axys_account_id, user_id, file_title, file_type, file_access, file_version, file_hash, file_size, file_ean, file_inserted, file_uploaded, file_updated, file_created FROM files WHERE file_id = :p0';
+        $sql = 'SELECT file_id, site_id, article_id, axys_account_id, user_id, file_title, file_type, file_access, file_version, file_hash, file_size, file_ean, file_inserted, file_uploaded, file_updated, file_created FROM files WHERE file_id = :p0';
         try {
             $stmt = $con->prepare($sql);
             $stmt->bindValue(':p0', $key, PDO::PARAM_INT);
@@ -384,6 +400,51 @@ abstract class FileQuery extends ModelCriteria
         }
 
         $this->addUsingAlias(FileTableMap::COL_FILE_ID, $id, $comparison);
+
+        return $this;
+    }
+
+    /**
+     * Filter the query on the site_id column
+     *
+     * Example usage:
+     * <code>
+     * $query->filterBySiteId(1234); // WHERE site_id = 1234
+     * $query->filterBySiteId(array(12, 34)); // WHERE site_id IN (12, 34)
+     * $query->filterBySiteId(array('min' => 12)); // WHERE site_id > 12
+     * </code>
+     *
+     * @see       filterBySite()
+     *
+     * @param mixed $siteId The value to use as filter.
+     *              Use scalar values for equality.
+     *              Use array values for in_array() equivalent.
+     *              Use associative array('min' => $minValue, 'max' => $maxValue) for intervals.
+     * @param string|null $comparison Operator to use for the column comparison, defaults to Criteria::EQUAL
+     *
+     * @return $this The current query, for fluid interface
+     */
+    public function filterBySiteId($siteId = null, ?string $comparison = null)
+    {
+        if (is_array($siteId)) {
+            $useMinMax = false;
+            if (isset($siteId['min'])) {
+                $this->addUsingAlias(FileTableMap::COL_SITE_ID, $siteId['min'], Criteria::GREATER_EQUAL);
+                $useMinMax = true;
+            }
+            if (isset($siteId['max'])) {
+                $this->addUsingAlias(FileTableMap::COL_SITE_ID, $siteId['max'], Criteria::LESS_EQUAL);
+                $useMinMax = true;
+            }
+            if ($useMinMax) {
+                return $this;
+            }
+            if (null === $comparison) {
+                $comparison = Criteria::IN;
+            }
+        }
+
+        $this->addUsingAlias(FileTableMap::COL_SITE_ID, $siteId, $comparison);
 
         return $this;
     }
@@ -926,6 +987,181 @@ abstract class FileQuery extends ModelCriteria
         $this->addUsingAlias(FileTableMap::COL_FILE_CREATED, $createdAt, $comparison);
 
         return $this;
+    }
+
+    /**
+     * Filter the query by a related \Model\Site object
+     *
+     * @param \Model\Site|ObjectCollection $site The related object(s) to use as filter
+     * @param string|null $comparison Operator to use for the column comparison, defaults to Criteria::EQUAL
+     *
+     * @throws \Propel\Runtime\Exception\PropelException
+     *
+     * @return $this The current query, for fluid interface
+     */
+    public function filterBySite($site, ?string $comparison = null)
+    {
+        if ($site instanceof \Model\Site) {
+            return $this
+                ->addUsingAlias(FileTableMap::COL_SITE_ID, $site->getId(), $comparison);
+        } elseif ($site instanceof ObjectCollection) {
+            if (null === $comparison) {
+                $comparison = Criteria::IN;
+            }
+
+            $this
+                ->addUsingAlias(FileTableMap::COL_SITE_ID, $site->toKeyValue('PrimaryKey', 'Id'), $comparison);
+
+            return $this;
+        } else {
+            throw new PropelException('filterBySite() only accepts arguments of type \Model\Site or Collection');
+        }
+    }
+
+    /**
+     * Adds a JOIN clause to the query using the Site relation
+     *
+     * @param string|null $relationAlias Optional alias for the relation
+     * @param string|null $joinType Accepted values are null, 'left join', 'right join', 'inner join'
+     *
+     * @return $this The current query, for fluid interface
+     */
+    public function joinSite(?string $relationAlias = null, ?string $joinType = Criteria::LEFT_JOIN)
+    {
+        $tableMap = $this->getTableMap();
+        $relationMap = $tableMap->getRelation('Site');
+
+        // create a ModelJoin object for this join
+        $join = new ModelJoin();
+        $join->setJoinType($joinType);
+        $join->setRelationMap($relationMap, $this->useAliasInSQL ? $this->getModelAlias() : null, $relationAlias);
+        if ($previousJoin = $this->getPreviousJoin()) {
+            $join->setPreviousJoin($previousJoin);
+        }
+
+        // add the ModelJoin to the current object
+        if ($relationAlias) {
+            $this->addAlias($relationAlias, $relationMap->getRightTable()->getName());
+            $this->addJoinObject($join, $relationAlias);
+        } else {
+            $this->addJoinObject($join, 'Site');
+        }
+
+        return $this;
+    }
+
+    /**
+     * Use the Site relation Site object
+     *
+     * @see useQuery()
+     *
+     * @param string $relationAlias optional alias for the relation,
+     *                                   to be used as main alias in the secondary query
+     * @param string $joinType Accepted values are null, 'left join', 'right join', 'inner join'
+     *
+     * @return \Model\SiteQuery A secondary query class using the current class as primary query
+     */
+    public function useSiteQuery($relationAlias = null, $joinType = Criteria::LEFT_JOIN)
+    {
+        return $this
+            ->joinSite($relationAlias, $joinType)
+            ->useQuery($relationAlias ? $relationAlias : 'Site', '\Model\SiteQuery');
+    }
+
+    /**
+     * Use the Site relation Site object
+     *
+     * @param callable(\Model\SiteQuery):\Model\SiteQuery $callable A function working on the related query
+     *
+     * @param string|null $relationAlias optional alias for the relation
+     *
+     * @param string|null $joinType Accepted values are null, 'left join', 'right join', 'inner join'
+     *
+     * @return $this
+     */
+    public function withSiteQuery(
+        callable $callable,
+        string $relationAlias = null,
+        ?string $joinType = Criteria::LEFT_JOIN
+    ) {
+        $relatedQuery = $this->useSiteQuery(
+            $relationAlias,
+            $joinType
+        );
+        $callable($relatedQuery);
+        $relatedQuery->endUse();
+
+        return $this;
+    }
+
+    /**
+     * Use the relation to Site table for an EXISTS query.
+     *
+     * @see \Propel\Runtime\ActiveQuery\ModelCriteria::useExistsQuery()
+     *
+     * @param string|null $modelAlias sets an alias for the nested query
+     * @param string|null $queryClass Allows to use a custom query class for the exists query, like ExtendedBookQuery::class
+     * @param string $typeOfExists Either ExistsQueryCriterion::TYPE_EXISTS or ExistsQueryCriterion::TYPE_NOT_EXISTS
+     *
+     * @return \Model\SiteQuery The inner query object of the EXISTS statement
+     */
+    public function useSiteExistsQuery($modelAlias = null, $queryClass = null, $typeOfExists = 'EXISTS')
+    {
+        /** @var $q \Model\SiteQuery */
+        $q = $this->useExistsQuery('Site', $modelAlias, $queryClass, $typeOfExists);
+        return $q;
+    }
+
+    /**
+     * Use the relation to Site table for a NOT EXISTS query.
+     *
+     * @see useSiteExistsQuery()
+     *
+     * @param string|null $modelAlias sets an alias for the nested query
+     * @param string|null $queryClass Allows to use a custom query class for the exists query, like ExtendedBookQuery::class
+     *
+     * @return \Model\SiteQuery The inner query object of the NOT EXISTS statement
+     */
+    public function useSiteNotExistsQuery($modelAlias = null, $queryClass = null)
+    {
+        /** @var $q \Model\SiteQuery */
+        $q = $this->useExistsQuery('Site', $modelAlias, $queryClass, 'NOT EXISTS');
+        return $q;
+    }
+
+    /**
+     * Use the relation to Site table for an IN query.
+     *
+     * @see \Propel\Runtime\ActiveQuery\ModelCriteria::useInQuery()
+     *
+     * @param string|null $modelAlias sets an alias for the nested query
+     * @param string|null $queryClass Allows to use a custom query class for the IN query, like ExtendedBookQuery::class
+     * @param string $typeOfIn Criteria::IN or Criteria::NOT_IN
+     *
+     * @return \Model\SiteQuery The inner query object of the IN statement
+     */
+    public function useInSiteQuery($modelAlias = null, $queryClass = null, $typeOfIn = 'IN')
+    {
+        /** @var $q \Model\SiteQuery */
+        $q = $this->useInQuery('Site', $modelAlias, $queryClass, $typeOfIn);
+        return $q;
+    }
+
+    /**
+     * Use the relation to Site table for a NOT IN query.
+     *
+     * @see useSiteInQuery()
+     *
+     * @param string|null $modelAlias sets an alias for the nested query
+     * @param string|null $queryClass Allows to use a custom query class for the NOT IN query, like ExtendedBookQuery::class
+     *
+     * @return \Model\SiteQuery The inner query object of the NOT IN statement
+     */
+    public function useNotInSiteQuery($modelAlias = null, $queryClass = null)
+    {
+        /** @var $q \Model\SiteQuery */
+        $q = $this->useInQuery('Site', $modelAlias, $queryClass, 'NOT IN');
+        return $q;
     }
 
     /**

--- a/src/Model/Base/SiteQuery.php
+++ b/src/Model/Base/SiteQuery.php
@@ -155,6 +155,26 @@ use Propel\Runtime\Exception\PropelException;
  * @method     ChildSiteQuery rightJoinWithCustomer() Adds a RIGHT JOIN clause and with to the query using the Customer relation
  * @method     ChildSiteQuery innerJoinWithCustomer() Adds a INNER JOIN clause and with to the query using the Customer relation
  *
+ * @method     ChildSiteQuery leftJoinDownload($relationAlias = null) Adds a LEFT JOIN clause to the query using the Download relation
+ * @method     ChildSiteQuery rightJoinDownload($relationAlias = null) Adds a RIGHT JOIN clause to the query using the Download relation
+ * @method     ChildSiteQuery innerJoinDownload($relationAlias = null) Adds a INNER JOIN clause to the query using the Download relation
+ *
+ * @method     ChildSiteQuery joinWithDownload($joinType = Criteria::INNER_JOIN) Adds a join clause and with to the query using the Download relation
+ *
+ * @method     ChildSiteQuery leftJoinWithDownload() Adds a LEFT JOIN clause and with to the query using the Download relation
+ * @method     ChildSiteQuery rightJoinWithDownload() Adds a RIGHT JOIN clause and with to the query using the Download relation
+ * @method     ChildSiteQuery innerJoinWithDownload() Adds a INNER JOIN clause and with to the query using the Download relation
+ *
+ * @method     ChildSiteQuery leftJoinFile($relationAlias = null) Adds a LEFT JOIN clause to the query using the File relation
+ * @method     ChildSiteQuery rightJoinFile($relationAlias = null) Adds a RIGHT JOIN clause to the query using the File relation
+ * @method     ChildSiteQuery innerJoinFile($relationAlias = null) Adds a INNER JOIN clause to the query using the File relation
+ *
+ * @method     ChildSiteQuery joinWithFile($joinType = Criteria::INNER_JOIN) Adds a join clause and with to the query using the File relation
+ *
+ * @method     ChildSiteQuery leftJoinWithFile() Adds a LEFT JOIN clause and with to the query using the File relation
+ * @method     ChildSiteQuery rightJoinWithFile() Adds a RIGHT JOIN clause and with to the query using the File relation
+ * @method     ChildSiteQuery innerJoinWithFile() Adds a INNER JOIN clause and with to the query using the File relation
+ *
  * @method     ChildSiteQuery leftJoinImage($relationAlias = null) Adds a LEFT JOIN clause to the query using the Image relation
  * @method     ChildSiteQuery rightJoinImage($relationAlias = null) Adds a RIGHT JOIN clause to the query using the Image relation
  * @method     ChildSiteQuery innerJoinImage($relationAlias = null) Adds a INNER JOIN clause to the query using the Image relation
@@ -335,7 +355,7 @@ use Propel\Runtime\Exception\PropelException;
  * @method     ChildSiteQuery rightJoinWithWishlist() Adds a RIGHT JOIN clause and with to the query using the Wishlist relation
  * @method     ChildSiteQuery innerJoinWithWishlist() Adds a INNER JOIN clause and with to the query using the Wishlist relation
  *
- * @method     \Model\AlertQuery|\Model\CartQuery|\Model\CrowdfundingCampaignQuery|\Model\CrowfundingRewardQuery|\Model\CustomerQuery|\Model\ImageQuery|\Model\InvitationQuery|\Model\StockItemListQuery|\Model\OptionQuery|\Model\OrderQuery|\Model\PageQuery|\Model\PaymentQuery|\Model\PostQuery|\Model\ArticleCategoryQuery|\Model\RightQuery|\Model\SessionQuery|\Model\SpecialOfferQuery|\Model\StockQuery|\Model\SubscriptionQuery|\Model\UserQuery|\Model\AuthenticationMethodQuery|\Model\VoteQuery|\Model\WishlistQuery endUse() Finalizes a secondary criteria and merges it with its primary Criteria
+ * @method     \Model\AlertQuery|\Model\CartQuery|\Model\CrowdfundingCampaignQuery|\Model\CrowfundingRewardQuery|\Model\CustomerQuery|\Model\DownloadQuery|\Model\FileQuery|\Model\ImageQuery|\Model\InvitationQuery|\Model\StockItemListQuery|\Model\OptionQuery|\Model\OrderQuery|\Model\PageQuery|\Model\PaymentQuery|\Model\PostQuery|\Model\ArticleCategoryQuery|\Model\RightQuery|\Model\SessionQuery|\Model\SpecialOfferQuery|\Model\StockQuery|\Model\SubscriptionQuery|\Model\UserQuery|\Model\AuthenticationMethodQuery|\Model\VoteQuery|\Model\WishlistQuery endUse() Finalizes a secondary criteria and merges it with its primary Criteria
  *
  * @method     ChildSite|null findOne(?ConnectionInterface $con = null) Return the first ChildSite matching the query
  * @method     ChildSite findOneOrCreate(?ConnectionInterface $con = null) Return the first ChildSite matching the query, or a new ChildSite object populated from the query conditions when no match is found
@@ -2803,6 +2823,352 @@ abstract class SiteQuery extends ModelCriteria
     {
         /** @var $q \Model\CustomerQuery */
         $q = $this->useInQuery('Customer', $modelAlias, $queryClass, 'NOT IN');
+        return $q;
+    }
+
+    /**
+     * Filter the query by a related \Model\Download object
+     *
+     * @param \Model\Download|ObjectCollection $download the related object to use as filter
+     * @param string|null $comparison Operator to use for the column comparison, defaults to Criteria::EQUAL
+     *
+     * @return $this The current query, for fluid interface
+     */
+    public function filterByDownload($download, ?string $comparison = null)
+    {
+        if ($download instanceof \Model\Download) {
+            $this
+                ->addUsingAlias(SiteTableMap::COL_SITE_ID, $download->getSiteId(), $comparison);
+
+            return $this;
+        } elseif ($download instanceof ObjectCollection) {
+            $this
+                ->useDownloadQuery()
+                ->filterByPrimaryKeys($download->getPrimaryKeys())
+                ->endUse();
+
+            return $this;
+        } else {
+            throw new PropelException('filterByDownload() only accepts arguments of type \Model\Download or Collection');
+        }
+    }
+
+    /**
+     * Adds a JOIN clause to the query using the Download relation
+     *
+     * @param string|null $relationAlias Optional alias for the relation
+     * @param string|null $joinType Accepted values are null, 'left join', 'right join', 'inner join'
+     *
+     * @return $this The current query, for fluid interface
+     */
+    public function joinDownload(?string $relationAlias = null, ?string $joinType = Criteria::LEFT_JOIN)
+    {
+        $tableMap = $this->getTableMap();
+        $relationMap = $tableMap->getRelation('Download');
+
+        // create a ModelJoin object for this join
+        $join = new ModelJoin();
+        $join->setJoinType($joinType);
+        $join->setRelationMap($relationMap, $this->useAliasInSQL ? $this->getModelAlias() : null, $relationAlias);
+        if ($previousJoin = $this->getPreviousJoin()) {
+            $join->setPreviousJoin($previousJoin);
+        }
+
+        // add the ModelJoin to the current object
+        if ($relationAlias) {
+            $this->addAlias($relationAlias, $relationMap->getRightTable()->getName());
+            $this->addJoinObject($join, $relationAlias);
+        } else {
+            $this->addJoinObject($join, 'Download');
+        }
+
+        return $this;
+    }
+
+    /**
+     * Use the Download relation Download object
+     *
+     * @see useQuery()
+     *
+     * @param string $relationAlias optional alias for the relation,
+     *                                   to be used as main alias in the secondary query
+     * @param string $joinType Accepted values are null, 'left join', 'right join', 'inner join'
+     *
+     * @return \Model\DownloadQuery A secondary query class using the current class as primary query
+     */
+    public function useDownloadQuery($relationAlias = null, $joinType = Criteria::LEFT_JOIN)
+    {
+        return $this
+            ->joinDownload($relationAlias, $joinType)
+            ->useQuery($relationAlias ? $relationAlias : 'Download', '\Model\DownloadQuery');
+    }
+
+    /**
+     * Use the Download relation Download object
+     *
+     * @param callable(\Model\DownloadQuery):\Model\DownloadQuery $callable A function working on the related query
+     *
+     * @param string|null $relationAlias optional alias for the relation
+     *
+     * @param string|null $joinType Accepted values are null, 'left join', 'right join', 'inner join'
+     *
+     * @return $this
+     */
+    public function withDownloadQuery(
+        callable $callable,
+        string $relationAlias = null,
+        ?string $joinType = Criteria::LEFT_JOIN
+    ) {
+        $relatedQuery = $this->useDownloadQuery(
+            $relationAlias,
+            $joinType
+        );
+        $callable($relatedQuery);
+        $relatedQuery->endUse();
+
+        return $this;
+    }
+
+    /**
+     * Use the relation to Download table for an EXISTS query.
+     *
+     * @see \Propel\Runtime\ActiveQuery\ModelCriteria::useExistsQuery()
+     *
+     * @param string|null $modelAlias sets an alias for the nested query
+     * @param string|null $queryClass Allows to use a custom query class for the exists query, like ExtendedBookQuery::class
+     * @param string $typeOfExists Either ExistsQueryCriterion::TYPE_EXISTS or ExistsQueryCriterion::TYPE_NOT_EXISTS
+     *
+     * @return \Model\DownloadQuery The inner query object of the EXISTS statement
+     */
+    public function useDownloadExistsQuery($modelAlias = null, $queryClass = null, $typeOfExists = 'EXISTS')
+    {
+        /** @var $q \Model\DownloadQuery */
+        $q = $this->useExistsQuery('Download', $modelAlias, $queryClass, $typeOfExists);
+        return $q;
+    }
+
+    /**
+     * Use the relation to Download table for a NOT EXISTS query.
+     *
+     * @see useDownloadExistsQuery()
+     *
+     * @param string|null $modelAlias sets an alias for the nested query
+     * @param string|null $queryClass Allows to use a custom query class for the exists query, like ExtendedBookQuery::class
+     *
+     * @return \Model\DownloadQuery The inner query object of the NOT EXISTS statement
+     */
+    public function useDownloadNotExistsQuery($modelAlias = null, $queryClass = null)
+    {
+        /** @var $q \Model\DownloadQuery */
+        $q = $this->useExistsQuery('Download', $modelAlias, $queryClass, 'NOT EXISTS');
+        return $q;
+    }
+
+    /**
+     * Use the relation to Download table for an IN query.
+     *
+     * @see \Propel\Runtime\ActiveQuery\ModelCriteria::useInQuery()
+     *
+     * @param string|null $modelAlias sets an alias for the nested query
+     * @param string|null $queryClass Allows to use a custom query class for the IN query, like ExtendedBookQuery::class
+     * @param string $typeOfIn Criteria::IN or Criteria::NOT_IN
+     *
+     * @return \Model\DownloadQuery The inner query object of the IN statement
+     */
+    public function useInDownloadQuery($modelAlias = null, $queryClass = null, $typeOfIn = 'IN')
+    {
+        /** @var $q \Model\DownloadQuery */
+        $q = $this->useInQuery('Download', $modelAlias, $queryClass, $typeOfIn);
+        return $q;
+    }
+
+    /**
+     * Use the relation to Download table for a NOT IN query.
+     *
+     * @see useDownloadInQuery()
+     *
+     * @param string|null $modelAlias sets an alias for the nested query
+     * @param string|null $queryClass Allows to use a custom query class for the NOT IN query, like ExtendedBookQuery::class
+     *
+     * @return \Model\DownloadQuery The inner query object of the NOT IN statement
+     */
+    public function useNotInDownloadQuery($modelAlias = null, $queryClass = null)
+    {
+        /** @var $q \Model\DownloadQuery */
+        $q = $this->useInQuery('Download', $modelAlias, $queryClass, 'NOT IN');
+        return $q;
+    }
+
+    /**
+     * Filter the query by a related \Model\File object
+     *
+     * @param \Model\File|ObjectCollection $file the related object to use as filter
+     * @param string|null $comparison Operator to use for the column comparison, defaults to Criteria::EQUAL
+     *
+     * @return $this The current query, for fluid interface
+     */
+    public function filterByFile($file, ?string $comparison = null)
+    {
+        if ($file instanceof \Model\File) {
+            $this
+                ->addUsingAlias(SiteTableMap::COL_SITE_ID, $file->getSiteId(), $comparison);
+
+            return $this;
+        } elseif ($file instanceof ObjectCollection) {
+            $this
+                ->useFileQuery()
+                ->filterByPrimaryKeys($file->getPrimaryKeys())
+                ->endUse();
+
+            return $this;
+        } else {
+            throw new PropelException('filterByFile() only accepts arguments of type \Model\File or Collection');
+        }
+    }
+
+    /**
+     * Adds a JOIN clause to the query using the File relation
+     *
+     * @param string|null $relationAlias Optional alias for the relation
+     * @param string|null $joinType Accepted values are null, 'left join', 'right join', 'inner join'
+     *
+     * @return $this The current query, for fluid interface
+     */
+    public function joinFile(?string $relationAlias = null, ?string $joinType = Criteria::LEFT_JOIN)
+    {
+        $tableMap = $this->getTableMap();
+        $relationMap = $tableMap->getRelation('File');
+
+        // create a ModelJoin object for this join
+        $join = new ModelJoin();
+        $join->setJoinType($joinType);
+        $join->setRelationMap($relationMap, $this->useAliasInSQL ? $this->getModelAlias() : null, $relationAlias);
+        if ($previousJoin = $this->getPreviousJoin()) {
+            $join->setPreviousJoin($previousJoin);
+        }
+
+        // add the ModelJoin to the current object
+        if ($relationAlias) {
+            $this->addAlias($relationAlias, $relationMap->getRightTable()->getName());
+            $this->addJoinObject($join, $relationAlias);
+        } else {
+            $this->addJoinObject($join, 'File');
+        }
+
+        return $this;
+    }
+
+    /**
+     * Use the File relation File object
+     *
+     * @see useQuery()
+     *
+     * @param string $relationAlias optional alias for the relation,
+     *                                   to be used as main alias in the secondary query
+     * @param string $joinType Accepted values are null, 'left join', 'right join', 'inner join'
+     *
+     * @return \Model\FileQuery A secondary query class using the current class as primary query
+     */
+    public function useFileQuery($relationAlias = null, $joinType = Criteria::LEFT_JOIN)
+    {
+        return $this
+            ->joinFile($relationAlias, $joinType)
+            ->useQuery($relationAlias ? $relationAlias : 'File', '\Model\FileQuery');
+    }
+
+    /**
+     * Use the File relation File object
+     *
+     * @param callable(\Model\FileQuery):\Model\FileQuery $callable A function working on the related query
+     *
+     * @param string|null $relationAlias optional alias for the relation
+     *
+     * @param string|null $joinType Accepted values are null, 'left join', 'right join', 'inner join'
+     *
+     * @return $this
+     */
+    public function withFileQuery(
+        callable $callable,
+        string $relationAlias = null,
+        ?string $joinType = Criteria::LEFT_JOIN
+    ) {
+        $relatedQuery = $this->useFileQuery(
+            $relationAlias,
+            $joinType
+        );
+        $callable($relatedQuery);
+        $relatedQuery->endUse();
+
+        return $this;
+    }
+
+    /**
+     * Use the relation to File table for an EXISTS query.
+     *
+     * @see \Propel\Runtime\ActiveQuery\ModelCriteria::useExistsQuery()
+     *
+     * @param string|null $modelAlias sets an alias for the nested query
+     * @param string|null $queryClass Allows to use a custom query class for the exists query, like ExtendedBookQuery::class
+     * @param string $typeOfExists Either ExistsQueryCriterion::TYPE_EXISTS or ExistsQueryCriterion::TYPE_NOT_EXISTS
+     *
+     * @return \Model\FileQuery The inner query object of the EXISTS statement
+     */
+    public function useFileExistsQuery($modelAlias = null, $queryClass = null, $typeOfExists = 'EXISTS')
+    {
+        /** @var $q \Model\FileQuery */
+        $q = $this->useExistsQuery('File', $modelAlias, $queryClass, $typeOfExists);
+        return $q;
+    }
+
+    /**
+     * Use the relation to File table for a NOT EXISTS query.
+     *
+     * @see useFileExistsQuery()
+     *
+     * @param string|null $modelAlias sets an alias for the nested query
+     * @param string|null $queryClass Allows to use a custom query class for the exists query, like ExtendedBookQuery::class
+     *
+     * @return \Model\FileQuery The inner query object of the NOT EXISTS statement
+     */
+    public function useFileNotExistsQuery($modelAlias = null, $queryClass = null)
+    {
+        /** @var $q \Model\FileQuery */
+        $q = $this->useExistsQuery('File', $modelAlias, $queryClass, 'NOT EXISTS');
+        return $q;
+    }
+
+    /**
+     * Use the relation to File table for an IN query.
+     *
+     * @see \Propel\Runtime\ActiveQuery\ModelCriteria::useInQuery()
+     *
+     * @param string|null $modelAlias sets an alias for the nested query
+     * @param string|null $queryClass Allows to use a custom query class for the IN query, like ExtendedBookQuery::class
+     * @param string $typeOfIn Criteria::IN or Criteria::NOT_IN
+     *
+     * @return \Model\FileQuery The inner query object of the IN statement
+     */
+    public function useInFileQuery($modelAlias = null, $queryClass = null, $typeOfIn = 'IN')
+    {
+        /** @var $q \Model\FileQuery */
+        $q = $this->useInQuery('File', $modelAlias, $queryClass, $typeOfIn);
+        return $q;
+    }
+
+    /**
+     * Use the relation to File table for a NOT IN query.
+     *
+     * @see useFileInQuery()
+     *
+     * @param string|null $modelAlias sets an alias for the nested query
+     * @param string|null $queryClass Allows to use a custom query class for the NOT IN query, like ExtendedBookQuery::class
+     *
+     * @return \Model\FileQuery The inner query object of the NOT IN statement
+     */
+    public function useNotInFileQuery($modelAlias = null, $queryClass = null)
+    {
+        /** @var $q \Model\FileQuery */
+        $q = $this->useInQuery('File', $modelAlias, $queryClass, 'NOT IN');
         return $q;
     }
 

--- a/src/Model/Base/User.php
+++ b/src/Model/Base/User.php
@@ -4400,6 +4400,32 @@ abstract class User implements ActiveRecordInterface
         return $this;
     }
 
+
+    /**
+     * If this collection has already been initialized with
+     * an identical criteria, it returns the collection.
+     * Otherwise if this User is new, it will return
+     * an empty collection; or if this User has previously
+     * been saved, it will retrieve related Downloads from storage.
+     *
+     * This method is protected by default in order to keep the public
+     * api reasonable.  You can provide public methods for those you
+     * actually need in User.
+     *
+     * @param Criteria $criteria optional Criteria object to narrow the query
+     * @param ConnectionInterface $con optional connection object
+     * @param string $joinBehavior optional join type to use (defaults to Criteria::LEFT_JOIN)
+     * @return ObjectCollection|ChildDownload[] List of ChildDownload objects
+     * @phpstan-return ObjectCollection&\Traversable<ChildDownload}> List of ChildDownload objects
+     */
+    public function getDownloadsJoinSite(?Criteria $criteria = null, ?ConnectionInterface $con = null, $joinBehavior = Criteria::LEFT_JOIN)
+    {
+        $query = ChildDownloadQuery::create(null, $criteria);
+        $query->joinWith('Site', $joinBehavior);
+
+        return $this->getDownloads($query, $con);
+    }
+
     /**
      * Clears out the collFiles collection
      *
@@ -4637,6 +4663,32 @@ abstract class User implements ActiveRecordInterface
         }
 
         return $this;
+    }
+
+
+    /**
+     * If this collection has already been initialized with
+     * an identical criteria, it returns the collection.
+     * Otherwise if this User is new, it will return
+     * an empty collection; or if this User has previously
+     * been saved, it will retrieve related Files from storage.
+     *
+     * This method is protected by default in order to keep the public
+     * api reasonable.  You can provide public methods for those you
+     * actually need in User.
+     *
+     * @param Criteria $criteria optional Criteria object to narrow the query
+     * @param ConnectionInterface $con optional connection object
+     * @param string $joinBehavior optional join type to use (defaults to Criteria::LEFT_JOIN)
+     * @return ObjectCollection|ChildFile[] List of ChildFile objects
+     * @phpstan-return ObjectCollection&\Traversable<ChildFile}> List of ChildFile objects
+     */
+    public function getFilesJoinSite(?Criteria $criteria = null, ?ConnectionInterface $con = null, $joinBehavior = Criteria::LEFT_JOIN)
+    {
+        $query = ChildFileQuery::create(null, $criteria);
+        $query->joinWith('Site', $joinBehavior);
+
+        return $this->getFiles($query, $con);
     }
 
 

--- a/src/Model/File.php
+++ b/src/Model/File.php
@@ -23,4 +23,9 @@ class File extends BaseFile
     {
         return FileType::getByMediaType($this->getType());
     }
+
+    public function getFullPath(): string
+    {
+        return __DIR__ . "/../../content/downloadable/{$this->getArticleId()}/{$this->getHash()}";
+    }
 }

--- a/src/Model/Map/DownloadTableMap.php
+++ b/src/Model/Map/DownloadTableMap.php
@@ -63,7 +63,7 @@ class DownloadTableMap extends TableMap
     /**
      * The total number of columns
      */
-    public const NUM_COLUMNS = 12;
+    public const NUM_COLUMNS = 13;
 
     /**
      * The number of lazy-loaded columns
@@ -73,12 +73,17 @@ class DownloadTableMap extends TableMap
     /**
      * The number of columns to hydrate (NUM_COLUMNS - NUM_LAZY_LOAD_COLUMNS)
      */
-    public const NUM_HYDRATE_COLUMNS = 12;
+    public const NUM_HYDRATE_COLUMNS = 13;
 
     /**
      * the column name for the download_id field
      */
     public const COL_DOWNLOAD_ID = 'downloads.download_id';
+
+    /**
+     * the column name for the site_id field
+     */
+    public const COL_SITE_ID = 'downloads.site_id';
 
     /**
      * the column name for the file_id field
@@ -149,11 +154,11 @@ class DownloadTableMap extends TableMap
      * @var array<string, mixed>
      */
     protected static $fieldNames = [
-        self::TYPE_PHPNAME       => ['Id', 'FileId', 'ArticleId', 'BookId', 'AxysAccountId', 'UserId', 'Filetype', 'Version', 'Ip', 'Date', 'CreatedAt', 'UpdatedAt', ],
-        self::TYPE_CAMELNAME     => ['id', 'fileId', 'articleId', 'bookId', 'axysAccountId', 'userId', 'filetype', 'version', 'ip', 'date', 'createdAt', 'updatedAt', ],
-        self::TYPE_COLNAME       => [DownloadTableMap::COL_DOWNLOAD_ID, DownloadTableMap::COL_FILE_ID, DownloadTableMap::COL_ARTICLE_ID, DownloadTableMap::COL_BOOK_ID, DownloadTableMap::COL_AXYS_ACCOUNT_ID, DownloadTableMap::COL_USER_ID, DownloadTableMap::COL_DOWNLOAD_FILETYPE, DownloadTableMap::COL_DOWNLOAD_VERSION, DownloadTableMap::COL_DOWNLOAD_IP, DownloadTableMap::COL_DOWNLOAD_DATE, DownloadTableMap::COL_DOWNLOAD_CREATED, DownloadTableMap::COL_DOWNLOAD_UPDATED, ],
-        self::TYPE_FIELDNAME     => ['download_id', 'file_id', 'article_id', 'book_id', 'axys_account_id', 'user_id', 'download_filetype', 'download_version', 'download_ip', 'download_date', 'download_created', 'download_updated', ],
-        self::TYPE_NUM           => [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, ]
+        self::TYPE_PHPNAME       => ['Id', 'SiteId', 'FileId', 'ArticleId', 'BookId', 'AxysAccountId', 'UserId', 'Filetype', 'Version', 'Ip', 'Date', 'CreatedAt', 'UpdatedAt', ],
+        self::TYPE_CAMELNAME     => ['id', 'siteId', 'fileId', 'articleId', 'bookId', 'axysAccountId', 'userId', 'filetype', 'version', 'ip', 'date', 'createdAt', 'updatedAt', ],
+        self::TYPE_COLNAME       => [DownloadTableMap::COL_DOWNLOAD_ID, DownloadTableMap::COL_SITE_ID, DownloadTableMap::COL_FILE_ID, DownloadTableMap::COL_ARTICLE_ID, DownloadTableMap::COL_BOOK_ID, DownloadTableMap::COL_AXYS_ACCOUNT_ID, DownloadTableMap::COL_USER_ID, DownloadTableMap::COL_DOWNLOAD_FILETYPE, DownloadTableMap::COL_DOWNLOAD_VERSION, DownloadTableMap::COL_DOWNLOAD_IP, DownloadTableMap::COL_DOWNLOAD_DATE, DownloadTableMap::COL_DOWNLOAD_CREATED, DownloadTableMap::COL_DOWNLOAD_UPDATED, ],
+        self::TYPE_FIELDNAME     => ['download_id', 'site_id', 'file_id', 'article_id', 'book_id', 'axys_account_id', 'user_id', 'download_filetype', 'download_version', 'download_ip', 'download_date', 'download_created', 'download_updated', ],
+        self::TYPE_NUM           => [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, ]
     ];
 
     /**
@@ -165,11 +170,11 @@ class DownloadTableMap extends TableMap
      * @var array<string, mixed>
      */
     protected static $fieldKeys = [
-        self::TYPE_PHPNAME       => ['Id' => 0, 'FileId' => 1, 'ArticleId' => 2, 'BookId' => 3, 'AxysAccountId' => 4, 'UserId' => 5, 'Filetype' => 6, 'Version' => 7, 'Ip' => 8, 'Date' => 9, 'CreatedAt' => 10, 'UpdatedAt' => 11, ],
-        self::TYPE_CAMELNAME     => ['id' => 0, 'fileId' => 1, 'articleId' => 2, 'bookId' => 3, 'axysAccountId' => 4, 'userId' => 5, 'filetype' => 6, 'version' => 7, 'ip' => 8, 'date' => 9, 'createdAt' => 10, 'updatedAt' => 11, ],
-        self::TYPE_COLNAME       => [DownloadTableMap::COL_DOWNLOAD_ID => 0, DownloadTableMap::COL_FILE_ID => 1, DownloadTableMap::COL_ARTICLE_ID => 2, DownloadTableMap::COL_BOOK_ID => 3, DownloadTableMap::COL_AXYS_ACCOUNT_ID => 4, DownloadTableMap::COL_USER_ID => 5, DownloadTableMap::COL_DOWNLOAD_FILETYPE => 6, DownloadTableMap::COL_DOWNLOAD_VERSION => 7, DownloadTableMap::COL_DOWNLOAD_IP => 8, DownloadTableMap::COL_DOWNLOAD_DATE => 9, DownloadTableMap::COL_DOWNLOAD_CREATED => 10, DownloadTableMap::COL_DOWNLOAD_UPDATED => 11, ],
-        self::TYPE_FIELDNAME     => ['download_id' => 0, 'file_id' => 1, 'article_id' => 2, 'book_id' => 3, 'axys_account_id' => 4, 'user_id' => 5, 'download_filetype' => 6, 'download_version' => 7, 'download_ip' => 8, 'download_date' => 9, 'download_created' => 10, 'download_updated' => 11, ],
-        self::TYPE_NUM           => [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, ]
+        self::TYPE_PHPNAME       => ['Id' => 0, 'SiteId' => 1, 'FileId' => 2, 'ArticleId' => 3, 'BookId' => 4, 'AxysAccountId' => 5, 'UserId' => 6, 'Filetype' => 7, 'Version' => 8, 'Ip' => 9, 'Date' => 10, 'CreatedAt' => 11, 'UpdatedAt' => 12, ],
+        self::TYPE_CAMELNAME     => ['id' => 0, 'siteId' => 1, 'fileId' => 2, 'articleId' => 3, 'bookId' => 4, 'axysAccountId' => 5, 'userId' => 6, 'filetype' => 7, 'version' => 8, 'ip' => 9, 'date' => 10, 'createdAt' => 11, 'updatedAt' => 12, ],
+        self::TYPE_COLNAME       => [DownloadTableMap::COL_DOWNLOAD_ID => 0, DownloadTableMap::COL_SITE_ID => 1, DownloadTableMap::COL_FILE_ID => 2, DownloadTableMap::COL_ARTICLE_ID => 3, DownloadTableMap::COL_BOOK_ID => 4, DownloadTableMap::COL_AXYS_ACCOUNT_ID => 5, DownloadTableMap::COL_USER_ID => 6, DownloadTableMap::COL_DOWNLOAD_FILETYPE => 7, DownloadTableMap::COL_DOWNLOAD_VERSION => 8, DownloadTableMap::COL_DOWNLOAD_IP => 9, DownloadTableMap::COL_DOWNLOAD_DATE => 10, DownloadTableMap::COL_DOWNLOAD_CREATED => 11, DownloadTableMap::COL_DOWNLOAD_UPDATED => 12, ],
+        self::TYPE_FIELDNAME     => ['download_id' => 0, 'site_id' => 1, 'file_id' => 2, 'article_id' => 3, 'book_id' => 4, 'axys_account_id' => 5, 'user_id' => 6, 'download_filetype' => 7, 'download_version' => 8, 'download_ip' => 9, 'download_date' => 10, 'download_created' => 11, 'download_updated' => 12, ],
+        self::TYPE_NUM           => [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, ]
     ];
 
     /**
@@ -186,6 +191,14 @@ class DownloadTableMap extends TableMap
         'COL_DOWNLOAD_ID' => 'DOWNLOAD_ID',
         'download_id' => 'DOWNLOAD_ID',
         'downloads.download_id' => 'DOWNLOAD_ID',
+        'SiteId' => 'SITE_ID',
+        'Download.SiteId' => 'SITE_ID',
+        'siteId' => 'SITE_ID',
+        'download.siteId' => 'SITE_ID',
+        'DownloadTableMap::COL_SITE_ID' => 'SITE_ID',
+        'COL_SITE_ID' => 'SITE_ID',
+        'site_id' => 'SITE_ID',
+        'downloads.site_id' => 'SITE_ID',
         'FileId' => 'FILE_ID',
         'Download.FileId' => 'FILE_ID',
         'fileId' => 'FILE_ID',
@@ -294,6 +307,7 @@ class DownloadTableMap extends TableMap
         $this->setUseIdGenerator(true);
         // columns
         $this->addPrimaryKey('download_id', 'Id', 'BIGINT', true, null, null);
+        $this->addForeignKey('site_id', 'SiteId', 'INTEGER', 'sites', 'site_id', false, null, null);
         $this->addColumn('file_id', 'FileId', 'INTEGER', false, null, null);
         $this->addColumn('article_id', 'ArticleId', 'INTEGER', false, null, null);
         $this->addColumn('book_id', 'BookId', 'INTEGER', false, null, null);
@@ -314,6 +328,13 @@ class DownloadTableMap extends TableMap
      */
     public function buildRelations(): void
     {
+        $this->addRelation('Site', '\\Model\\Site', RelationMap::MANY_TO_ONE, array (
+  0 =>
+  array (
+    0 => ':site_id',
+    1 => ':site_id',
+  ),
+), null, null, null, false);
         $this->addRelation('User', '\\Model\\User', RelationMap::MANY_TO_ONE, array (
   0 =>
   array (
@@ -479,6 +500,7 @@ class DownloadTableMap extends TableMap
     {
         if (null === $alias) {
             $criteria->addSelectColumn(DownloadTableMap::COL_DOWNLOAD_ID);
+            $criteria->addSelectColumn(DownloadTableMap::COL_SITE_ID);
             $criteria->addSelectColumn(DownloadTableMap::COL_FILE_ID);
             $criteria->addSelectColumn(DownloadTableMap::COL_ARTICLE_ID);
             $criteria->addSelectColumn(DownloadTableMap::COL_BOOK_ID);
@@ -492,6 +514,7 @@ class DownloadTableMap extends TableMap
             $criteria->addSelectColumn(DownloadTableMap::COL_DOWNLOAD_UPDATED);
         } else {
             $criteria->addSelectColumn($alias . '.download_id');
+            $criteria->addSelectColumn($alias . '.site_id');
             $criteria->addSelectColumn($alias . '.file_id');
             $criteria->addSelectColumn($alias . '.article_id');
             $criteria->addSelectColumn($alias . '.book_id');
@@ -522,6 +545,7 @@ class DownloadTableMap extends TableMap
     {
         if (null === $alias) {
             $criteria->removeSelectColumn(DownloadTableMap::COL_DOWNLOAD_ID);
+            $criteria->removeSelectColumn(DownloadTableMap::COL_SITE_ID);
             $criteria->removeSelectColumn(DownloadTableMap::COL_FILE_ID);
             $criteria->removeSelectColumn(DownloadTableMap::COL_ARTICLE_ID);
             $criteria->removeSelectColumn(DownloadTableMap::COL_BOOK_ID);
@@ -535,6 +559,7 @@ class DownloadTableMap extends TableMap
             $criteria->removeSelectColumn(DownloadTableMap::COL_DOWNLOAD_UPDATED);
         } else {
             $criteria->removeSelectColumn($alias . '.download_id');
+            $criteria->removeSelectColumn($alias . '.site_id');
             $criteria->removeSelectColumn($alias . '.file_id');
             $criteria->removeSelectColumn($alias . '.article_id');
             $criteria->removeSelectColumn($alias . '.book_id');

--- a/src/Model/Map/FileTableMap.php
+++ b/src/Model/Map/FileTableMap.php
@@ -63,7 +63,7 @@ class FileTableMap extends TableMap
     /**
      * The total number of columns
      */
-    public const NUM_COLUMNS = 15;
+    public const NUM_COLUMNS = 16;
 
     /**
      * The number of lazy-loaded columns
@@ -73,12 +73,17 @@ class FileTableMap extends TableMap
     /**
      * The number of columns to hydrate (NUM_COLUMNS - NUM_LAZY_LOAD_COLUMNS)
      */
-    public const NUM_HYDRATE_COLUMNS = 15;
+    public const NUM_HYDRATE_COLUMNS = 16;
 
     /**
      * the column name for the file_id field
      */
     public const COL_FILE_ID = 'files.file_id';
+
+    /**
+     * the column name for the site_id field
+     */
+    public const COL_SITE_ID = 'files.site_id';
 
     /**
      * the column name for the article_id field
@@ -164,11 +169,11 @@ class FileTableMap extends TableMap
      * @var array<string, mixed>
      */
     protected static $fieldNames = [
-        self::TYPE_PHPNAME       => ['Id', 'ArticleId', 'AxysAccountId', 'UserId', 'Title', 'Type', 'Access', 'Version', 'Hash', 'Size', 'Ean', 'Inserted', 'Uploaded', 'UpdatedAt', 'CreatedAt', ],
-        self::TYPE_CAMELNAME     => ['id', 'articleId', 'axysAccountId', 'userId', 'title', 'type', 'access', 'version', 'hash', 'size', 'ean', 'inserted', 'uploaded', 'updatedAt', 'createdAt', ],
-        self::TYPE_COLNAME       => [FileTableMap::COL_FILE_ID, FileTableMap::COL_ARTICLE_ID, FileTableMap::COL_AXYS_ACCOUNT_ID, FileTableMap::COL_USER_ID, FileTableMap::COL_FILE_TITLE, FileTableMap::COL_FILE_TYPE, FileTableMap::COL_FILE_ACCESS, FileTableMap::COL_FILE_VERSION, FileTableMap::COL_FILE_HASH, FileTableMap::COL_FILE_SIZE, FileTableMap::COL_FILE_EAN, FileTableMap::COL_FILE_INSERTED, FileTableMap::COL_FILE_UPLOADED, FileTableMap::COL_FILE_UPDATED, FileTableMap::COL_FILE_CREATED, ],
-        self::TYPE_FIELDNAME     => ['file_id', 'article_id', 'axys_account_id', 'user_id', 'file_title', 'file_type', 'file_access', 'file_version', 'file_hash', 'file_size', 'file_ean', 'file_inserted', 'file_uploaded', 'file_updated', 'file_created', ],
-        self::TYPE_NUM           => [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, ]
+        self::TYPE_PHPNAME       => ['Id', 'SiteId', 'ArticleId', 'AxysAccountId', 'UserId', 'Title', 'Type', 'Access', 'Version', 'Hash', 'Size', 'Ean', 'Inserted', 'Uploaded', 'UpdatedAt', 'CreatedAt', ],
+        self::TYPE_CAMELNAME     => ['id', 'siteId', 'articleId', 'axysAccountId', 'userId', 'title', 'type', 'access', 'version', 'hash', 'size', 'ean', 'inserted', 'uploaded', 'updatedAt', 'createdAt', ],
+        self::TYPE_COLNAME       => [FileTableMap::COL_FILE_ID, FileTableMap::COL_SITE_ID, FileTableMap::COL_ARTICLE_ID, FileTableMap::COL_AXYS_ACCOUNT_ID, FileTableMap::COL_USER_ID, FileTableMap::COL_FILE_TITLE, FileTableMap::COL_FILE_TYPE, FileTableMap::COL_FILE_ACCESS, FileTableMap::COL_FILE_VERSION, FileTableMap::COL_FILE_HASH, FileTableMap::COL_FILE_SIZE, FileTableMap::COL_FILE_EAN, FileTableMap::COL_FILE_INSERTED, FileTableMap::COL_FILE_UPLOADED, FileTableMap::COL_FILE_UPDATED, FileTableMap::COL_FILE_CREATED, ],
+        self::TYPE_FIELDNAME     => ['file_id', 'site_id', 'article_id', 'axys_account_id', 'user_id', 'file_title', 'file_type', 'file_access', 'file_version', 'file_hash', 'file_size', 'file_ean', 'file_inserted', 'file_uploaded', 'file_updated', 'file_created', ],
+        self::TYPE_NUM           => [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, ]
     ];
 
     /**
@@ -180,11 +185,11 @@ class FileTableMap extends TableMap
      * @var array<string, mixed>
      */
     protected static $fieldKeys = [
-        self::TYPE_PHPNAME       => ['Id' => 0, 'ArticleId' => 1, 'AxysAccountId' => 2, 'UserId' => 3, 'Title' => 4, 'Type' => 5, 'Access' => 6, 'Version' => 7, 'Hash' => 8, 'Size' => 9, 'Ean' => 10, 'Inserted' => 11, 'Uploaded' => 12, 'UpdatedAt' => 13, 'CreatedAt' => 14, ],
-        self::TYPE_CAMELNAME     => ['id' => 0, 'articleId' => 1, 'axysAccountId' => 2, 'userId' => 3, 'title' => 4, 'type' => 5, 'access' => 6, 'version' => 7, 'hash' => 8, 'size' => 9, 'ean' => 10, 'inserted' => 11, 'uploaded' => 12, 'updatedAt' => 13, 'createdAt' => 14, ],
-        self::TYPE_COLNAME       => [FileTableMap::COL_FILE_ID => 0, FileTableMap::COL_ARTICLE_ID => 1, FileTableMap::COL_AXYS_ACCOUNT_ID => 2, FileTableMap::COL_USER_ID => 3, FileTableMap::COL_FILE_TITLE => 4, FileTableMap::COL_FILE_TYPE => 5, FileTableMap::COL_FILE_ACCESS => 6, FileTableMap::COL_FILE_VERSION => 7, FileTableMap::COL_FILE_HASH => 8, FileTableMap::COL_FILE_SIZE => 9, FileTableMap::COL_FILE_EAN => 10, FileTableMap::COL_FILE_INSERTED => 11, FileTableMap::COL_FILE_UPLOADED => 12, FileTableMap::COL_FILE_UPDATED => 13, FileTableMap::COL_FILE_CREATED => 14, ],
-        self::TYPE_FIELDNAME     => ['file_id' => 0, 'article_id' => 1, 'axys_account_id' => 2, 'user_id' => 3, 'file_title' => 4, 'file_type' => 5, 'file_access' => 6, 'file_version' => 7, 'file_hash' => 8, 'file_size' => 9, 'file_ean' => 10, 'file_inserted' => 11, 'file_uploaded' => 12, 'file_updated' => 13, 'file_created' => 14, ],
-        self::TYPE_NUM           => [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, ]
+        self::TYPE_PHPNAME       => ['Id' => 0, 'SiteId' => 1, 'ArticleId' => 2, 'AxysAccountId' => 3, 'UserId' => 4, 'Title' => 5, 'Type' => 6, 'Access' => 7, 'Version' => 8, 'Hash' => 9, 'Size' => 10, 'Ean' => 11, 'Inserted' => 12, 'Uploaded' => 13, 'UpdatedAt' => 14, 'CreatedAt' => 15, ],
+        self::TYPE_CAMELNAME     => ['id' => 0, 'siteId' => 1, 'articleId' => 2, 'axysAccountId' => 3, 'userId' => 4, 'title' => 5, 'type' => 6, 'access' => 7, 'version' => 8, 'hash' => 9, 'size' => 10, 'ean' => 11, 'inserted' => 12, 'uploaded' => 13, 'updatedAt' => 14, 'createdAt' => 15, ],
+        self::TYPE_COLNAME       => [FileTableMap::COL_FILE_ID => 0, FileTableMap::COL_SITE_ID => 1, FileTableMap::COL_ARTICLE_ID => 2, FileTableMap::COL_AXYS_ACCOUNT_ID => 3, FileTableMap::COL_USER_ID => 4, FileTableMap::COL_FILE_TITLE => 5, FileTableMap::COL_FILE_TYPE => 6, FileTableMap::COL_FILE_ACCESS => 7, FileTableMap::COL_FILE_VERSION => 8, FileTableMap::COL_FILE_HASH => 9, FileTableMap::COL_FILE_SIZE => 10, FileTableMap::COL_FILE_EAN => 11, FileTableMap::COL_FILE_INSERTED => 12, FileTableMap::COL_FILE_UPLOADED => 13, FileTableMap::COL_FILE_UPDATED => 14, FileTableMap::COL_FILE_CREATED => 15, ],
+        self::TYPE_FIELDNAME     => ['file_id' => 0, 'site_id' => 1, 'article_id' => 2, 'axys_account_id' => 3, 'user_id' => 4, 'file_title' => 5, 'file_type' => 6, 'file_access' => 7, 'file_version' => 8, 'file_hash' => 9, 'file_size' => 10, 'file_ean' => 11, 'file_inserted' => 12, 'file_uploaded' => 13, 'file_updated' => 14, 'file_created' => 15, ],
+        self::TYPE_NUM           => [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, ]
     ];
 
     /**
@@ -201,6 +206,14 @@ class FileTableMap extends TableMap
         'COL_FILE_ID' => 'FILE_ID',
         'file_id' => 'FILE_ID',
         'files.file_id' => 'FILE_ID',
+        'SiteId' => 'SITE_ID',
+        'File.SiteId' => 'SITE_ID',
+        'siteId' => 'SITE_ID',
+        'file.siteId' => 'SITE_ID',
+        'FileTableMap::COL_SITE_ID' => 'SITE_ID',
+        'COL_SITE_ID' => 'SITE_ID',
+        'site_id' => 'SITE_ID',
+        'files.site_id' => 'SITE_ID',
         'ArticleId' => 'ARTICLE_ID',
         'File.ArticleId' => 'ARTICLE_ID',
         'articleId' => 'ARTICLE_ID',
@@ -333,6 +346,7 @@ class FileTableMap extends TableMap
         $this->setUseIdGenerator(true);
         // columns
         $this->addPrimaryKey('file_id', 'Id', 'INTEGER', true, null, null);
+        $this->addForeignKey('site_id', 'SiteId', 'INTEGER', 'sites', 'site_id', false, null, null);
         $this->addForeignKey('article_id', 'ArticleId', 'INTEGER', 'articles', 'article_id', false, null, null);
         $this->addColumn('axys_account_id', 'AxysAccountId', 'INTEGER', false, null, null);
         $this->addForeignKey('user_id', 'UserId', 'INTEGER', 'users', 'id', false, null, null);
@@ -356,6 +370,13 @@ class FileTableMap extends TableMap
      */
     public function buildRelations(): void
     {
+        $this->addRelation('Site', '\\Model\\Site', RelationMap::MANY_TO_ONE, array (
+  0 =>
+  array (
+    0 => ':site_id',
+    1 => ':site_id',
+  ),
+), null, null, null, false);
         $this->addRelation('Article', '\\Model\\Article', RelationMap::MANY_TO_ONE, array (
   0 =>
   array (
@@ -528,6 +549,7 @@ class FileTableMap extends TableMap
     {
         if (null === $alias) {
             $criteria->addSelectColumn(FileTableMap::COL_FILE_ID);
+            $criteria->addSelectColumn(FileTableMap::COL_SITE_ID);
             $criteria->addSelectColumn(FileTableMap::COL_ARTICLE_ID);
             $criteria->addSelectColumn(FileTableMap::COL_AXYS_ACCOUNT_ID);
             $criteria->addSelectColumn(FileTableMap::COL_USER_ID);
@@ -544,6 +566,7 @@ class FileTableMap extends TableMap
             $criteria->addSelectColumn(FileTableMap::COL_FILE_CREATED);
         } else {
             $criteria->addSelectColumn($alias . '.file_id');
+            $criteria->addSelectColumn($alias . '.site_id');
             $criteria->addSelectColumn($alias . '.article_id');
             $criteria->addSelectColumn($alias . '.axys_account_id');
             $criteria->addSelectColumn($alias . '.user_id');
@@ -577,6 +600,7 @@ class FileTableMap extends TableMap
     {
         if (null === $alias) {
             $criteria->removeSelectColumn(FileTableMap::COL_FILE_ID);
+            $criteria->removeSelectColumn(FileTableMap::COL_SITE_ID);
             $criteria->removeSelectColumn(FileTableMap::COL_ARTICLE_ID);
             $criteria->removeSelectColumn(FileTableMap::COL_AXYS_ACCOUNT_ID);
             $criteria->removeSelectColumn(FileTableMap::COL_USER_ID);
@@ -593,6 +617,7 @@ class FileTableMap extends TableMap
             $criteria->removeSelectColumn(FileTableMap::COL_FILE_CREATED);
         } else {
             $criteria->removeSelectColumn($alias . '.file_id');
+            $criteria->removeSelectColumn($alias . '.site_id');
             $criteria->removeSelectColumn($alias . '.article_id');
             $criteria->removeSelectColumn($alias . '.axys_account_id');
             $criteria->removeSelectColumn($alias . '.user_id');

--- a/src/Model/Map/SiteTableMap.php
+++ b/src/Model/Map/SiteTableMap.php
@@ -713,6 +713,20 @@ class SiteTableMap extends TableMap
     1 => ':site_id',
   ),
 ), null, null, 'Customers', false);
+        $this->addRelation('Download', '\\Model\\Download', RelationMap::ONE_TO_MANY, array (
+  0 =>
+  array (
+    0 => ':site_id',
+    1 => ':site_id',
+  ),
+), null, null, 'Downloads', false);
+        $this->addRelation('File', '\\Model\\File', RelationMap::ONE_TO_MANY, array (
+  0 =>
+  array (
+    0 => ':site_id',
+    1 => ':site_id',
+  ),
+), null, null, 'Files', false);
         $this->addRelation('Image', '\\Model\\Image', RelationMap::ONE_TO_MANY, array (
   0 =>
   array (

--- a/tests/Model/FileTest.php
+++ b/tests/Model/FileTest.php
@@ -18,4 +18,18 @@ class FileTest extends TestCase
         // then
         $this->assertEquals("ePub", $type->getName());
     }
+
+    public function testGetFullPath(): void
+    {
+        // given
+        $file = new File();
+        $file->setArticleId(1234);
+        $file->setHash("abcd");
+
+        // when
+        $path = $file->getFullPath();
+
+        // then
+        $this->assertStringEndsWith("/content/downloadable/1234/abcd", $path);
+    }
 }


### PR DESCRIPTION
## 📦 Problème

Aujourd'hui, le stockage des fichiers téléchargeables est effectué dans un dossier commun pour tous les sites et les entrées en base correspondantes ne sont pas associées à un site.

## 👜 Solution

- Associer les fichiers téléchargeables à un site en fonction du filtre éditeur
- Déplacer les fichiers dans le répertoire spécifique du site