### PR TITLE
Permettre d'afficher le contenu d'un lot sur la page article

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Historique des modifications
 
-### 3.1.0 (dev)
+## 3.1.0 (dev)
 
-Améliorations
+### Améliorations
 
 - Lors d'une expédition avec Mondial Relay, le lien de suivi est désormais
   affiché sur la page de la commande et inclus dans le courriel de confirmation
@@ -11,6 +11,10 @@ Améliorations
   qu'elle ne soit plus proposée lors de la création de nouvelles commandes.
 - Il n'est plus possible de supprimer une tranche de frais de port si elle est
   utilisée par au moins une commande.
+- De nouvelles méthodes `isBundle`, `isInABundle`, `getArticlesFromBundle` et
+  `getBundles` ont été ajoutées à la classe `Article` pour faciliter l'affichage
+  des lots d'articles (voir
+  la [documentation](https://docs.biblys.fr/personnaliser/entites/article/#article-de-type-lot)).
 
 ### Instructions de mise à jour
 

--- a/inc/Article.class.php
+++ b/inc/Article.class.php
@@ -115,6 +115,7 @@ class Article extends Entity
     {
         $model = new \Model\Article();
         $model->setId($this->get("id"));
+        $model->setTypeId($this->get("type_id"));
 
         return $model;
     }

--- a/inc/Article.class.php
+++ b/inc/Article.class.php
@@ -1127,6 +1127,14 @@ class Article extends Entity
         return $this->getModel()->getArticlesFromBundle();
     }
 
+    /**
+     * @throws Exception
+     */
+    public function isInABundle(): bool
+    {
+        return $this->getModel()->isInABundle();
+    }
+
 }
 
 class ArticleManager extends EntityManager

--- a/inc/Article.class.php
+++ b/inc/Article.class.php
@@ -1107,6 +1107,26 @@ class Article extends Entity
         return $this->has("article_editing_user");
     }
 
+    /**
+     * METHODS FROM MODEL
+     */
+
+    /**
+     * @throws Exception
+     */
+    public function isBundle(): bool
+    {
+        return $this->getModel()->isBundle();
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function getArticlesFromBundle(): \Propel\Runtime\Collection\Collection
+    {
+        return $this->getModel()->getArticlesFromBundle();
+    }
+
 }
 
 class ArticleManager extends EntityManager

--- a/inc/Article.class.php
+++ b/inc/Article.class.php
@@ -1135,6 +1135,14 @@ class Article extends Entity
         return $this->getModel()->isInABundle();
     }
 
+    /**
+     * @throws Exception
+     */
+    public function getBundles(): \Propel\Runtime\Collection\Collection
+    {
+        return $this->getModel()->getBundles();
+    }
+
 }
 
 class ArticleManager extends EntityManager

--- a/inc/constants.php
+++ b/inc/constants.php
@@ -15,4 +15,4 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-const BIBLYS_VERSION = "3.1.0-dev";
+const BIBLYS_VERSION = "3.1.0-dev.1";

--- a/src/Biblys/Data/ArticleType.php
+++ b/src/Biblys/Data/ArticleType.php
@@ -32,6 +32,7 @@ class ArticleType
     public const BOOK = 1;
     public const EBOOK = 2;
     public const EAUDIOBOOK = 11;
+    public const BUNDLE = 8;
 
     public function setId($id): void
     {

--- a/src/Biblys/Test/ModelFactory.php
+++ b/src/Biblys/Test/ModelFactory.php
@@ -243,11 +243,13 @@ class ModelFactory
     public static function createLink(
         Article         $article = null,
         ArticleCategory $articleCategory = null,
+        Article         $bundleArticle = null,
     ): Link
     {
         $link = new Link();
         $link->setArticle($article);
         $link->setArticleCategory($articleCategory);
+        $link->setBundleId($bundleArticle?->getId());
         $link->save();
 
         return $link;

--- a/src/Model/Article.php
+++ b/src/Model/Article.php
@@ -25,6 +25,7 @@ use Exception;
 use Model\Base\Article as BaseArticle;
 use Model\StockQuery as ChildStockQuery;
 use Propel\Runtime\ActiveQuery\Criteria;
+use Propel\Runtime\Collection\Collection;
 use Propel\Runtime\Connection\ConnectionInterface;
 use Propel\Runtime\Exception\PropelException;
 
@@ -105,6 +106,16 @@ class Article extends BaseArticle
         }
 
         return false;
+    }
+
+    public function getArticlesFromBundle(): Collection
+    {
+        return ArticleQuery::create()
+            ->joinWithLink()
+            ->useLinkQuery()
+                ->filterByBundleId($this->getId())
+            ->endUse()
+            ->find();
     }
 
     public function isWatermarkable(): bool

