### PR TITLE
Correctif 3.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 Corrections
 
 - Le choix d'un mode d'expédition pouvait échouer sans erreur. C'est corrigé.
+- Les champs d'ajout d'image n'autorisait que certains formats. Ils autorisent
+  désormais tous JPEG, PNG ou WebP.
 
 ## 3.0.1 (6 novembre 2024)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,11 @@
 Corrections
 
 - Le choix d'un mode d'expédition pouvait échouer sans erreur. C'est corrigé.
-- Les champs d'ajout d'image n'autorisait que certains formats. Ils autorisent
+- Les champs d'ajout d'image n'autorisaient que certains formats. Ils autorisent
   désormais tous JPEG, PNG ou WebP.
+- La contrainte du nombre d'articles dans une commande pour une tranche
+  tarifaire de frais de port n'était pas prise en compte. C'est maintenant le
+  cas.
 
 ## 3.0.1 (6 novembre 2024)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Historique des modifications
 
+## 3.0.2 (DEV)
+
+Corrections
+
+- Le choix d'un mode d'expédition pouvait échouer sans erreur. C'est corrigé.
+
 ## 3.0.1 (6 novembre 2024)
 
 Corrections

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Historique des modifications
 
-## 3.0.2 (DEV)
+## 3.0.2 (13 novembre 2024)
 
 Corrections
 

--- a/controllers/common/php/adm_order.php
+++ b/controllers/common/php/adm_order.php
@@ -188,15 +188,18 @@ return function (Request $request, CurrentSite $currentSite): Response|RedirectR
         return '<option value="' . $country->get('id') . '"' . ($country == $order->get('country') ? ' selected' : null) . '>' . $country->get('name') . '</option>';
     }, $countries);
 
