### PR TITLE
Gérer les numéros de suivi Mondial Relay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Historique des modifications
 
+### 3.1.0 (dev)
+
+Améliorations
+
+- Lors d'une expédition avec Mondial Relay, le lien de suivi est désormais
+  affiché sur la page de la commande et inclus dans le courriel de confirmation
+  d'expédition.
+
 ## 3.0.2 (13 novembre 2024)
 
 Corrections

--- a/assets/js/orders/order.js
+++ b/assets/js/orders/order.js
@@ -153,8 +153,10 @@ export default class Order {
         icon.attr('class', 'fa fa-spinner fa-spin');
 
         // Ask for tracking number
-        if (self.data.shipping_mode == 'suivi' && action == 'shipped') {
-          tracking_number = prompt('Numéro de suivi ?');
+        const shippingModeUsesTracking = self.data.shipping_mode === 'suivi' || self.data.shipping_mode === 'mondial-relay';
+        debugger;
+        if (shippingModeUsesTracking && action === 'shipped') {
+          tracking_number = window.prompt('Numéro de suivi ?');
           if (tracking_number === null) {
             new Notification(
               'La commande n\'a pas été marquée comme expédiée.', { type: 'warning' });

--- a/controllers/common/php/order.php
+++ b/controllers/common/php/order.php
@@ -15,8 +15,8 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-/** @noinspection PhpUnhandledExceptionInspection */
 /** @noinspection CommaExpressionJS */
+/** @noinspection DuplicatedCode */
 /** @noinspection BadExpressionStatementJS */
 
 use Biblys\Legacy\LegacyCodeHelper;
@@ -26,322 +26,319 @@ use Biblys\Service\CurrentUser;
 use Biblys\Service\Images\ImagesService;
 use DansMaCulotte\MondialRelay\DeliveryChoice;
 use Model\StockQuery;
-use Symfony\Component\Filesystem\Filesystem;
+use Propel\Runtime\Exception\PropelException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
 use Symfony\Component\Routing\Exception\ResourceNotFoundException as NotFoundException;
-
-$om = new OrderManager();
-$am = new ArticleManager();
-
-$config = Config::load();
-$request = Request::createFromGlobals();
-$currentSiteService = CurrentSite::buildFromConfig($config);
-$currentUserService = CurrentUser::buildFromRequestAndConfig($request, $config);
-$imagesService = new ImagesService($config, $currentSiteService, new Filesystem());
-
-$orderUrl = LegacyCodeHelper::getRouteParam("url");
-$order = $om->get(["order_url" => $orderUrl]);
+use Symfony\Component\Routing\Generator\UrlGenerator;
 
 
-if (!$order) {
-    throw new NotFoundException("Order $orderUrl not found.");
-}
+/**
+ * @throws InvalidDateFormatException
+ * @throws PropelException
+ */
+return function (
+    CurrentUser   $currentUserService,
+    Request       $request,
+    Config        $config,
+    CurrentSite   $currentSiteService,
+    ImagesService $imagesService,
+    UrlGenerator  $urlGenerator
+): Response {
+    $om = new OrderManager();
 
-$o = $order;
-$content = '';
+    $orderUrl = LegacyCodeHelper::getRouteParam("url");
+    $orderEntity = $om->get(["order_url" => $orderUrl]);
 
-if (_isAnonymousOrder($order) || _orderBelongsToVisitor($order, $currentUserService) || $currentUserService->isAdmin()) {
+    if (!$orderEntity) {
+        throw new NotFoundException("Order $orderUrl not found.");
+    }
 
-    $buttons = NULL;
+    $o = $orderEntity;
+    $content = '';
 
-    $request->attributes->set("page_title", "Commande n° {$o["order_id"]}");
+    if (_isAnonymousOrder($orderEntity) || _orderBelongsToVisitor($orderEntity, $currentUserService) || $currentUserService->isAdmin()) {
 
-    $content .= '<h2>Commande n° ' . $o["order_id"] . '</h2>';
+        $buttons = NULL;
 
-    if ($currentUserService->isAdmin()) {
+        $request->attributes->set("page_title", "Commande n° {$o["order_id"]}");
+
+        $content .= '<h2>Commande n° ' . $o["order_id"] . '</h2>';
+
+        if ($currentUserService->isAdmin()) {
+            $content .= '
+                <div class="admin">
+                    <p>Commande n° ' . $o["order_id"] . '</p>
+                    <p><a href="/pages/adm_order?order_id=' . $o["order_id"] . '">modifier</a></p>
+                    <p><a href="/invoice/' . $o["order_url"] . '">facture</a></p>
+                </div>
+            ';
+        }
+
         $content .= '
-            <div class="admin">
-                <p>Commande n° ' . $o["order_id"] . '</p>
-                <p><a href="/pages/adm_order?order_id=' . $o["order_id"] . '">modifier</a></p>
-                <p><a href="/invoice/' . $o["order_url"] . '">facture</a></p>
+            <div class="floatR">
+                <h4 class="text-right">État de la commande</h4>
+                <p class="right">Validée le ' . _date($o["order_insert"], 'j f Y') . '</p>
+        ';
+
+        if ($o["order_followup_date"]) {
+            $content .= '<p class="right">Relancée le ' . _date($o["order_followup_date"], 'j f Y') . '</p>';
+        }
+        if ($o["order_payment_date"]) {
+            $content .= '<p class="right">Payée le ' . _date($o["order_payment_date"], 'j f Y') . '</p>';
+        }
+        if ($orderEntity->has('shipping_date')) {
+            if ($orderEntity->get('shipping_mode') == 'magasin') {
+                $content .= '<p class="right">Mise à dispo. en magasin le ' . _date($o["order_shipping_date"], 'j f Y') . '</p>';
+            } else {
+                $content .= '<p class="right">Expédiée le ' . _date($o["order_shipping_date"], 'j f Y') . '</p>';
+            }
+        }
+        if ($o["order_cancel_date"]) {
+            $content .= '<p class="right">Annulée le ' . _date($o["order_cancel_date"], 'j f Y') . '</p>';
+        }
+
+        $content .= '
             </div>
         ';
-    }
 
-    $content .= '
-        <div class="floatR">
-            <h4 class="text-right">État de la commande</h4>
-            <p class="right">Validée le ' . _date($o["order_insert"], 'j f Y') . '</p>
-    ';
-
-    if ($o["order_followup_date"]) {
-        $content .= '<p class="right">Relancée le ' . _date($o["order_followup_date"], 'j f Y') . '</p>';
-    }
-    if ($o["order_payment_date"]) {
-        $content .= '<p class="right">Payée le ' . _date($o["order_payment_date"], 'j f Y') . '</p>';
-    }
-    if ($order->has('shipping_date')) {
-        if ($order->get('shipping_mode') == 'magasin') {
-            $content .= '<p class="right">Mise à dispo. en magasin le ' . _date($o["order_shipping_date"], 'j f Y') . '</p>';
-        } else {
-            $content .= '<p class="right">Expédiée le ' . _date($o["order_shipping_date"], 'j f Y') . '</p>';
+        $country = $orderEntity->get('country');
+        if ($country instanceof Country) {
+            $country = $country->get('name');
         }
-    }
-    if ($o["order_cancel_date"]) {
-        $content .= '<p class="right">Annulée le ' . _date($o["order_cancel_date"], 'j f Y') . '</p>';
-    }
 
-    $content .= '
-        </div>
-    ';
+        if (!empty($o["order_address2"])) $o["order_address2"] = $o["order_address2"] . '<br />';
 
-    $country = $order->get('country');
-    if ($country instanceof Country) {
-        $country = $country->get('name');
-    }
-
-    if (!empty($o["order_address2"])) $o["order_address2"] = $o["order_address2"] . '<br />';
-
-    if ($order->get("shipping_mode") === "normal" || $order->get("shipping_mode") === "suivi") {
-        $content .= '
-            <h4>Adresse de livraison</h4>
-            <p>
-                ' . $o["order_firstname"] . ' ' . $o["order_lastname"] . '<br />
-                ' . $o["order_address1"] . '<br />
-                ' . $o["order_address2"] . '
-                ' . $o["order_postalcode"] . ' ' . $o["order_city"] . '<br />
-                ' . $country . '
-            </p>
-        ';
-    } elseif ($order->get("shipping_mode") === "retrait") {
-        $content .= '<p>Retrait en magasin</p>';
-    } elseif ($order->get("shipping_mode") === "mondial-relay") {
-        if ($config->isMondialRelayEnabled()) {
-        $content .= '<p></p>';
-
-            $delivery = new DeliveryChoice([
-                "site_id" => $config->get("mondial_relay.code_enseigne"),
-                "site_key" => $config->get("mondial_relay.private_key"),
-            ]);
-            $pickupPoint = $delivery->findPickupPointByCode(
-                country: 'FR',
-                code: $order->get("mondial_relay_pickup_point_code")
-            );
+        if ($orderEntity->get("shipping_mode") === "normal" || $orderEntity->get("shipping_mode") === "suivi") {
             $content .= '
                 <h4>Adresse de livraison</h4>
-                <p>            
+                <p>
                     ' . $o["order_firstname"] . ' ' . $o["order_lastname"] . '<br />
-                    Point Mondial Relay n° '.$order->get("mondial_relay_pickup_point_code").'<br>
-                    <strong>'.$pickupPoint->name.'</strong><br />
-                    '.$pickupPoint->address.'<br />
-                    '.$pickupPoint->postalCode.' '.$pickupPoint->city.'
+                    ' . $o["order_address1"] . '<br />
+                    ' . $o["order_address2"] . '
+                    ' . $o["order_postalcode"] . ' ' . $o["order_city"] . '<br />
+                    ' . $country . '
+                </p>
+            ';
+        } elseif ($orderEntity->get("shipping_mode") === "retrait") {
+            $content .= '<p>Retrait en magasin</p>';
+        } elseif ($orderEntity->get("shipping_mode") === "mondial-relay") {
+            if ($config->isMondialRelayEnabled()) {
+                $content .= '<p></p>';
+
+                $delivery = new DeliveryChoice([
+                    "site_id" => $config->get("mondial_relay.code_enseigne"),
+                    "site_key" => $config->get("mondial_relay.private_key"),
+                ]);
+                $pickupPoint = $delivery->findPickupPointByCode(
+                    country: 'FR',
+                    code: $orderEntity->get("mondial_relay_pickup_point_code")
+                );
+                $content .= '
+                    <h4>Adresse de livraison</h4>
+                    <p>            
+                        ' . $o["order_firstname"] . ' ' . $o["order_lastname"] . '<br />
+                        Point Mondial Relay n° ' . $orderEntity->get("mondial_relay_pickup_point_code") . '<br>
+                        <strong>' . $pickupPoint->name . '</strong><br />
+                        ' . $pickupPoint->address . '<br />
+                        ' . $pickupPoint->postalCode . ' ' . $pickupPoint->city . '
+                    </p>
+                ';
+            }
+
+            $content .= '
+                <h4>Adresse de facturation</h4>
+                <p>
+                    ' . $o["order_firstname"] . ' ' . $o["order_lastname"] . '<br />
+                    ' . $o["order_address1"] . '<br />
+                    ' . $o["order_address2"] . '
+                    ' . $o["order_postalcode"] . ' ' . $o["order_city"] . '<br />
+                    ' . $country . '
                 </p>
             ';
         }
 
-        $content .= '
-            <h4>Adresse de facturation</h4>
-            <p>
-                ' . $o["order_firstname"] . ' ' . $o["order_lastname"] . '<br />
-                ' . $o["order_address1"] . '<br />
-                ' . $o["order_address2"] . '
-                ' . $o["order_postalcode"] . ' ' . $o["order_city"] . '<br />
-                ' . $country . '
-            </p>
-        ';
-    }
+        $content .= '<p><a href="mailto:' . $o["order_email"] . '">' . $o["order_email"] . '</a></p>';
 
-    $content .= '<p><a href="mailto:' . $o["order_email"] . '">' . $o["order_email"] . '</a></p>';
+        if ($orderEntity->has("phone")) {
+            $content .= '<p>Tel: ' . $orderEntity->get("phone") . '</p>';
+        }
 
-    if ($order->has("phone")) {
-        $content .= '<p>Tel: ' . $order->get("phone") . '</p>';
-    }
-
-    if ($order->has('comment') && $currentUserService->isAdmin()) {
-        $content .= '
-        <h4>Commentaire du client</h4>
-        <p>' . nl2br($order->get('comment')) . '</p>
-        ';
-    }
-
-    $content .= '<br /><div class="center">';
-
-    // Creation de la commande
-    if (isset($_GET["created"])) {
-        $content .= '<br /><p class="success">Votre commande a bien été enregistrée sous le numéro ' . $o["order_id"] . '.</p><p class="center">Vous pouvez la régler en utilisant le bouton ci-dessous.</p><br />';
-    }
-
-    // MAJ de la commande
-    if (isset($_GET["updated"])) $content .= '<p class="success">La commande a été mise à jour.</p><br />';
-
-    // Paiement de la commande
-    if (isset($_GET["payed"])) $content .= '<p class="success">La commande a été payée.</p><br />';
-
-    // Paiement
-    if (!$o["order_payment_date"]) $buttons .= '<a href="/payment/' . $o["order_url"] . '" class="btn btn-primary"><i class="fa fa-money"></i>&nbsp; Payer la commande (' . currency($o["order_amount_tobepaid"] / 100) . ')</a> ';
-    else $buttons .= '<a href="/invoice/' . $o["order_url"] . '" class="btn btn-default"><i class="fa fa-print"></i> Imprimer une facture</a> ';
-
-    $currentSite = $currentSiteService->getSite();
-    if ($o["order_shipping_date"]) {
-        if ($o["order_track_number"]) {
+        if ($orderEntity->has('comment') && $currentUserService->isAdmin()) {
             $content .= '
-                <p class="center">
-                    Numéro de suivi : 
-                    <a href="https://www.laposte.fr/outils/suivre-vos-envois?code='.$o["order_track_number"].'">
-                        '.$o["order_track_number"].'
-                    </a>
-                </p><br />
+                <h4>Commentaire du client</h4>
+                <p>' . nl2br($orderEntity->get('comment')) . '</p>
             ';
         }
-    }
 
-    $content .= $buttons;
+        $content .= '<br /><div class="center">';
 
-    $content .= '<br /></div>';
-
-    $copies = $order->getCopies();
-
-    $i = 0;
-    $numerique = 0;
-    $total_tva = 0;
-    $total_ht = 0;
-    $o['order_weight'] = 0;
-    $ArticlesCount = 0;
-    $books = NULL;
-    foreach ($copies as $copy) {
-        $article = $copy->getArticle() ?: ArticleManager::buildUnknownArticle();
-        $stockItem = StockQuery::create()->findPk($copy->get('id'));
-        $articleModel = $stockItem->getArticle();
-        $a = $article;
-        $i++;
-
-        // Image
-        $cover = null;
-        $stockItemPhotoUrl = $imagesService->getImageUrlFor($stockItem, height: 60);
-        $articleCoverUrl = $imagesService->getImageUrlFor($articleModel, height: 60);
-        if ($stockItemPhotoUrl) {
-            $cover = '<img src="' . $stockItemPhotoUrl . '" alt="' . $articleModel->getTitle() . '" height="60" />';
-        } elseif ($articleCoverUrl) {
-            $cover = '<img src="' . $articleCoverUrl . '" alt="' . $articleModel->getTitle() . '" /></a>';
+        // Creation de la commande
+        if (isset($_GET["created"])) {
+            $content .= '<br /><p class="success">Votre commande a bien été enregistrée sous le numéro ' . $o["order_id"] . '.</p><p class="center">Vous pouvez la régler en utilisant le bouton ci-dessous.</p><br />';
         }
 
-        // Precommande
-        if ($a["article_pubdate"] > $o["order_insert"]) $a["article_title"] .= ' (précommande)';
+        // MAJ de la commande
+        if (isset($_GET["updated"])) $content .= '<p class="success">La commande a été mise à jour.</p><br />';
 
-        // Livres numeriques
-        $a['dl_links'] = NULL;
-        if ($a["type_id"] == 2) {
-            $a["article_title"] .= ' (numérique)';
-            $numerique++;
-        }
+        // Paiement de la commande
+        if (isset($_GET["payed"])) $content .= '<p class="success">La commande a été payée.</p><br />';
 
-        // Downloadable files
-        if ($order->isPayed() && $article->getType()->isDownloadable()) {
-            if ($article->isPublished()) {
-                $fm = new FileManager();
-                $files = $fm->getAll(['article_id' => $a['article_id'], 'file_access' => 1]);
-                if ($files) {
-                    foreach ($files as $f) {
-                        $a['dl_links'] .= ' <a href="' . $f->getUrl() . '" title="' . $f->get('version') . ' | ' . file_size($f->get('size')) . ' | ' . $f->getType('name') . '"><img src="' . $f->getType('icon') . '" width=16 alt="Télécharger"> ' . $f->get('title') . '</a> &nbsp;';
-                    }
-                    $a['dl_links'] = '<div class="btn btn-default"><i class="fa fa-cloud-download"></i> &nbsp; ' . $a['dl_links'] . '</a>';
-                }
-            } else {
-                $a['dl_links'] = '<p class="alert alert-info">Téléchargement possible à partir du ' . _date($article->get('pubdate'), 'd/m') . '.</p>';
+        // Paiement
+        if (!$o["order_payment_date"]) $buttons .= '<a href="/payment/' . $o["order_url"] . '" class="btn btn-primary"><i class="fa fa-money"></i>&nbsp; Payer la commande (' . currency($o["order_amount_tobepaid"] / 100) . ')</a> ';
+        else $buttons .= '<a href="/invoice/' . $o["order_url"] . '" class="btn btn-default"><i class="fa fa-print"></i> Imprimer une facture</a> ';
+
+        $currentSite = $currentSiteService->getSite();
+        if ($o["order_shipping_date"]) {
+            if ($o["order_track_number"]) {
+                $content .= '
+                    <p class="center">
+                        Numéro de suivi : 
+                        <a href="https://www.laposte.fr/outils/suivre-vos-envois?code=' . $o["order_track_number"] . '">
+                            ' . $o["order_track_number"] . '
+                        </a>
+                    </p><br />
+                ';
             }
         }
 
-        // TVA
-        $total_ht += $a['stock_selling_price_ht'];
-        $total_tva += $a['stock_selling_price_tva'];
+        $content .= $buttons;
 
-        $copyId = $copy->get('id');
-        if ($currentUserService->isAdmin()) {
-            $copyId = '<a href="/pages/adm_stock?id=' . $copyId . '">' . $copyId . '</a>';
-        }
+        $content .= '<br /></div>';
 
-        $books .= '
-            <tr>
-                <td class="center">' . $copyId . '</td>
-                <td class="center">' . $cover . '</td>
-                <td>
-                    <strong><a href="/a/' . $a["article_url"] . '">' . $article->get("title") . '</a><br /></strong>
-                    <em>de ' . $a["article_authors"] . '</em><br />
-                    coll. ' . $a["article_collection"] . ' ' . numero($a["article_number"]) . '<br />
-                    ' . $a["dl_links"] . '
-        ';
-        if (!empty($a["stock_condition"])) $books .= 'état : ' . $a["stock_condition"] . '<br />';
-        if (!empty($a["stock_weight"]) && !empty($_GET["weight"])) $books .= $a["stock_weight"] . 'g<br />';
-        $books .= '
+        $copies = $orderEntity->getCopies();
+
+        $total_tva = 0;
+        $total_ht = 0;
+        $o['order_weight'] = 0;
+        $ArticlesCount = 0;
+        $books = NULL;
+        foreach ($copies as $copy) {
+            $article = $copy->getArticle() ?: ArticleManager::buildUnknownArticle();
+            $stockItem = StockQuery::create()->findPk($copy->get('id'));
+            $articleModel = $stockItem->getArticle();
+            $a = $article;
+
+            // Image
+            $cover = null;
+            $stockItemPhotoUrl = $imagesService->getImageUrlFor($stockItem, height: 60);
+            $articleCoverUrl = $imagesService->getImageUrlFor($articleModel, height: 60);
+            if ($stockItemPhotoUrl) {
+                $cover = '<img src="' . $stockItemPhotoUrl . '" alt="' . $articleModel->getTitle() . '" height="60" />';
+            } elseif ($articleCoverUrl) {
+                $cover = '<img src="' . $articleCoverUrl . '" alt="' . $articleModel->getTitle() . '" /></a>';
+            }
+
+            if ($a["article_pubdate"] > $o["order_insert"]) $a["article_title"] .= ' (précommande)';
+
+            $a['dl_links'] = NULL;
+
+            // Downloadable files
+            if ($orderEntity->isPayed() && $article->getType()->isDownloadable()) {
+                if ($article->isPublished()) {
+                    $fm = new FileManager();
+                    $files = $fm->getAll(['article_id' => $a['article_id'], 'file_access' => 1]);
+                    if ($files) {
+                        foreach ($files as $f) {
+                            $a['dl_links'] .= ' <a href="' . $f->getUrl() . '" title="' . $f->get('version') . ' | ' . file_size($f->get('size')) . ' | ' . $f->getType('name') . '"><img src="' . $f->getType('icon') . '" width=16 alt="Télécharger"> ' . $f->get('title') . '</a> &nbsp;';
+                        }
+                        $a['dl_links'] = '<div class="btn btn-default"><i class="fa fa-cloud-download"></i> &nbsp; ' . $a['dl_links'] . '</a>';
+                    }
+                } else {
+                    $a['dl_links'] = '<p class="alert alert-info">Téléchargement possible à partir du ' . _date($article->get('pubdate'), 'd/m') . '.</p>';
+                }
+            }
+
+            // TVA
+            $total_ht += $a['stock_selling_price_ht'];
+            $total_tva += $a['stock_selling_price_tva'];
+
+            $copyId = $copy->get('id');
+            if ($currentUserService->isAdmin()) {
+                $copyId = '<a href="/pages/adm_stock?id=' . $copyId . '">' . $copyId . '</a>';
+            }
+
+            $books .= '
+                <tr>
+                    <td class="center">' . $copyId . '</td>
+                    <td class="center">' . $cover . '</td>
+                    <td>
+                        <strong><a href="/a/' . $a["article_url"] . '">' . $article->get("title") . '</a><br /></strong>
+                        <em>de ' . $a["article_authors"] . '</em><br />
+                        coll. ' . $a["article_collection"] . ' ' . numero($a["article_number"]) . '<br />
+                        ' . $a["dl_links"] . '
+            ';
+            if (!empty($a["stock_condition"])) $books .= 'État : ' . $a["stock_condition"] . '<br />';
+            if (!empty($a["stock_weight"]) && !empty($_GET["weight"])) $books .= $a["stock_weight"] . 'g<br />';
+            $books .= '
                 </td>
                 <td class="right">
                     ' . currency($copy->get('selling_price') / 100) . '<br />
                 </td>
             </tr>
         ';
-        $o["order_weight"] += $a["stock_weight"];
+            $o["order_weight"] += $a["stock_weight"];
 
-        $ArticlesCount++;
-    }
+            $ArticlesCount++;
+        }
 
-    $content .= '
-        <br />
-        <table class="table cart list order">
-            <thead>
+        $content .= '
+            <br />
+            <table class="table cart list order">
+                <thead>
+                    <tr>
+                        <th>Ref.</th>
+                        <th colspan="2">Articles</th>
+                        <th>Prix</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    ' . $books . '
+                </tbody>
+                <tfoot>
                 <tr>
-                    <th>Ref.</th>
-                    <th colspan="2">Articles</th>
-                    <th>Prix</th>
+                    <th colspan="3" class="right">Articles :</th>
+                    <th class="right">' . $ArticlesCount . '</th>
                 </tr>
-            </thead>
-            <tbody>
-                ' . $books . '
-            </tbody>
-            <tfoot>
-            <tr>
-                <th colspan="3" class="right">Articles :</th>
-                <th class="right">' . $ArticlesCount . '</th>
-            </tr>
-    ';
-
-    if (isset($o["order_weight"]) && $currentSite->getShippingFee()) {
-        $content .= '
-                    <tr>
-                        <th colspan="3" class="right">Poids :</th>
-                        <th class="right">' . round($o["order_weight"] / 1000, 2) . '&nbsp;kg</th>
-                    </tr>
-                    <tr>
-                        <th colspan="3" class="right">Frais de port (' . $o["order_shipping_mode"] . ') :</th>
-                        <th class="right">' . currency($o["order_shipping"] / 100) . '</th>
-                    </tr>
         ';
-    } elseif ($o["order_shipping"]) {
-        $content .= '
+
+        if (isset($o["order_weight"]) && $currentSite->getShippingFee()) {
+            $content .= '
+                <tr>
+                    <th colspan="3" class="right">Poids :</th>
+                    <th class="right">' . round($o["order_weight"] / 1000, 2) . '&nbsp;kg</th>
+                </tr>
+                <tr>
+                    <th colspan="3" class="right">Frais de port (' . $o["order_shipping_mode"] . ') :</th>
+                    <th class="right">' . currency($o["order_shipping"] / 100) . '</th>
+                </tr>
+            ';
+        } elseif ($o["order_shipping"]) {
+            $content .= '
                 <tr>
                     <th colspan="3" class="right">Frais de port :</th>
                     <th class="right">' . currency($o["order_shipping"] / 100) . '</th>
                 </tr>
         ';
-    }
+        }
 
-    if ($total_tva) {
+        if ($total_tva) {
+            $content .= '
+                <tr>
+                    <th colspan="3" class="right">Total H.T. :</th>
+                    <th class="right">' . currency($total_ht / 100) . '</th>
+                </tr>
+                <tr>
+                    <th colspan="3" class="right">T.V.A. :</th>
+                    <th class="right">' . currency($total_tva / 100) . '</th>
+                </tr>
+            ';
+        }
+
+        $contactPageUrl = $urlGenerator->generate("main_contact");
         $content .= '
-                    <tr>
-                        <th colspan="3" class="right">Total H.T. :</th>
-                        <th class="right">' . currency($total_ht / 100) . '</th>
-                    </tr>
-                    <tr>
-                        <th colspan="3" class="right">T.V.A. :</th>
-                        <th class="right">' . currency($total_tva / 100) . '</th>
-                    </tr>
-        ';
-    }
-
-    $contactPageUrl = \Biblys\Legacy\LegacyCodeHelper::getGlobalUrlGenerator()->generate("main_contact");
-    $content .= '
                 <tr>
                     <th colspan="3" class="right">Total T.T.C.&nbsp;:</th>
                     <th class="right">' . currency(($o["order_amount"] + $o["order_shipping"]) / 100) . '</th>
@@ -352,18 +349,19 @@ if (_isAnonymousOrder($order) || _orderBelongsToVisitor($order, $currentUserServ
         <p class="text-center">
             <strong>
                 Un problème avez votre commande ? 
-                <a href="'.$contactPageUrl.'" class="btn btn-info">Contactez-nous</a>
+                <a href="' . $contactPageUrl . '" class="btn btn-info">Contactez-nous</a>
             </strong>
         </p>
-    ';
+      ';
 
-} elseif (!$currentUserService->isAuthentified()) {
-    throw new UnauthorizedHttpException("", "Vous n'avez pas le droit d'accéder à cette page.");
-} else {
-    throw new AccessDeniedHttpException("Vous n'avez pas le droit d'accéder à cette page.");
-}
+    } elseif (!$currentUserService->isAuthentified()) {
+        throw new UnauthorizedHttpException("", "Vous n'avez pas le droit d'accéder à cette page.");
+    } else {
+        throw new AccessDeniedHttpException("Vous n'avez pas le droit d'accéder à cette page.");
+    }
 
-return new Response($content);
+    return new Response($content);
+};
 
 function _isAnonymousOrder(Order $order): bool
 {

--- a/controllers/common/php/order.php
+++ b/controllers/common/php/order.php
@@ -25,6 +25,7 @@ use Biblys\Service\CurrentSite;
 use Biblys\Service\CurrentUser;
 use Biblys\Service\Images\ImagesService;
 use DansMaCulotte\MondialRelay\DeliveryChoice;
+use Model\OrderQuery;
 use Model\StockQuery;
 use Propel\Runtime\Exception\PropelException;
 use Symfony\Component\HttpFoundation\Request;
@@ -55,6 +56,8 @@ return function (
     if (!$orderEntity) {
         throw new NotFoundException("Order $orderUrl not found.");
     }
+
+    $order = OrderQuery::create()->findPk($orderEntity->get('id'));
 
     $o = $orderEntity;
     $content = '';
@@ -191,17 +194,16 @@ return function (
         else $buttons .= '<a href="/invoice/' . $o["order_url"] . '" class="btn btn-default"><i class="fa fa-print"></i> Imprimer une facture</a> ';
 
         $currentSite = $currentSiteService->getSite();
-        if ($o["order_shipping_date"]) {
-            if ($o["order_track_number"]) {
-                $content .= '
-                    <p class="center">
-                        Numéro de suivi : 
-                        <a href="https://www.laposte.fr/outils/suivre-vos-envois?code=' . $o["order_track_number"] . '">
-                            ' . $o["order_track_number"] . '
-                        </a>
-                    </p><br />
-                ';
-            }
+        $trackingLink = $order->getTrackingLink();
+        if ($trackingLink) {
+            $content .= '
+                <p class="text-center">
+                    Numéro de suivi : ' . $o["order_track_number"] . '
+                    <a href="'.$trackingLink.'" class="btn btn-primary">
+                      Suivre l’envoi
+                    </a>
+                </p><br />
+            ';
         }
 
         $content .= $buttons;

--- a/inc/Order.class.php
+++ b/inc/Order.class.php
@@ -16,6 +16,8 @@
  */
 
 
+use Biblys\Data\ArticleType;
+use Biblys\Exception\InvalidEmailAddressException;
 use Biblys\Legacy\LegacyCodeHelper;
 use Biblys\Service\Config;
 use Biblys\Service\CurrentSite;
@@ -970,10 +972,10 @@ class OrderManager extends EntityManager
 
     /**
      * Mark the order as shipped and warn customer by mail
-     * @param  Order  $order           the order to mark
-     * @param  String $trackingNumber a tracking number
+     * @throws TransportExceptionInterface
+     * @throws InvalidEmailAddressException
      */
-    public function markAsShipped(Order $order, $trackingNumber = null)
+    public function markAsShipped(Order $order, $trackingLink = null): void
     {
         $globalSite = LegacyCodeHelper::getGlobalSite();
 
@@ -982,8 +984,8 @@ class OrderManager extends EntityManager
         // Save shipping date
         $order->set('order_shipping_date', date('Y-m-d H:i:s'));
 
-        if ($trackingNumber) {
-            $order->set('order_track_number', $trackingNumber);
+        if ($trackingLink) {
+            $order->set("order_track_number", $order->get("track_number"));
         }
 
         $message = null;
@@ -1010,12 +1012,11 @@ class OrderManager extends EntityManager
             }
 
             $message .= '<p>'.$shippedMessage.'</p>';
-            if ($trackingNumber) {
+            if ($trackingLink) {
                 $message .= '
-                    <p>N° de suivi : '.$trackingNumber.'</p>
                     <p>
-                        Vous pouvez suivre l\'envoi de votre colis sur le site de La Poste :<br>
-                        http://www.coliposte.net/particulier/suivi_particulier.jsp?colispart='.$trackingNumber.'
+                        Pour suivre l’envoi, rendez-vous sur :<br />
+                        <a href="'.$trackingLink.'">'.$trackingLink.'</a>
                     </p>
                 ';
             }

--- a/inc/constants.php
+++ b/inc/constants.php
@@ -15,4 +15,4 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-const BIBLYS_VERSION = "3.0.2";
+const BIBLYS_VERSION = "3.1.0-dev";

--- a/src/Model/Order.php
+++ b/src/Model/Order.php
@@ -31,5 +31,26 @@ use Model\Base\Order as BaseOrder;
  */
 class Order extends BaseOrder
 {
+    public function getTrackingLink(): string
+    {
+        $trackingNumber = $this->getTrackNumber();
 
+        if (!$trackingNumber) {
+            return "";
+        }
+
+        if ($this->getShippingMode() === "suivi") {
+            return "https://www.laposte.fr/outils/suivre-vos-envois?code=$trackingNumber";
+        }
+
+        if ($this->getShippingMode() === "mondial-relay") {
+            return sprintf(
+                "https://www.mondialrelay.fr/suivi-de-colis?numeroExpedition=%s&codePostal=%s",
+                $trackingNumber,
+                $this->getPostalcode()
+            );
+        }
+
+        return "";
+    }
 }

--- a/tests/Model/OrderTest.php
+++ b/tests/Model/OrderTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Model;
+
+use PHPUnit\Framework\TestCase;
+
+class OrderTest extends TestCase
+{
+    public function testGetTrackingLink(): void
+    {
+        // given
+        $order = new Order();
+        $order->setShippingMode("normal");
+
+        // when
+        $result = $order->getTrackingLink();
+
+        // then
+        $this->assertEquals("", $result);
+    }
+
+    public function testGetTrackingLinkWithoutTrackingNumber(): void
+    {
+        // given
+        $order = new Order();
+        $order->setShippingMode("suivi");
+
+        // when
+        $result = $order->getTrackingLink();
+
+        // then
+        $this->assertEquals("", $result);
+    }
+
+    public function testGetTrackingLinkForColissimo(): void
+    {
+        // given
+        $order = new Order();
+        $order->setShippingMode("suivi");
+        $order->setTrackNumber("1234567890");
+
+        // when
+        $result = $order->getTrackingLink();
+
+        // then
+        $this->assertEquals("https://www.laposte.fr/outils/suivre-vos-envois?code=1234567890", $result);
+    }
+
+    public function testGetTrackingLinkForMondialRelay(): void
+    {
+        // given
+        $order = new Order();
+        $order->setShippingMode("mondial-relay");
+        $order->setTrackNumber("1234567890");
+        $order->setPostalcode(46800);
+
+        // when
+        $result = $order->getTrackingLink();
+
+        // then
+        $this->assertEquals(
+            "https://www.mondialrelay.fr/suivi-de-colis?numeroExpedition=1234567890&codePostal=46800",
+            $result
+        );
+    }
+}


### PR DESCRIPTION
## 📦 Problème

Lorsqu'une commande utilisant le mode d'expédition Mondial Relais est marquée comme expédiée, il n'est pas possible de préciser le numéro de suivi, et la ou la client·e ne reçoit pas de lien de suivi.

## 🚚 Solution

- Permettre à l'administrateur·ice de préciser le numéro de suivi lorsque la commande est marquée comme expédiée
- Inclure le lien de suivi dans le courriel de confirmation d'expédition
- Afficher un bouton de suivi de l'expédition sur la page de la commande