--- a/src/Model/Article.php
+++ b/src/Model/Article.php
@@ -129,6 +129,21 @@ class Article extends BaseArticle
             ->exists();
     }
 
+    /**
+     * @throws PropelException
+     */
+    public function getBundles(): Collection
+    {
+        $linksId = LinkQuery::create()
+            ->select(["bundle_id"])
+            ->filterByArticle($this)
+            ->filterByBundleId(null, Criteria::ISNOTNULL)
+            ->find()
+            ->getArrayCopy();
+
+        return ArticleQuery::create()->filterById($linksId)->find();
+    }
+
     public function isWatermarkable(): bool
     {
         return $this->getLemoninkMasterId() !== null;

--- a/src/Model/Article.php
+++ b/src/Model/Article.php
@@ -98,6 +98,11 @@ class Article extends BaseArticle
         return ArticleType::getById($this->getTypeId());
     }
 
+    public function isBundle(): bool
+    {
+        return false;
+    }
+
     public function isWatermarkable(): bool
     {
         return $this->getLemoninkMasterId() !== null;

--- a/src/Model/Article.php
+++ b/src/Model/Article.php
@@ -100,6 +100,10 @@ class Article extends BaseArticle
 
     public function isBundle(): bool
     {
+        if ($this->getTypeId() === ArticleType::BUNDLE) {
+            return true;
+        }
+
         return false;
     }
 

--- a/src/Model/Article.php
+++ b/src/Model/Article.php
@@ -118,6 +118,17 @@ class Article extends BaseArticle
             ->find();
     }
 
+    /**
+     * @throws PropelException
+     */
+    public function isInABundle(): bool
+    {
+        return LinkQuery::create()
+            ->filterByArticle($this)
+            ->filterByBundleId(null, Criteria::ISNOTNULL)
+            ->exists();
+    }
+
     public function isWatermarkable(): bool
     {
         return $this->getLemoninkMasterId() !== null;

--- a/tests/Model/ArticleTest.php
+++ b/tests/Model/ArticleTest.php
@@ -235,6 +235,26 @@ class ArticleTest extends TestCase
         $this->assertTrue($isInABundle);
     }
 
+    /** getContainingArticleBundles */
+
+    /**
+     * @throws PropelException
+     */
+
+    public function testGetBundles(): void
+    {
+        // given
+        $bundle = ModelFactory::createArticle();
+        $articleInBundle = ModelFactory::createArticle();
+        ModelFactory::createLink(article: $articleInBundle, bundleArticle: $bundle);
+
+        // when
+        $containingArticleBundles = $articleInBundle->getBundles();
+
+        // then
+        $this->assertContains($bundle, $containingArticleBundles);
+    }
+
     /** delete */
 
     public function testDeleteSucceedsIfArticleHasNoStock(): void

--- a/tests/Model/ArticleTest.php
+++ b/tests/Model/ArticleTest.php
@@ -29,7 +29,7 @@ require_once __DIR__."/../setUp.php";
 
 class ArticleTest extends TestCase
 {
-    /** Article->isPublished */
+    /** isPublished */
 
     /**
      * @throws PropelException
@@ -73,6 +73,8 @@ class ArticleTest extends TestCase
         $this->assertFalse($isPublished);
     }
 
+    /** addContributor */
+
     /**
      * @throws Exception
      */
@@ -94,6 +96,8 @@ class ArticleTest extends TestCase
             ->findOne();
         $this->assertNotNull($role, "role should have been created");
     }
+
+    /** countAvailableStockForSite */
 
     /**
      * @throws PropelException
@@ -117,9 +121,7 @@ class ArticleTest extends TestCase
         $this->assertEquals(1, $count);
     }
 
-    /**
-     * #isWatermarkable
-     */
+    /** isWatermarkable */
 
     public function testIsWatermarkableWithMasterIdReturnsTrue(): void
     {
@@ -146,6 +148,8 @@ class ArticleTest extends TestCase
         // then
         $this->assertFalse($isWatermarkable);
     }