+    $stockItemCount = \Model\StockQuery::create()->filterByOrderId($order->get('id'))->count();
+
     $feesList = [];
     $country = $order->get("country");
     if ($country instanceof Country) {
         $countryModel = CountryQuery::create()->findPk($country->get("id"));
-        $fees = ShippingFeeQuery::getForCountryWeightAndAmount(
+        $fees = ShippingFeeQuery::getForCountryAndWeightAndAmountAndArticleCount(
             $currentSite,
             $countryModel,
             $order->getTotalWeight(),
             $order->get('amount'),
+            articleCount: $stockItemCount,
         );
         $feesList = array_map(function ($fee) {
             return '<option value="' . $fee->getId() . '">' . $fee->getMode() . ' [' . currency($fee->getFee(), true) . ']</option>';

--- a/controllers/common/php/adm_stock.php
+++ b/controllers/common/php/adm_stock.php
@@ -786,7 +786,7 @@ return function (
             <br /><br />
 
             <label for="upload_photo">Photo :</label>
-            <input type="file" accept="image/jpeg" id="upload_photo" name="upload_photo" />
+            <input type="file" accept="image/jpeg, image/png, image/webp" id="upload_photo" name="upload_photo" />
             <br /><br />
 
             ' . $tva . $remises . '

--- a/controllers/common/php/article_edit.php
+++ b/controllers/common/php/article_edit.php
@@ -534,9 +534,9 @@ return function (
     // ** FICHIERS ** //
 
     // Couverture
-    $article_cover_upload = '<input type="file" id="article_cover_upload" name="article_cover_upload" accept="image/jpeg" />';
+    $article_cover_upload = '<input type="file" id="article_cover_upload" name="article_cover_upload" accept="image/jpeg, image/png, image/webp" />';
     if ($imagesService->imageExistsFor($article)) {
-        $article_cover_upload = '<input type="file" id="article_cover_upload" name="article_cover_upload" accept="image/jpeg" hidden /> <label class="after btn btn-default" for="article_cover_upload">Remplacer</label> <input type="checkbox" id="article_cover_delete" name="article_cover_delete" value="1" /> <label for="article_cover_delete" class="after">Supprimer</label>';
+        $article_cover_upload = '<input type="file" id="article_cover_upload" name="article_cover_upload" accept="image/jpeg, image/png, image/webp" hidden /> <label class="after btn btn-default" for="article_cover_upload">Remplacer</label> <input type="checkbox" id="article_cover_delete" name="article_cover_delete" value="1" /> <label for="article_cover_delete" class="after">Supprimer</label>';
     }
 
     // ** FICHIERS TELECHARGEABLES ** //
@@ -939,7 +939,7 @@ return function (
         <fieldset>
             <legend>Images</legend>
 
-            <p title="Image au format JPEG">
+            <p title="Image au format JPEG (recommandé), PNG ou WebP">
                 <label for="article_cover_upload">Couverture :</label>
                 ' . $article_cover_upload . '<input type="hidden" id="article_cover_import" name="article_cover_import" placeholder="Adresse de l\'image...">
             </p>

--- a/controllers/common/php/cart.php
+++ b/controllers/common/php/cart.php
@@ -300,11 +300,11 @@ return function (
                     $s["cover"] = null;
                     $stockItemPhotoUrl = $imagesService->getImageUrlFor($stockItem, height: 60);
                     $stockItemPhotoThumbnailUrl = $imagesService->getImageUrlFor($stockItem, height: 60);
-                    $articleCoverUrl = $imagesService->getImageUrlFor($articleModel, height: 100);
+                    $articleCoverUrl = $imagesService->getImageUrlFor($articleModel, height: 60);
                     if ($stockItemPhotoUrl) {
                         $s["cover"] = '<a href="' . $stockItemPhotoUrl . '" rel="lightbox"><img src="' . $stockItemPhotoThumbnailUrl . '" alt="' . $s["article_title"] . '" height="60" /></a>';
                     } elseif ($articleCoverUrl) {
-                        $s["cover"] = '<img src="' . $articleCoverUrl . '" alt="' . $articleEntity->get('title') . '" /></a>';
+                        $s["cover"] = '<img src="' . $articleCoverUrl . '" alt="' . $articleEntity->get('title') . '" height="60" /></a>';
                     }
 
                     $content .= '

--- a/controllers/common/php/cart.php
+++ b/controllers/common/php/cart.php
@@ -415,7 +415,7 @@ return function (
 
                 <input type="hidden" id="order_weight" value="' . $Poids . '">
                 <input type="hidden" id="order_amount" value="' . $Total . '">
-                <input type="hidden" id="articles_num" value="' . $Articles . '">
+                <input type="hidden" id="article_count" value="' . $Articles . '">
 
                 <table class="table">
                     <thead>

--- a/controllers/common/php/post_edit.php
+++ b/controllers/common/php/post_edit.php
@@ -144,7 +144,7 @@ return function (
 
     $postIllustrationUpload = '
         <label for="post_illustration">Image :</label>
-        <input type="file" id="post_illustration_upload" name="post_illustration_upload" accept="image/jpeg" />
+        <input type="file" id="post_illustration_upload" name="post_illustration_upload" accept="image/jpeg, image/png, image/webp" />
     ';
 
     if ($postEntity) {

--- a/controllers/common/php/publisher_edit.php
+++ b/controllers/common/php/publisher_edit.php
@@ -195,10 +195,10 @@ return function (
 
     // Logo
     if ($imagesService->imageExistsFor($publisher)) {
-        $publisher_logo_upload = '<input type="file" id="publisher_logo_upload" name="publisher_logo_upload" accept="image/png" class="hidden"> <label class="after button" for="publisher_logo_upload">Remplacer</label> <input type="checkbox" id="publisher_logo_delete" name="publisher_logo_delete" value="1" /> <label for="publisher_logo_delete" class="after">Supprimer</label>';
+        $publisher_logo_upload = '<input type="file" id="publisher_logo_upload" name="publisher_logo_upload" accept="image/jpeg, image/png, image/webp" class="hidden"> <label class="after button" for="publisher_logo_upload">Remplacer</label> <input type="checkbox" id="publisher_logo_delete" name="publisher_logo_delete" value="1" /> <label for="publisher_logo_delete" class="after">Supprimer</label>';
         $publisher_logo = '<a href="' . $imagesService->getImageUrlFor($publisher) . '" rel="lightbox"><img height="100" src="' . $imagesService->getImageUrlFor($publisher, height: 100) . '" alt="Logo" class="floatR"></a>';
     } else {
-        $publisher_logo_upload = '<input type="file" id="publisher_logo_upload" accept="image/png" name="publisher_logo_upload">';
+        $publisher_logo_upload = '<input type="file" id="publisher_logo_upload" accept="image/jpeg, image/png, image/webp" name="publisher_logo_upload">';
         $publisher_logo = NULL;
     }
 

--- a/inc/constants.php
+++ b/inc/constants.php
@@ -15,4 +15,4 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-const BIBLYS_VERSION = "3.0.2-dev.1";
+const BIBLYS_VERSION = "3.0.2";

--- a/inc/constants.php
+++ b/inc/constants.php
@@ -16,4 +16,4 @@
  */
 
 
-const BIBLYS_VERSION = "3.0.1";
+const BIBLYS_VERSION = "3.0.2-dev";

--- a/inc/constants.php
+++ b/inc/constants.php
@@ -15,5 +15,4 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-
-const BIBLYS_VERSION = "3.0.2-dev";
+const BIBLYS_VERSION = "3.0.2-dev.1";

--- a/public/api.php
+++ b/public/api.php
@@ -36,7 +36,6 @@ Biblys\Database\Connection::initPropel($config);
 $routes = RouteLoader::load();
 
 $container = include __DIR__."/../src/container.php";
-$container->setParameter("routes", $routes);
 $container->register("listener.error", ErrorListener::class)
     ->setArguments(["ApiBundle\Controller\ErrorController::exception"]);
 $container->getDefinition("dispatcher")

--- a/public/common/js/common.js
+++ b/public/common/js/common.js
@@ -799,7 +799,8 @@ function reloadEvents(scope) {
 
     const orderWeightInput = document.querySelector('#order_weight');
     const orderAmountInput = document.querySelector('#order_amount');
-    const query = `country_id=${countryId}&order_weight=${orderWeightInput.value}&order_amount=${orderAmountInput.value}`;
+    const articleCountInput = document.querySelector('#article_count');
+    const query = `country_id=${countryId}&order_weight=${orderWeightInput.value}&order_amount=${orderAmountInput.value}&article_count=${articleCountInput.value}`;
 
     const response = await fetch(`/api/shipping/search?${query}`);
     const json = await response.json();

--- a/src/ApiBundle/Controller/ShippingController.php
+++ b/src/ApiBundle/Controller/ShippingController.php
@@ -21,6 +21,7 @@ namespace ApiBundle\Controller;
 use Biblys\Service\Config;
 use Biblys\Service\CurrentSite;
 use Biblys\Service\CurrentUser;
+use Biblys\Service\InvalidSiteIdException;
 use Exception;
 use Framework\Controller;
 use Model\CountryQuery;
@@ -131,6 +132,7 @@ class ShippingController extends Controller
 
     /**
      * @route GET /api/shipping/{id}
+     * @throws InvalidSiteIdException
      */
     public function get(Config $config, int $id): JsonResponse
     {
@@ -160,11 +162,13 @@ class ShippingController extends Controller
 
         $orderWeight = $request->query->get("order_weight", 0);
         $orderAmount = $request->query->get("order_amount", 0);
-        $fees = ShippingFeeQuery::getForCountryWeightAndAmount(
+        $articleCount = $request->query->get("article_count", 0);
+        $fees = ShippingFeeQuery::getForCountryAndWeightAndAmountAndArticleCount(
             $currentSite,
             $country,
             $orderWeight,
-            $orderAmount
+            $orderAmount,
+            $articleCount
         );
         $serializedFees = array_values(array_map(function ($fee) {
                 return [
@@ -251,9 +255,7 @@ class ShippingController extends Controller
     }
 
     /**
-     * @param Config $config
-     * @param int $id
-     * @return ShippingFee
+     * @throws InvalidSiteIdException
      */
     private static function _getFeeFromId(Config $config, int $id): ShippingFee
     {

--- a/src/Biblys/Service/Images/ImagesService.php
+++ b/src/Biblys/Service/Images/ImagesService.php
@@ -84,7 +84,6 @@ class ImagesService
         if ($image->exists()) {
             $imageModel = $image->getModel();
             $imageModel->setVersion($imageModel->getVersion() + 1);
-            $this->filesystem->remove($image->getFilePath());
         } else {
             $imageModel = new Image();
             $imageModel->setVersion(1);

--- a/src/Biblys/Test/ModelFactory.php
+++ b/src/Biblys/Test/ModelFactory.php
@@ -431,7 +431,7 @@ class ModelFactory
         int     $maxWeight = 1000,
         int     $minAmount = 0,
         int     $maxAmount = 2000,
-        int     $maxArticles = 10,
+        int     $maxArticles = 10
     ): ShippingFee
     {
         $shippingFee = new ShippingFee();

--- a/src/Model/ShippingFeeQuery.php
+++ b/src/Model/ShippingFeeQuery.php
@@ -41,18 +41,15 @@ class ShippingFeeQuery extends BaseShippingFeeQuery
     }
 
     /**
-     * @param CurrentSite $currentSite
-     * @param Country $country
-     * @param int $weight
-     * @param int $amount
      * @return ShippingFee[]
      * @throws Exception
      */
-    public static function getForCountryWeightAndAmount(
+    public static function getForCountryAndWeightAndAmountAndArticleCount(
         CurrentSite $currentSite,
         Country $country,
         int $weight,
-        int $amount
+        int $amount,
+        int $articleCount
     ): array
     {
         $weightIncludingWrapping = $weight * 1.05;
@@ -64,14 +61,14 @@ class ShippingFeeQuery extends BaseShippingFeeQuery
         $shippingTypes = ['magasin', 'normal', 'suivi', 'mondial-relay'];
 
         $feesForEachTypes = array_map(
-            function ($type) use ($fees, $zone, $weightIncludingWrapping, $amount, $currentSite) {
+            function ($type) use ($fees, $zone, $weightIncludingWrapping, $amount, $currentSite, $articleCount) {
                 foreach ($fees as $fee) {
                     // Keeps only fees for current type
                     if ($fee->getType() !== $type) {
                         continue;
                     }
 
-                    // Keep only shipping without article
+                    // Keep only shipping without an article
                     if ($fee->getArticleId()) {
                         continue;
                     }
@@ -93,6 +90,11 @@ class ShippingFeeQuery extends BaseShippingFeeQuery
 
                     // Keep only fees for which order's amount is lesser than max amount
                     if ($fee->getMaxAmount() !== null && $amount > $fee->getMaxAmount()) {
+                        continue;
+                    }
+
+                    // Keep only fees for which order's article count is lesser than max articles
+                    if ($fee->getMaxArticles() !== null && $articleCount > $fee->getMaxArticles()) {
                         continue;
                     }
 

--- a/tests/ApiBundle/Controller/ShippingControllerTest.php
+++ b/tests/ApiBundle/Controller/ShippingControllerTest.php
@@ -335,7 +335,8 @@ class ShippingControllerTest extends TestCase
             info: "Expedition sous 72h",
             fee: 560,
             maxWeight: 2000,
-            maxAmount: 10000
+            maxAmount: 10000,
+            maxArticles: 5,
         );
         $country = ModelFactory::createCountry();
         $controller = new ShippingController();
@@ -343,6 +344,7 @@ class ShippingControllerTest extends TestCase
         $request->query->set("country_id", $country->getId());
         $request->query->set("order_weight", "500");
         $request->query->set("order_amount", "2000");
+        $request->query->set("article_count", "2");
         $currentSite = new CurrentSite($site);
 
         // when

--- a/tests/Biblys/Service/Images/ImagesServiceTest.php
+++ b/tests/Biblys/Service/Images/ImagesServiceTest.php
@@ -147,7 +147,6 @@ class ImagesServiceTest extends TestCase
         $this->assertEquals(4410, $updatedImage->getFilesize());
         $this->assertEquals(100, $updatedImage->getWidth());
         $this->assertEquals(150, $updatedImage->getHeight());
-        $filesystem->shouldHaveReceived("remove");
         $filesystem->shouldHaveReceived("copy");
     }
 
@@ -452,7 +451,6 @@ class ImagesServiceTest extends TestCase
         $this->assertEquals(4410, $updatedImage->getFilesize());
         $this->assertEquals(100, $updatedImage->getWidth());
         $this->assertEquals(150, $updatedImage->getHeight());
-        $filesystem->shouldHaveReceived("remove");
         $filesystem->shouldHaveReceived("copy");
     }
 
@@ -677,7 +675,6 @@ class ImagesServiceTest extends TestCase
         $this->assertEquals(4410, $updatedImage->getFilesize());
         $this->assertEquals(100, $updatedImage->getWidth());
         $this->assertEquals(150, $updatedImage->getHeight());
-        $filesystem->shouldHaveReceived("remove");
         $filesystem->shouldHaveReceived("copy");
     }
 
@@ -902,7 +899,6 @@ class ImagesServiceTest extends TestCase
         $this->assertEquals(4410, $updatedImage->getFilesize());
         $this->assertEquals(100, $updatedImage->getWidth());
         $this->assertEquals(150, $updatedImage->getHeight());
-        $filesystem->shouldHaveReceived("remove");
         $filesystem->shouldHaveReceived("copy");
     }
 
@@ -1128,7 +1124,6 @@ class ImagesServiceTest extends TestCase
         $this->assertEquals(4410, $updatedImage->getFilesize());
         $this->assertEquals(100, $updatedImage->getWidth());
         $this->assertEquals(150, $updatedImage->getHeight());
-        $filesystem->shouldHaveReceived("remove");
         $filesystem->shouldHaveReceived("copy");
     }
 
@@ -1353,7 +1348,6 @@ class ImagesServiceTest extends TestCase
         $this->assertEquals(4410, $updatedImage->getFilesize());
         $this->assertEquals(100, $updatedImage->getWidth());
         $this->assertEquals(150, $updatedImage->getHeight());
-        $filesystem->shouldHaveReceived("remove");
         $filesystem->shouldHaveReceived("copy");
     }
 

--- a/tests/Model/ShippingFeeQueryTest.php
+++ b/tests/Model/ShippingFeeQueryTest.php
@@ -33,7 +33,7 @@ class ShippingFeeQueryTest extends TestCase
      * @throws PropelException
      * @throws Exception
      */
-    public function testGetForCountryAmountAndWeight()
+    public function testGetForCountryAndAmountAndWeightAndArticleCount()
     {
         // given
         $site = ModelFactory::createSite();
@@ -47,17 +47,58 @@ class ShippingFeeQueryTest extends TestCase
         $currentSite = new CurrentSite($site);
 
         // when
-        list(, $feeNormal) = ShippingFeeQuery::getForCountryWeightAndAmount(
+        list(, $feeNormal) = ShippingFeeQuery::getForCountryAndWeightAndAmountAndArticleCount(
             $currentSite,
             $country,
             $orderWeight,
-            $orderAmount
+            $orderAmount,
+            articleCount: 1
         );
 
         // then
         $this->assertEquals(
             $feeNormal,
             $fee
+        );
+    }
+
+    /**
+     * Test getting fees
+     * @throws PropelException
+     * @throws Exception
+     */
+    public function testGetForWithArticleCountConstraint()
+    {
+        // given
+        $site = ModelFactory::createSite();
+        $country = ModelFactory::createCountry();
+        ModelFactory::createShippingFee(
+            site: $site,
+            country: $country,
+            maxArticles: 1
+        );
+        $feeForTwoArticles = ModelFactory::createShippingFee(
+            site: $site,
+            country: $country,
+            maxArticles: 2
+        );
+        $orderWeight = 500;
+        $orderAmount = 1500;
+        $currentSite = new CurrentSite($site);
+
+        // when
+        list(, $returnedFee) = ShippingFeeQuery::getForCountryAndWeightAndAmountAndArticleCount(
+            $currentSite,
+            $country,
+            $orderWeight,
+            $orderAmount,
+            articleCount: 2
+        );
+
+        // then
+        $this->assertEquals(
+            $returnedFee,
+            $feeForTwoArticles
         );
     }
 }


### PR DESCRIPTION
## Corrections

- Le choix d'un mode d'expédition pouvait échouer sans erreur. C'est corrigé.
- Les champs d'ajout d'image n'autorisaient que certains formats. Ils autorisent désormais tous JPEG, PNG ou WebP.
- La contrainte du nombre d'articles dans une commande pour une tarifaire de frais de port n'était pas prise en compte. C'est maintenant le cas.