+
+    /** delete */
 
     public function testDeleteSucceedsIfArticleHasNoStock(): void
     {

--- a/tests/Model/ArticleTest.php
+++ b/tests/Model/ArticleTest.php
@@ -178,7 +178,9 @@ class ArticleTest extends TestCase
         $this->assertTrue($isBundle);
     }
 
-    /** getArticlesFromBundle
+    /** getArticlesFromBundle */
+
+    /**
      * @throws PropelException
      */
 
@@ -197,6 +199,40 @@ class ArticleTest extends TestCase
         // then
         $this->assertContains($articleInBundle1, $articlesFromBundle);
         $this->assertContains($articleInBundle2, $articlesFromBundle);
+    }
+
+    /** isInABundle */
+
+    /**
+     * @throws PropelException
+     */
+    public function testIsInABundleReturnsFalse(): void
+    {
+        // given
+        $article = ModelFactory::createArticle();
+
+        // when
+        $isInABundle = $article->isInABundle();
+
+        // then
+        $this->assertFalse($isInABundle);
+    }
+
+    /**
+     * @throws PropelException
+     */
+    public function testIsInABundleReturnsTrue(): void
+    {
+        // given
+        $bundle = ModelFactory::createArticle();
+        $articleInBundle = ModelFactory::createArticle();
+        ModelFactory::createLink(article: $articleInBundle, bundleArticle: $bundle);
+
+        // when
+        $isInABundle = $articleInBundle->isInABundle();
+
+        // then
+        $this->assertTrue($isInABundle);
     }
 
     /** delete */

--- a/tests/Model/ArticleTest.php
+++ b/tests/Model/ArticleTest.php
@@ -18,6 +18,7 @@
 
 namespace Model;
 
+use Biblys\Data\ArticleType;
 use Biblys\Exception\CannotDeleteArticleWithStock;
 use Biblys\Test\ModelFactory;
 use DateTime;
@@ -147,6 +148,34 @@ class ArticleTest extends TestCase
 
         // then
         $this->assertFalse($isWatermarkable);
+    }
+
+    /** isBundle */
+
+    public function testIsBundleReturnsFalse(): void
+    {
+        // given
+        $article = new Article();
+        $article->setTypeId(ArticleType::BOOK);
+
+        // when
+        $isBundle = $article->isBundle();
+
+        // then
+        $this->assertFalse($isBundle);
+    }
+
+    public function testIsBundleReturnsTrue(): void
+    {
+        // given
+        $article = new Article();
+        $article->setTypeId(ArticleType::BUNDLE);
+
+        // when
+        $isBundle = $article->isBundle();
+
+        // then
+        $this->assertTrue($isBundle);
     }
 
     /** delete */

--- a/tests/Model/ArticleTest.php
+++ b/tests/Model/ArticleTest.php
@@ -178,6 +178,27 @@ class ArticleTest extends TestCase
         $this->assertTrue($isBundle);
     }
 
+    /** getArticlesFromBundle
+     * @throws PropelException
+     */
+
+    public function testGetArticlesFromBundle(): void
+    {
+        // given
+        $bundle = ModelFactory::createArticle();
+        $articleInBundle1 = ModelFactory::createArticle();
+        $articleInBundle2 = ModelFactory::createArticle();
+        ModelFactory::createLink(article: $articleInBundle1, bundleArticle: $bundle);
+        ModelFactory::createLink(article: $articleInBundle2, bundleArticle: $bundle);
+
+        // when
+        $articlesFromBundle = $bundle->getArticlesFromBundle();
+
+        // then
+        $this->assertContains($articleInBundle1, $articlesFromBundle);
+        $this->assertContains($articleInBundle2, $articlesFromBundle);
+    }
+
     /** delete */
 
     public function testDeleteSucceedsIfArticleHasNoStock(): void


### PR DESCRIPTION
## 👝 Problème

Aujourd'hui, il n'est pas possible d'afficher facilement, sur la page d'un article de type lot, les articles contenus dans le lot, ou les lots dans lequel l'article est contenu.
xtdo
## 👜 Solution

Ajouter à l'entité `Article` les méthodes suivantes :

* `isBundle` : renvoie `true` pour un article de type **lot**, `false` sinon
* `getArticlesFromBundle` : renvoie une collection d'entité `Article` contenus dans le lot
* `isInABundle` : renvoie `true` si l'article fait partie d'un lot
* `getBundles` : renvoie les entités `Article` de type **lot** dont l'article fait partie

[Documenter les nouvelles méthodes](https://docs.biblys.fr/personnaliser/entites/article/#article-de-type-lot)