### PR TITLE
Correctif 3.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 - Les liens "billet précédent" et "billet suivant" pouvaient pointer vers des
   billets hors-ligne. Désormais, ils pointent uniquement vers des billets
   publiés.
+- La création d'une demande de paiement Stripe pouvait échouer si le commande
+  contenait un article gratuit. Maintenant, ça marche.
 
 ## 3.1.1 (11 décembre 2024)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,13 @@
 
 ### Corrections
 
-- Le bouton d'export des commandes pouvait apparaître même si le mode 
+- Le bouton d'export des commandes pouvait apparaître même si le mode
   d'expédition Mondial Relay n'était pas activé. C'est corrigé.
-- Il n'était pas possible de remplacer une illustration de billet de blog sans 
+- Il n'était pas possible de remplacer une illustration de billet de blog sans
   supprimer au préalable. C'est désormais possible.
+- Les articles sans titres provoquaient l'affichage d'une ligne vide sur la
+  page "Catalogue" de l'administration. Désormais, la mention "Article sans
+  titre" est affichée.
 
 ## 3.1.1 (11 décembre 2024)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Historique des modifications
 
-## 3.1.2 (DEV)
+## 3.1.2 (18 décembre 2024)
 
 ### Corrections
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Historique des modifications
 
+## 3.1.2 (DEV)
+
+### Corrections
+
+- Le bouton d'export des commandes pouvait apparaître même si le mode d'expédition Mondial Relay n'était pas activé. C'est corrigé.
+
 ## 3.1.1 (11 décembre 2024)
 
 ### Corrections

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 - Les articles sans titres provoquaient l'affichage d'une ligne vide sur la
   page "Catalogue" de l'administration. Désormais, la mention "Article sans
   titre" est affichée.
+- Les liens "billet précédent" et "billet suivant" pouvaient pointer vers des
+  billets hors-ligne. Désormais, ils pointent uniquement vers des billets
+  publiés.
 
 ## 3.1.1 (11 décembre 2024)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@
 
 ### Corrections
 
-- Le bouton d'export des commandes pouvait apparaître même si le mode d'expédition Mondial Relay n'était pas activé. C'est corrigé.
+- Le bouton d'export des commandes pouvait apparaître même si le mode 
+  d'expédition Mondial Relay n'était pas activé. C'est corrigé.
+- Il n'était pas possible de remplacer une illustration de billet de blog sans 
+  supprimer au préalable. C'est désormais possible.
 
 ## 3.1.1 (11 décembre 2024)
 

--- a/controllers/common/php/adm_stocks.php
+++ b/controllers/common/php/adm_stocks.php
@@ -363,11 +363,15 @@ return function (
                     </span>
                 </a>
             ';
-            $x['soldButton'] = '
-                <a href="/pages/adm_stock?sold=' . $x['stock_id'] . '">
-                    <span class="fa fa-shopping-bag fa-lg black" title="Vendu en magasin" />
-                </a>
-            ';
+
+            if ($currentSite->getOption("fake_shop_customer")) {
+                $soldButton = '
+                    <a href="/pages/adm_stock?sold=' . $x['stock_id'] . '">
+                        <span class="fa fa-shopping-bag fa-lg black" title="Vendu en magasin" />
+                    </a>
+                ';
+            }
+
 
             if ($x['stock_return_date']) { // Retourné
                 $x['led'] = 'square_orange';

--- a/controllers/common/php/adm_stocks.php
+++ b/controllers/common/php/adm_stocks.php
@@ -30,11 +30,10 @@ use Symfony\Component\HttpFoundation\Response;
  * @throws PropelException
  */
 return function (
-    Request $request,
-    CurrentSite $currentSite,
+    Request       $request,
+    CurrentSite   $currentSite,
     ImagesService $imagesService
-): Response|RedirectResponse
-{
+): Response|RedirectResponse {
     $lm = new ListeManager();
     $sm = new StockManager();
 
@@ -347,30 +346,30 @@ return function (
             $stock = $sm->getById($x['stock_id']);
 
             $x['copyButton'] = '
-            <a href="/pages/adm_stock?copy=' . $x['stock_id'] . '">
-                <span class="fa fa-clone fa-lg black" aria-label="Dupliquer"
-                    title="Dupliquer"></span>
-            </a>
-        ';
+                <a href="/pages/adm_stock?copy=' . $x['stock_id'] . '">
+                    <span class="fa fa-clone fa-lg black" aria-label="Dupliquer"
+                        title="Dupliquer"></span>
+                </a>
+            ';
             $x['returnButton'] = '
-            <a href="/pages/adm_stock?return=' . $x['stock_id'] . '">
-                <span class="fa fa-undo fa-lg black" aria-label="Retourner"
-                    title="Retourner"></span>
-            </a>
-        ';
+                <a href="/pages/adm_stock?return=' . $x['stock_id'] . '">
+                    <span class="fa fa-undo fa-lg black" aria-label="Retourner"
+                        title="Retourner"></span>
+                </a>
+            ';
             $x['lostButton'] = '
-            <a href="/pages/adm_stock?lost=' . $x['stock_id'] . '">
-                <span class="fa fa-question fa-lg black"
-                    aria-label="Marquer comme perdu"
-                    title="Marquer comme perdu">
-                </span>
-            </a>
-        ';
+                <a href="/pages/adm_stock?lost=' . $x['stock_id'] . '">
+                    <span class="fa fa-question fa-lg black"
+                        aria-label="Marquer comme perdu"
+                        title="Marquer comme perdu">
+                    </span>
+                </a>
+            ';
             $x['soldButton'] = '
-            <a href="/pages/adm_stock?sold=' . $x['stock_id'] . '">
-                <span class="fa fa-shopping-bag fa-lg black" title="Vendu en magasin" />
-            </a>
-        ';
+                <a href="/pages/adm_stock?sold=' . $x['stock_id'] . '">
+                    <span class="fa fa-shopping-bag fa-lg black" title="Vendu en magasin" />
+                </a>
+            ';
 
             if ($x['stock_return_date']) { // Retourné
                 $x['led'] = 'square_orange';

--- a/controllers/common/php/adm_stocks.php
+++ b/controllers/common/php/adm_stocks.php
@@ -17,7 +17,6 @@
 
 
 use Biblys\Data\ArticleType;
-use Biblys\Legacy\LegacyCodeHelper;
 use Biblys\Service\CurrentSite;
 use Biblys\Service\Images\ImagesService;
 use Propel\Runtime\Exception\PropelException;
@@ -100,9 +99,7 @@ return function (
     }
 
     $types = ArticleType::getAll();
-    $types_options = array_map(function ($type) {
-        $request = LegacyCodeHelper::getGlobalRequest();
-
+    $types_options = array_map(function ($type) use($request) {
         return '<option value="' . $type->getId() . '"' . ($type->getId() == $request->query->get('type_id', 0) ? ' selected' : null) . '>' . $type->getName() . '</option>';
     }, $types);
 
@@ -212,7 +209,6 @@ return function (
     </form>
 ';
 
-// Build query
     $req = null;
     if (isset($_GET['stock_created'])) {
         $req .= " AND `stock_created` LIKE '" . $_GET['stock_created'] . "%' ";
@@ -345,19 +341,21 @@ return function (
             /** @var Stock $stock */
             $stock = $sm->getById($x['stock_id']);
 
-            $x['copyButton'] = '
+            $copyButton = '
                 <a href="/pages/adm_stock?copy=' . $x['stock_id'] . '">
                     <span class="fa fa-clone fa-lg black" aria-label="Dupliquer"
                         title="Dupliquer"></span>
                 </a>
             ';
-            $x['returnButton'] = '
+
+            $returnButton = '
                 <a href="/pages/adm_stock?return=' . $x['stock_id'] . '">
                     <span class="fa fa-undo fa-lg black" aria-label="Retourner"
                         title="Retourner"></span>
                 </a>
             ';
-            $x['lostButton'] = '
+
+            $lostButton = '
                 <a href="/pages/adm_stock?lost=' . $x['stock_id'] . '">
                     <span class="fa fa-question fa-lg black"
                         aria-label="Marquer comme perdu"
@@ -374,7 +372,7 @@ return function (
             if ($x['stock_return_date']) { // Retourné
                 $x['led'] = 'square_orange';
                 $x['status'] = 'Retourné&nbsp;le<br />' . _date($x['stock_return_date'], 'd/m/Y');
-                unset($x['returnButton'], $x['soldButton']);
+                unset($returnButton, $soldButton);
                 ++$retours;
             } elseif ($x['stock_selling_date']) { // Vendu
                 $x['led'] = 'square_blue';
@@ -387,7 +385,7 @@ return function (
                     $x['status'] .= '<span class="fa fa- fa-lg" aria-label="Vendu en ligne" title="Vendu en ligne" />';
                 }
 
-                $x['soldButton'] = null;
+                $soldButton = null;
                 ++$ventes;
             } elseif ($x['stock_cart_date']) { // En panier
                 $x['led'] = 'square_gray';
@@ -396,7 +394,7 @@ return function (
             } elseif ($x['stock_lost_date']) { // Perdu
                 $x['led'] = 'square_purple';
                 $x['status'] = 'Perdu le<br />' . _date($x['stock_lost_date'], 'd/m/Y');
-                $x['lostButton'] = '';
+                $lostButton = '';
                 ++$perdus;
             } else { // En stock
                 $x['led'] = 'square_green';
@@ -412,10 +410,10 @@ return function (
                 <tr id="stock_' . $x['stock_id'] . '">
                     <td>
                         <a href="/pages/adm_stock?id=' . $x['stock_id'] . '">' . $x['stock_id'] . '</a><br />
-                        ' . $x['copyButton'] . '
-                        ' . ($x['soldButton'] ?? null) . '
-                        ' . ($x['returnButton'] ?? null) . '
-                        ' . $x['lostButton'] . '
+                        ' . $copyButton . '
+                        ' . ($soldButton ?? null) . '
+                        ' . ($returnButton ?? null) . '
+                        ' . $lostButton . '
                         <span class="fa fa-trash fa-lg deleteStock pointer"
                             aria-label="Supprimer"
                             data-stock_id="' . $x['stock_id'] . '"

--- a/controllers/common/php/post_edit.php
+++ b/controllers/common/php/post_edit.php
@@ -142,11 +142,7 @@ return function (
         }
     }
 
-    $postIllustrationUpload = '
-        <label for="post_illustration">Image :</label>
-        <input type="file" id="post_illustration_upload" name="post_illustration_upload" accept="image/jpeg, image/png, image/webp" />
-    ';
-
+    $existingPostIllustration = '';
     if ($postEntity) {
         $post = PostQuery::create()->findPk($postEntity->get('id'));
         $p = $postEntity;
@@ -167,7 +163,7 @@ return function (
 
         // Illustration
         if ($imagesService->imageExistsFor($post)) {
-            $postIllustrationUpload = '
+            $existingPostIllustration = '
                 <div class="text-center">
                     <img src="'.$imagesService->getImageUrlFor($post, height: 300).'" height="300" alt="">
                     <br />
@@ -270,9 +266,13 @@ return function (
         </fieldset>
         <fieldset>
             <legend>Illustration</legend>
-            <p>
-                ' . $postIllustrationUpload . '
-            </p>
+              <div class="form-group">
+                '.$existingPostIllustration.'
+              
+                <label for="post_illustration_upload">Image</label>
+                <input type="file" id="post_illustration_upload" name="post_illustration_upload" accept="image/jpeg, image/png, image/webp">
+                <p class="help-block">Image au format JPEG, PNG ou WebP affichée en prévisualisation sur les réseaux sociaux.</p>
+              </div>
             <p>
                 <label class="floating" for="post_illustration_legend">Texte alternatif :</label>
                 <input type="text" name="post_illustration_legend" id="post_illustration_legend" value="' . ($p['post_illustration_legend'] ?? null) . '" maxlength=64 class="long" />

--- a/controllers/common/php/post_edit.php
+++ b/controllers/common/php/post_edit.php
@@ -274,10 +274,9 @@ return function (
                 ' . $postIllustrationUpload . '
             </p>
             <p>
-                <label class="floating" for="post_illustration_legend">Légende :</label>
+                <label class="floating" for="post_illustration_legend">Texte alternatif :</label>
                 <input type="text" name="post_illustration_legend" id="post_illustration_legend" value="' . ($p['post_illustration_legend'] ?? null) . '" maxlength=64 class="long" />
             </p>
-            <p>Cette image (au format JPEG) sera utilisée comme vignette pour les aperçus du billet sur le site ou sur les réseaux sociaux. Taille minimale conseillée pour Facebook : 1200 x 627 pixels.</p>
         </fieldset>
         <fieldset>
             <legend>Contenu</legend>

--- a/inc/Order.class.php
+++ b/inc/Order.class.php
@@ -373,7 +373,7 @@ class Order extends Entity
             $product = Product::create(["name" => $copy->get("article")->get("title")]);
             $price = \Stripe\Price::create([
                 "product" => $product->id,
-                "unit_amount" => $copy->get("selling_price"),
+                "unit_amount" => $copy->get("selling_price") ?? 0,
                 "currency" => "EUR",
             ]);
             return [ "quantity" => 1, "price" => $price->id ];

--- a/inc/Post.class.php
+++ b/inc/Post.class.php
@@ -221,8 +221,10 @@ class Post extends Entity
     public function getPrevPost()
     {
         $pm = new PostManager();
-        return $pm->get(
-            ['post_date' => '< ' . $this->get('date')],
+        return $pm->get([
+            "post_status" => 1,
+            "post_date" => "< {$this->get('date')}"
+        ],
             ['order' => 'post_date', 'sort' => 'desc']
         );
     }
@@ -234,7 +236,10 @@ class Post extends Entity
     public function getNextPost()
     {
         $pm = new PostManager();
-        return $pm->get(['post_date' => '> ' . $this->get('date')]);
+        return $pm->get([
+            "post_status" => 1,
+            "post_date" => "> {$this->get('date')}"
+        ]);
     }
 }
 

--- a/inc/constants.php
+++ b/inc/constants.php
@@ -15,4 +15,4 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-const BIBLYS_VERSION = "3.1.2-dev";
+const BIBLYS_VERSION = "3.1.2-dev.1";

--- a/inc/constants.php
+++ b/inc/constants.php
@@ -15,4 +15,4 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-const BIBLYS_VERSION = "3.1.1";
+const BIBLYS_VERSION = "3.1.2-dev";

--- a/inc/constants.php
+++ b/inc/constants.php
@@ -15,4 +15,4 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-const BIBLYS_VERSION = "3.1.2-dev.1";
+const BIBLYS_VERSION = "3.1.2";

--- a/src/AppBundle/Controller/ArticleController.php
+++ b/src/AppBundle/Controller/ArticleController.php
@@ -710,6 +710,7 @@ class ArticleController extends Controller
         Request $request,
         CurrentSite $currentSite,
         CurrentUser $currentUser,
+        TemplateService $templateService,
     ): Response
     {
         $currentUser->authAdmin();
@@ -732,7 +733,7 @@ class ArticleController extends Controller
             ->offset($pagination->getOffset())
             ->find();
 
-        return $this->render("AppBundle:Article:articleAdminCatalog.html.twig", [
+        return $templateService->renderResponse("AppBundle:Article:articleAdminCatalog.html.twig", [
             "articles" => $articles,
             "count" => $count,
             "site" => $currentSite->getSite(),

--- a/src/AppBundle/Controller/OrderController.php
+++ b/src/AppBundle/Controller/OrderController.php
@@ -61,7 +61,11 @@ class OrderController extends Controller
      * @throws LoaderError
      * @throws Exception
      */
-    public function indexAction(Request $request, CurrentUser $currentUser): JsonResponse|Response
+    public function indexAction(
+        Request $request,
+        CurrentUser $currentUser,
+        TemplateService $templateService,
+    ): JsonResponse|Response
     {
         $currentUser->authAdmin();
 
@@ -131,7 +135,7 @@ class OrderController extends Controller
         // Index view
         $request->attributes->set("page_title", "Commandes web");
 
-        return $this->render('AppBundle:Order:index.html.twig');
+        return $templateService->renderResponse("AppBundle:Order:index.html.twig");
     }
 
     /**

--- a/src/AppBundle/Resources/views/Article/_list_pagination.html.twig
+++ b/src/AppBundle/Resources/views/Article/_list_pagination.html.twig
@@ -16,10 +16,12 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 {% if pages is defined and pages.total > 1 %}
 
+	{% set url = app.currentUrl.relativeUrl %}
+
 	<p class="articles-pagination text-center">
 
 		{% if pages.previous > -1 %}
-			<a href="{{ pages.previousQuery }}" class="btn btn-default btn-sm pagination-button button-prev">
+			<a href="{{ url }}{{ pages.previousQuery }}" class="btn btn-default btn-sm pagination-button button-prev">
 				<span class="icon fa fa-chevron-circle-left"></span>
 			</a>
 			&nbsp;
@@ -29,13 +31,13 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 			{% if pages.current == pageNumber %}
 				<span class="pagination-page pagination-page-current">{{ pageNumber }}</span>
 			{% else %}
-				<a href="{{ pages.queryForPageNumber(pageNumber) }}" class="pagination-page">{{ pageNumber }}</a>
+				<a href="{{ url }}{{ pages.queryForPageNumber(pageNumber) }}" class="pagination-page">{{ pageNumber }}</a>
 			{% endif %}
 		{% endfor %}
 
 		{% if pages.next %}
 			&nbsp;
-			<a href="{{ pages.nextQuery }}" class="btn btn-default btn-sm pagination-button button-next">
+			<a href="{{ url }}{{ pages.nextQuery }}" class="btn btn-default btn-sm pagination-button button-next">
 				<span class="icon fa fa-chevron-circle-right"></span>
 			</a>
 		{% endif %}

--- a/src/AppBundle/Resources/views/Article/_list_pagination.html.twig
+++ b/src/AppBundle/Resources/views/Article/_list_pagination.html.twig
@@ -14,33 +14,4 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #}
 
-{% if pages is defined and pages.total > 1 %}
-
-	{% set url = app.currentUrl.relativeUrl %}
-
-	<p class="articles-pagination text-center">
-
-		{% if pages.previous > -1 %}
-			<a href="{{ url }}{{ pages.previousQuery }}" class="btn btn-default btn-sm pagination-button button-prev">
-				<span class="icon fa fa-chevron-circle-left"></span>
-			</a>
-			&nbsp;
-		{% endif %}
-
-		{% for pageNumber in 1..pages.total %}
-			{% if pages.current == pageNumber %}
-				<span class="pagination-page pagination-page-current">{{ pageNumber }}</span>
-			{% else %}
-				<a href="{{ url }}{{ pages.queryForPageNumber(pageNumber) }}" class="pagination-page">{{ pageNumber }}</a>
-			{% endif %}
-		{% endfor %}
-
-		{% if pages.next %}
-			&nbsp;
-			<a href="{{ url }}{{ pages.nextQuery }}" class="btn btn-default btn-sm pagination-button button-next">
-				<span class="icon fa fa-chevron-circle-right"></span>
-			</a>
-		{% endif %}
-	</p>
-
-{% endif %}
+{% include "AppBundle:Utils:_pagination.html.twig" %}

--- a/src/AppBundle/Resources/views/Article/articleAdminCatalog.html.twig
+++ b/src/AppBundle/Resources/views/Article/articleAdminCatalog.html.twig
@@ -52,10 +52,16 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
           {{ article.ean }}
         </td>
         <td>
-          <a href="/a/{{ article.url }}">
-            {{ article.title }}
-          </a><br/>
-          <small>{{ article.authors|authors }}</small>
+          {% if article.title %}
+            <a href="/a/{{ article.url }}">
+              {{ article.title }}
+            </a><br/>
+            <small>{{ article.authors|authors }}</small>
+          {% else %}
+            <a href="/pages/article_edit?id={{ article.id }}">
+              <em>Article sans titre</em>
+            </a>
+          {% endif %}
         </td>
         <td>
           {{ article.collectionName }}<br>

--- a/src/AppBundle/Resources/views/Event/_pagination.html.twig
+++ b/src/AppBundle/Resources/views/Event/_pagination.html.twig
@@ -14,32 +14,4 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #}
 
-{% if pages is defined and pages.total > 1 %}
-
-	<p class="events-pagination text-center">
-
-		{% if pages.previous > -1 %}
-			<a href="?{% if query is defined %}q={{ query|url_encode }}&amp;{% endif %}p={{ pages.previous }}" class="btn btn-default btn-sm">
-				<span class="fa fa-chevron-circle-left"></span>
-			</a>
-			&nbsp;
-		{% endif %}
-
-		{% for i in 1..pages.total %}
-			{% if pages.current == i %}
-				<span class="pagination-page pagination-page-current">{{ i }}</span>
-			{% else %}
-				<a href="?{% if query is defined %}q={{ query|url_encode }}&amp;{% endif %}p={{ i - 1 }}" class="pagination-page">{{ i }}</a>
-			{% endif %}
-		{% endfor %}
-
-		{% if pages.next %}
-			&nbsp;
-			<a href="?{% if query is defined %}q={{ query|url_encode }}&amp;{% endif %}p={{ pages.next }}" class="btn btn-default btn-sm">
-				<span class="fa fa-chevron-circle-right"></span>
-			</a>
-
-		{% endif %}
-	</p>
-
-{% endif %}
+{% include "AppBundle:Utils:_pagination.html.twig" %}

--- a/src/AppBundle/Resources/views/Event/index.html.twig
+++ b/src/AppBundle/Resources/views/Event/index.html.twig
@@ -29,5 +29,5 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
     {% endfor %}
   </div>
 
-  {% include 'AppBundle:Event:_pagination.html.twig' %}
+  {% include 'AppBundle:Utils:_pagination.html.twig' %}
 {% endblock %}

--- a/src/AppBundle/Resources/views/Invitation/list.html.twig
+++ b/src/AppBundle/Resources/views/Invitation/list.html.twig
@@ -93,5 +93,5 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
     </tbody>
   </table>
 
-  {% include 'AppBundle:Payment:_pagination.html.twig' %}
+  {% include 'AppBundle:Utils:_pagination.html.twig' %}
 {% endblock %}

--- a/src/AppBundle/Resources/views/Mailing/_pagination.html.twig
+++ b/src/AppBundle/Resources/views/Mailing/_pagination.html.twig
@@ -14,31 +14,4 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #}
 
-{% if pagination is defined and pagination.total > 1 %}
-
-	<p class="contacts-pagination text-center">
-
-		{% if pagination.previous > -1 %}
-			<a href="?{% if query is defined %}q={{ query|url_encode }}&amp;{% endif %}p={{ pagination.previous }}" class="btn btn-default btn-sm">
-				<span class="fa fa-chevron-circle-left"></span>
-			</a>
-			&nbsp;
-		{% endif %}
-
-		{% for i in 1..pagination.total %}
-			{% if pagination.current == i %}
-				<span class="pagination-page pagination-page-current">{{ i }}</span>
-			{% else %}
-				<a href="?{% if query is defined %}q={{ query|url_encode }}&amp;{% endif %}p={{ i - 1 }}" class="pagination-page">{{ i }}</a>
-			{% endif %}
-		{% endfor %}
-
-		{% if pagination.next %}
-			&nbsp;
-			<a href="?{% if query is defined %}q={{ query|url_encode }}&amp;{% endif %}p={{ pagination.next }}" class="btn btn-default btn-sm">
-				<span class="fa fa-chevron-circle-right"></span>
-			</a>
-		{% endif %}
-	</p>
-
-{% endif %}
+{% include "AppBundle:Utils:_pagination.html.twig" %}

--- a/src/AppBundle/Resources/views/Mailing/contacts.html.twig
+++ b/src/AppBundle/Resources/views/Mailing/contacts.html.twig
@@ -70,5 +70,5 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
     </tbody>
   </table>
 
-  {% include "AppBundle:Mailing:_pagination.html.twig" %}
+  {% include "AppBundle:Utils:_pagination.html.twig" %}
 {% endblock %}

--- a/src/AppBundle/Resources/views/Main/_pagination.html.twig
+++ b/src/AppBundle/Resources/views/Main/_pagination.html.twig
@@ -14,20 +14,4 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #}
 
-{% if pages is defined and pages.total > 1 %}
-
-  <p class="items-pagination text-center">
-    {% if pages.previous > -1 %}
-      <a href="?{% if query is defined %}q={{ query|url_encode }}&amp;{% endif %}p={{ pages.previous }}" class="btn btn-default btn-sm">
-        <span class="fa fa-chevron-circle-left"></span>
-      </a> &nbsp;
-    {% endif %}
-    Page {{ pages.current }} sur {{ pages.total }}
-    {% if pages.next %}
-      &nbsp; <a href="?{% if query is defined %}q={{ query|url_encode }}&amp;{% endif %}p={{ pages.next }}" class="btn btn-default btn-sm">
-        <span class="fa fa-chevron-circle-right"></span>
-      </a>
-    {% endif %}
-  </p>
-
-{% endif %}
+{% include "AppBundle:Utils:_pagination.html.twig" %}

--- a/src/AppBundle/Resources/views/Main/home-posts.html.twig
+++ b/src/AppBundle/Resources/views/Main/home-posts.html.twig
@@ -18,5 +18,5 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 {% block main %}
   {% include 'AppBundle:Post:_postList.html.twig' %}
-  {% include 'AppBundle:Post:_pagination.html.twig' %}
+  {% include 'AppBundle:Utils:_pagination.html.twig' %}
 {% endblock %}

--- a/src/AppBundle/Resources/views/Order/index.html.twig
+++ b/src/AppBundle/Resources/views/Order/index.html.twig
@@ -72,12 +72,15 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
       <div class="form-group">
         <div class="col-sm-offset-2 col-sm-10">
           <button type="submit" class="btn btn-primary" data-action="show">Afficher les commandes</button>
-          <button type="submit" class="btn btn-info" data-action="export" data-export_url="{{
-            path('api_orders_export')
-          }}">
-            <span class="fa fa-cloud-download"></span>
-            Exporter en CSV
-          </button>
+
+          {% if display_export_button %}
+            <button type="submit" class="btn btn-info" data-action="export" data-export_url="{{
+              path('api_orders_export')
+            }}">
+              <span class="fa fa-cloud-download"></span>
+              Exporter pour Mondial Relay
+            </button>
+          {% endif %}
         </div>
       </div>
 

--- a/src/AppBundle/Resources/views/Payment/_pagination.html.twig
+++ b/src/AppBundle/Resources/views/Payment/_pagination.html.twig
@@ -14,31 +14,4 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #}
 
-{% if pages is defined and pages.total > 1 %}
-
-	<p class="posts-pagination text-center">
-
-		{% if pages.previous > -1 %}
-			<a href="{{ pages.previousQuery }}" class="btn btn-default btn-sm">
-				<span class="fa fa-chevron-circle-left"></span>
-			</a>
-			&nbsp;
-		{% endif %}
-
-		{% for pageNumber in 1..pages.total %}
-			{% if pages.current == pageNumber %}
-				<span class="pagination-page pagination-page-current">{{ pageNumber }}</span>
-			{% else %}
-				<a href="{{ pages.queryForPageNumber(pageNumber) }}" class="pagination-page">{{ pageNumber }}</a>
-			{% endif %}
-		{% endfor %}
-
-		{% if pages.next %}
-			&nbsp;
-			<a href="{{ pages.nextQuery }}" class="btn btn-default btn-sm">
-				<span class="fa fa-chevron-circle-right"></span>
-			</a>
-		{% endif %}
-	</p>
-
-{% endif %}
+{% include "AppBundle:Utils:_pagination.html.twig" %}

--- a/src/AppBundle/Resources/views/Payment/index.html.twig
+++ b/src/AppBundle/Resources/views/Payment/index.html.twig
@@ -91,5 +91,5 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
     </tfoot>
   </table>
 
-  {% include 'AppBundle:Payment:_pagination.html.twig' %}
+  {% include 'AppBundle:Utils:_pagination.html.twig' %}
 {% endblock %}

--- a/src/AppBundle/Resources/views/Post/_pagination.html.twig
+++ b/src/AppBundle/Resources/views/Post/_pagination.html.twig
@@ -14,31 +14,4 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #}
 
-{% if pages is defined and pages.total > 1 %}
-
-	<p class="posts-pagination text-center">
-
-		{% if pages.previous > -1 %}
-			<a href="?{% if query is defined %}q={{ query|url_encode }}&amp;{% endif %}p={{ pages.previous }}" class="btn btn-default btn-sm">
-				<span class="fa fa-chevron-circle-left"></span>
-			</a>
-			&nbsp;
-		{% endif %}
-
-		{% for i in 1..pages.total %}
-			{% if pages.current == i %}
-				<span class="pagination-page pagination-page-current">{{ i }}</span>
-			{% else %}
-				<a href="?{% if query is defined %}q={{ query|url_encode }}&amp;{% endif %}p={{ i - 1 }}" class="pagination-page">{{ i }}</a>
-			{% endif %}
-		{% endfor %}
-
-		{% if pages.next %}
-			&nbsp;
-			<a href="?{% if query is defined %}q={{ query|url_encode }}&amp;{% endif %}p={{ pages.next }}" class="btn btn-default btn-sm">
-				<span class="fa fa-chevron-circle-right"></span>
-			</a>
-		{% endif %}
-	</p>
-
-{% endif %}
+{% include "AppBundle:Utils:_pagination.html.twig" %}

--- a/src/AppBundle/Resources/views/Post/index.html.twig
+++ b/src/AppBundle/Resources/views/Post/index.html.twig
@@ -23,5 +23,5 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 {% block main %}
   <h1 class="posts-title">Actualités</h1>
   {% include 'AppBundle:Post:_postList.html.twig' %}
-  {% include 'AppBundle:Post:_pagination.html.twig' %}
+  {% include 'AppBundle:Utils:_pagination.html.twig' %}
 {% endblock %}

--- a/src/AppBundle/Resources/views/PostCategory/show.html.twig
+++ b/src/AppBundle/Resources/views/PostCategory/show.html.twig
@@ -23,5 +23,5 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 {% block main %}
   <h1 class="posts-title">{{ category.name }}</h1>
   {% include 'AppBundle:Post:_postList.html.twig' %}
-  {% include 'AppBundle:Post:_pagination.html.twig' %}
+  {% include 'AppBundle:Utils:_pagination.html.twig' %}
 {% endblock %}

--- a/src/AppBundle/Resources/views/Publisher/_pagination.html.twig
+++ b/src/AppBundle/Resources/views/Publisher/_pagination.html.twig
@@ -14,40 +14,4 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #}
 
-{% if pages is defined and pages.total > 1 %}
-
-	<p class="pagination text-center">
-
-		{% if pages.previous > -1 %}
-			<a
-				href="?{% if query is defined %}q={{ query|url_encode }}&amp;{% endif %}p={{ pages.previous }}"
-				class="btn btn-default btn-sm pagination-button button-prev"
-			>
-				<span class="icon fa fa-chevron-circle-left"></span>
-			</a>
-			&nbsp;
-		{% endif %}
-
-		{% for i in 1..pages.total %}
-			{% if pages.current == i %}
-				<span class="pagination-page pagination-page-current">{{ i }}</span>
-			{% else %}
-				<a
-					href="?{% if query is defined %}q={{ query|url_encode }}&amp;{% endif %}p={{ i - 1 }}"
-					class="pagination-page"
-				>{{ i }}</a>
-			{% endif %}
-		{% endfor %}
-
-		{% if pages.next %}
-			&nbsp;
-			<a
-				href="?{% if query is defined %}q={{ query|url_encode }}&amp;{% endif %}p={{ pages.next }}"
-				class="btn btn-default btn-sm pagination-button button-next"
-			>
-				<span class="icon fa fa-chevron-circle-right"></span>
-			</a>
-		{% endif %}
-	</p>
-
-{% endif %}
+{% include "AppBundle:Utils:_pagination.html.twig" %}

--- a/src/AppBundle/Resources/views/Publisher/index.html.twig
+++ b/src/AppBundle/Resources/views/Publisher/index.html.twig
@@ -34,6 +34,6 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
     {% endfor %}
   </ul>
 
-  {% include 'AppBundle:Publisher:_pagination.html.twig' %}
+  {% include 'AppBundle:Utils:_pagination.html.twig' %}
 
 {% endblock %}

--- a/src/AppBundle/Resources/views/Utils/_pagination.html.twig
+++ b/src/AppBundle/Resources/views/Utils/_pagination.html.twig
@@ -16,12 +16,14 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 {% if pages is defined and pages.total > 1 %}
 
+  {% set url = app.currentUrl.relativeUrl %}
+
   <nav class="Pagination text-center" aria-label="Page navigation">
     <ul class="pagination">
       {% if pages.previous > -1 %}
         <li class="Pagination__previous">
           <a
-            href="{{ pages.previousQuery }}"
+            href="{{ url }}{{ pages.previousQuery }}"
             aria-label="Précédent"
           >
             <span aria-hidden="true">&laquo;</span>
@@ -36,7 +38,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
           </li>
         {% else %}
           <li class="Pagination__page">
-            <a href="{{ pages.queryForPageNumber(pageNumber) }}" class="pagination-page">{{ pageNumber }}</a>
+            <a href="{{ url }}{{ pages.queryForPageNumber(pageNumber) }}" class="pagination-page">{{ pageNumber }}</a>
           </li>
         {% endif %}
       {% endfor %}
@@ -44,7 +46,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
       {% if pages.next %}
         <li class="Pagination__next">
           <a
-            href="{{ pages.nextQuery }}"
+            href="{{ url }}{{ pages.nextQuery }}"
             aria-label="Suivant"
           >
             <span aria-hidden="true">&raquo;</span>

--- a/src/Biblys/Service/Pagination.php
+++ b/src/Biblys/Service/Pagination.php
@@ -92,13 +92,13 @@ class Pagination
         return $this->queryParams;
     }
 
-    public function getQueryForPageNumber(int $pageNumber): ?string
+    public function getQueryForPageNumber(int $pageNumber): string
     {
         $pageIndex = $pageNumber - 1;
         return $this->getQueryForPageIndex($pageIndex);
     }
 
-    public function getQueryForPageIndex(?int $pageIndex = null): ?string
+    public function getQueryForPageIndex(?int $pageIndex = null): string
     {
         $params = $this->getQueryParams();
 
@@ -107,19 +107,19 @@ class Pagination
         }
 
         if (count($params) === 0) {
-            return null;
+            return "";
         }
 
         return "?".http_build_query($params);
     }
 
-    public function getPreviousQuery(): ?string
+    public function getPreviousQuery(): string
     {
         $previousPageNumber = $this->getPrevious();
         return $this->getQueryForPageIndex($previousPageNumber);
     }
 
-    public function getNextQuery(): ?string
+    public function getNextQuery(): string
     {
         $nextPageNumber = $this->getNext();
         return $this->getQueryForPageIndex($nextPageNumber);

--- a/src/Biblys/Service/Pagination.php
+++ b/src/Biblys/Service/Pagination.php
@@ -102,8 +102,8 @@ class Pagination
     {
         $params = $this->getQueryParams();
 
-        if ($pageIndex !== null) {
-            $params['p'] = $pageIndex;
+        if ($pageIndex !== null && $pageIndex > 0) {
+            $params["p"] = $pageIndex;
         }
 
         if (count($params) === 0) {

--- a/tests/AppBundle/Controller/ArticleControllerTest.php
+++ b/tests/AppBundle/Controller/ArticleControllerTest.php
@@ -41,6 +41,7 @@ use Exception;
 use LemonInk\Models\Transaction;
 use Mockery;
 use Model\ArticleQuery;
+use Model\PublisherQuery;
 use PHPUnit\Framework\TestCase;
 use Propel\Runtime\Exception\PropelException;
 use Psr\Http\Client\ClientExceptionInterface;
@@ -68,6 +69,7 @@ class ArticleControllerTest extends TestCase
     public function setUp(): void
     {
         ArticleQuery::create()->deleteAll();
+        PublisherQuery::create()->deleteAll();
     }
 
     /** adminCatalogAction  */
@@ -77,12 +79,15 @@ class ArticleControllerTest extends TestCase
      * @throws PropelException
      * @throws RuntimeError
      * @throws SyntaxError
+     * @throws Exception
      */
     public function testAdminCatalogAction(): void
     {
         // given
         $controller = new ArticleController();
         $site = ModelFactory::createSite();
+        ModelFactory::createArticle(title: "Article du catalogue");
+        ModelFactory::createArticle(title: "");
 
         $request = new Request();
         $currentUser = Mockery::mock(CurrentUser::class);
@@ -90,12 +95,15 @@ class ArticleControllerTest extends TestCase
         $currentSite = Mockery::mock(CurrentSite::class);
         $currentSite->expects("getOption")->andReturn(null);
         $currentSite->expects("getSite")->andReturn($site);
+        $templateService = Helpers::getTemplateService();
 
         // when
-        $response = $controller->adminCatalog($request, $currentSite, $currentUser);
+        $response = $controller->adminCatalog($request, $currentSite, $currentUser, $templateService);
 
         // then
         $this->assertEquals(200, $response->getStatusCode());
+        $this->assertStringContainsString("Article du catalogue", $response->getContent());
+        $this->assertStringContainsString("Article sans titre", $response->getContent());
     }
 
     /** show */

--- a/tests/AppBundle/Controller/ArticleControllerTest.php
+++ b/tests/AppBundle/Controller/ArticleControllerTest.php
@@ -70,6 +70,34 @@ class ArticleControllerTest extends TestCase
         ArticleQuery::create()->deleteAll();
     }
 
+    /** adminCatalogAction  */
+
+    /**
+     * @throws LoaderError
+     * @throws PropelException
+     * @throws RuntimeError
+     * @throws SyntaxError
+     */
+    public function testAdminCatalogAction(): void
+    {
+        // given
+        $controller = new ArticleController();
+        $site = ModelFactory::createSite();
+
+        $request = new Request();
+        $currentUser = Mockery::mock(CurrentUser::class);
+        $currentUser->expects("authAdmin");
+        $currentSite = Mockery::mock(CurrentSite::class);
+        $currentSite->expects("getOption")->andReturn(null);
+        $currentSite->expects("getSite")->andReturn($site);
+
+        // when
+        $response = $controller->adminCatalog($request, $currentSite, $currentUser);
+
+        // then
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
     /** show */
 
     /**

--- a/tests/AppBundle/Controller/ArticleControllerTest.php
+++ b/tests/AppBundle/Controller/ArticleControllerTest.php
@@ -101,11 +101,12 @@ class ArticleControllerTest extends TestCase
     /** show */
 
     /**
+     * @throws ClientExceptionInterface
      * @throws LoaderError
      * @throws PropelException
      * @throws RuntimeError
      * @throws SyntaxError
-     * @throws ClientExceptionInterface
+     * @throws \PHPUnit\Framework\MockObject\Exception
      */
     public function testShow()
     {
@@ -184,7 +185,8 @@ class ArticleControllerTest extends TestCase
     /** byIsbn */
 
     /**
-     * @throws Exception
+     * @throws PropelException
+     * @throws \PHPUnit\Framework\MockObject\Exception
      */
     public function testByIsbn()
     {
@@ -212,6 +214,9 @@ class ArticleControllerTest extends TestCase
         );
     }
 
+    /**
+     * @throws \PHPUnit\Framework\MockObject\Exception
+     */
     public function testByIsbnWithInvalidEan()
     {
         // then
@@ -227,6 +232,9 @@ class ArticleControllerTest extends TestCase
         $controller->byIsbn($urlGenerator, "7908026792240");
     }
 
+    /**
+     * @throws \PHPUnit\Framework\MockObject\Exception
+     */
     public function testByIsbnWithUnexistingArticle()
     {
         // then
@@ -274,7 +282,7 @@ class ArticleControllerTest extends TestCase
 
     /**
      * @throws PropelException
-     * @throws Exception
+     * @throws \PHPUnit\Framework\MockObject\Exception
      */
     public function testAddRayonActionForPublisher()
     {
@@ -314,6 +322,7 @@ class ArticleControllerTest extends TestCase
      * @throws PropelException
      * @throws RuntimeError
      * @throws SyntaxError
+     * @throws \PHPUnit\Framework\MockObject\Exception
      */
     public function testDeleteAction()
     {
@@ -355,6 +364,7 @@ class ArticleControllerTest extends TestCase
      * @throws PropelException
      * @throws RuntimeError
      * @throws SyntaxError
+     * @throws \PHPUnit\Framework\MockObject\Exception
      */
     public function testDeleteActionDeletesArticle()
     {
@@ -401,6 +411,7 @@ class ArticleControllerTest extends TestCase
      * @throws PropelException
      * @throws RuntimeError
      * @throws SyntaxError
+     * @throws \PHPUnit\Framework\MockObject\Exception
      */
     public function testDeleteActionDeletesArticleWithCover()
     {
@@ -446,6 +457,7 @@ class ArticleControllerTest extends TestCase
 
     /**
      * @throws PropelException
+     * @throws \PHPUnit\Framework\MockObject\Exception
      * @throws Exception
      */
     public function testDeleteActionDeletesArticleWhenCoverFileDeletionFails()
@@ -495,6 +507,7 @@ class ArticleControllerTest extends TestCase
 
     /**
      * @throws PropelException
+     * @throws \PHPUnit\Framework\MockObject\Exception
      * @throws Exception
      */
     public function testDeleteActionIsImpossibleIfArticleHasStock()
@@ -548,10 +561,11 @@ class ArticleControllerTest extends TestCase
     /** ArticleController->searchAction */
 
     /**
-     * @throws RuntimeError
-     * @throws SyntaxError
      * @throws LoaderError
      * @throws PropelException
+     * @throws RuntimeError
+     * @throws SyntaxError
+     * @throws \PHPUnit\Framework\MockObject\Exception
      */
     public function testSearchAction()
     {
@@ -596,10 +610,11 @@ class ArticleControllerTest extends TestCase
     }
 
     /**
-     * @throws RuntimeError
-     * @throws SyntaxError
      * @throws LoaderError
      * @throws PropelException
+     * @throws RuntimeError
+     * @throws SyntaxError
+     * @throws \PHPUnit\Framework\MockObject\Exception
      */
     public function testSearchActionWithSortOption()
     {
@@ -644,10 +659,11 @@ class ArticleControllerTest extends TestCase
     }
 
     /**
-     * @throws RuntimeError
-     * @throws SyntaxError
      * @throws LoaderError
      * @throws PropelException
+     * @throws RuntimeError
+     * @throws SyntaxError
+     * @throws \PHPUnit\Framework\MockObject\Exception
      */
     public function testSearchActionWithIllegalSortOption()
     {
@@ -832,11 +848,12 @@ class ArticleControllerTest extends TestCase
     /** freeDownloadAction */
 
     /**
-     * @throws SyntaxError
-     * @throws RuntimeError
-     * @throws PropelException
      * @throws LoaderError
+     * @throws PropelException
+     * @throws RuntimeError
+     * @throws SyntaxError
      * @throws TransportExceptionInterface
+     * @throws \PHPUnit\Framework\MockObject\Exception
      */
     public function testFreeDownloadAction()
     {
@@ -878,11 +895,12 @@ class ArticleControllerTest extends TestCase
     }
 
     /**
-     * @throws SyntaxError
-     * @throws RuntimeError
-     * @throws PropelException
      * @throws LoaderError
+     * @throws PropelException
+     * @throws RuntimeError
+     * @throws SyntaxError
      * @throws TransportExceptionInterface
+     * @throws \PHPUnit\Framework\MockObject\Exception
      */
     public function testFreeDownloadActionWithNewsletterPrompt()
     {
@@ -935,16 +953,17 @@ class ArticleControllerTest extends TestCase
         $this->assertStringContainsString(
             "Je souhaite recevoir la newsletter pour être tenu·e",
             $response->getContent(),
-            "includes newletter prompt"
+            "includes newsletter prompt"
         );
     }
 
     /**
-     * @throws SyntaxError
-     * @throws RuntimeError
-     * @throws PropelException
      * @throws LoaderError
+     * @throws PropelException
+     * @throws RuntimeError
+     * @throws SyntaxError
      * @throws TransportExceptionInterface
+     * @throws \PHPUnit\Framework\MockObject\Exception
      */
     public function testFreeDownloadActionWhileAlreadyInLibrary()
     {
@@ -983,7 +1002,7 @@ class ArticleControllerTest extends TestCase
 
         // then
         $this->assertEquals(302, $response->getStatusCode(), "returns HTTP 302");
-        $this->assertEquals("/user_library", $response->getTargetUrl(), "redirects to elibrary");
+        $this->assertEquals("/user_library", $response->getTargetUrl(), "redirects to e-library");
     }
 
     /** downloadWithWatermarkAction */

--- a/tests/AppBundle/Controller/ArticleControllerTest.php
+++ b/tests/AppBundle/Controller/ArticleControllerTest.php
@@ -70,6 +70,8 @@ class ArticleControllerTest extends TestCase
         ArticleQuery::create()->deleteAll();
     }
 
+    /** show */
+
     /**
      * @throws LoaderError
      * @throws PropelException
@@ -122,6 +124,8 @@ class ArticleControllerTest extends TestCase
         );
     }
 
+    /** updatePublisherStock */
+
     /**
      * @throws Exception
      */
@@ -148,6 +152,8 @@ class ArticleControllerTest extends TestCase
             "it should update article publisher stock"
         );
     }
+
+    /** byIsbn */
 
     /**
      * @throws Exception
@@ -208,6 +214,8 @@ class ArticleControllerTest extends TestCase
         $controller->byIsbn($urlGenerator, "9781233456789");
     }
 
+    /** addTags */
+
     /**
      * @throws PropelException
      * @throws Exception
@@ -233,6 +241,8 @@ class ArticleControllerTest extends TestCase
             "it should return HTTP 200"
         );
     }
+
+    /** addRayon */
 
     /**
      * @throws PropelException
@@ -269,7 +279,7 @@ class ArticleControllerTest extends TestCase
         );
     }
 
-    /** ArticleController->deleteAction */
+    /** deleteAction */
 
     /**
      * @throws LoaderError
@@ -605,7 +615,6 @@ class ArticleControllerTest extends TestCase
         );
     }
 
-
     /**
      * @throws RuntimeError
      * @throws SyntaxError
@@ -748,6 +757,8 @@ class ArticleControllerTest extends TestCase
         );
     }
 
+    /** checkIsbn */
+
     /**
      * @throws PropelException
      */
@@ -789,6 +800,8 @@ class ArticleControllerTest extends TestCase
             "should respond with 200"
         );
     }
+
+    /** freeDownloadAction */
 
     /**
      * @throws SyntaxError
@@ -945,6 +958,8 @@ class ArticleControllerTest extends TestCase
         $this->assertEquals("/user_library", $response->getTargetUrl(), "redirects to elibrary");
     }
 
+    /** downloadWithWatermarkAction */
+
     /**
      * @throws PropelException
      * @throws LoaderError
@@ -1074,9 +1089,7 @@ class ArticleControllerTest extends TestCase
         );
     }
 
-    /**
-     * #watermarkAction
-     */
+    /** watermarkAction */
 
     /**
      * @throws PropelException

--- a/tests/AppBundle/Controller/OrderControllerTest.php
+++ b/tests/AppBundle/Controller/OrderControllerTest.php
@@ -18,6 +18,7 @@
 
 namespace AppBundle\Controller;
 
+use Biblys\Service\Config;
 use Biblys\Service\CurrentSite;
 use Biblys\Service\CurrentUser;
 use Biblys\Test\Helpers;
@@ -51,13 +52,44 @@ class OrderControllerTest extends TestCase
         $currentUser = Mockery::mock(CurrentUser::class);
         $currentUser->expects("authAdmin");
         $templateService = Helpers::getTemplateService();
+        $config = Mockery::mock(Config::class);
+        $config->expects("isMondialRelayEnabled")->andReturn(false);
 
         // when
-        $response = $controller->indexAction($request, $currentUser, $templateService);
+        $response = $controller->indexAction($request, $currentUser, $config, $templateService);
 
         // then
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertStringContainsString("Commandes web", $response->getContent());
+        $this->assertStringNotContainsString("Exporter pour Mondial Relay", $response->getContent());
+    }
+
+    /**
+     * @throws SyntaxError
+     * @throws RuntimeError
+     * @throws LoaderError
+     * @throws PropelException
+     * @throws Exception
+     */
+    public function testIndexActionWithMondialRelayEnabled(): void
+    {
+        // given
+        $controller = new OrderController();
+        $request = new Request();
+
+        $currentUser = Mockery::mock(CurrentUser::class);
+        $currentUser->expects("authAdmin");
+        $templateService = Helpers::getTemplateService();
+        $config = Mockery::mock(Config::class);
+        $config->expects("isMondialRelayEnabled")->andReturn(true);
+
+        // when
+        $response = $controller->indexAction($request, $currentUser, $config, $templateService);
+
+        // then
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertStringContainsString("Commandes web", $response->getContent());
+        $this->assertStringContainsString("Exporter pour Mondial Relay", $response->getContent());
     }
 
     /**

--- a/tests/AppBundle/Controller/OrderControllerTest.php
+++ b/tests/AppBundle/Controller/OrderControllerTest.php
@@ -20,15 +20,46 @@ namespace AppBundle\Controller;
 
 use Biblys\Service\CurrentSite;
 use Biblys\Service\CurrentUser;
+use Biblys\Test\Helpers;
 use Biblys\Test\ModelFactory;
+use Exception;
 use Mockery;
 use PHPUnit\Framework\TestCase;
 use Propel\Runtime\Exception\PropelException;
+use Symfony\Component\HttpFoundation\Request;
+use Twig\Error\LoaderError;
+use Twig\Error\RuntimeError;
+use Twig\Error\SyntaxError;
 
 require_once __DIR__."/../../setUp.php";
 
 class OrderControllerTest extends TestCase
 {
+    /**
+     * @throws SyntaxError
+     * @throws RuntimeError
+     * @throws PropelException
+     * @throws LoaderError
+     * @throws Exception
+     */
+    public function testIndexAction(): void
+    {
+        // given
+        $controller = new OrderController();
+        $request = new Request();
+
+        $currentUser = Mockery::mock(CurrentUser::class);
+        $currentUser->expects("authAdmin");
+        $templateService = Helpers::getTemplateService();
+
+        // when
+        $response = $controller->indexAction($request, $currentUser, $templateService);
+
+        // then
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertStringContainsString("Commandes web", $response->getContent());
+    }
+
     /**
      * @throws PropelException
      */

--- a/tests/Biblys/Service/PaginationTest.php
+++ b/tests/Biblys/Service/PaginationTest.php
@@ -89,14 +89,14 @@ class PaginationTest extends TestCase
     public function testGetPreviousQueryForFirstPage()
     {
         $pagination = new Pagination(1, 25, 10);
-        $this->assertEquals("?p=0", $pagination->getPreviousQuery());
+        $this->assertEquals("", $pagination->getPreviousQuery());
     }
 
     public function testGetPreviousQueryForFirstPageWithParams()
     {
         $pagination = new Pagination(1, 25, 10);
         $pagination->setQueryParams(["date" => "2013-05-22"]);
-        $this->assertEquals("?date=2013-05-22&p=0", $pagination->getPreviousQuery());
+        $this->assertEquals("?date=2013-05-22", $pagination->getPreviousQuery());
     }
 
     public function testGetPreviousQuery()
@@ -130,14 +130,14 @@ class PaginationTest extends TestCase
     public function testGetNextQueryForLastPage()
     {
         $pagination = new Pagination(3, 25, 10);
-        $this->assertEquals("?p=0", $pagination->getNextQuery());
+        $this->assertEquals("", $pagination->getNextQuery());
     }
 
     public function testGetNextQueryForLastPageWithParams()
     {
         $pagination = new Pagination(3, 25, 10);
         $pagination->setQueryParams(["date" => "2013-05-22"]);
-        $this->assertEquals("?date=2013-05-22&p=0", $pagination->getNextQuery());
+        $this->assertEquals("?date=2013-05-22", $pagination->getNextQuery());
     }
 
     /** getQueryForPageNumber */
@@ -163,7 +163,7 @@ class PaginationTest extends TestCase
         $queryForPageNumber = $pagination->getQueryForPageNumber(1);
 
         // then
-        $this->assertEquals("?p=0", $queryForPageNumber);
+        $this->assertEquals("", $queryForPageNumber);
     }
 
     public function testGetQueryForPageNumberWithParams()

--- a/tests/Biblys/Service/PaginationTest.php
+++ b/tests/Biblys/Service/PaginationTest.php
@@ -64,20 +64,27 @@ class PaginationTest extends TestCase
         $this->assertEquals(3, $this->pagination->getTotal());
     }
 
-    public function getOffset()
+    public function getOffset(): void
     {
         $this->assertEquals(10, $this->pagination->getOffset());
     }
 
-    public function getLimit()
+    public function getLimit(): void
     {
         $this->assertEquals(10, $this->pagination->getLimit());
     }
 
-    public function getPrevious()
+    public function getPrevious(): void
     {
         $this->assertEquals(0, $this->pagination->getPrevious());
     }
+
+    public function getNext(): void
+    {
+        $this->assertEquals(2, $this->pagination->getNext());
+    }
+
+    /** getPreviousQuery */
 
     public function testGetPreviousQueryForFirstPage()
     {
@@ -105,10 +112,7 @@ class PaginationTest extends TestCase
         $this->assertEquals("?date=2013-05-22&p=1", $pagination->getPreviousQuery());
     }
 
-    public function getNext()
-    {
-        $this->assertEquals(2, $this->pagination->getNext());
-    }
+    /** getNextQuery */
 
     public function testGetNextQuery()
     {
@@ -134,5 +138,44 @@ class PaginationTest extends TestCase
         $pagination = new Pagination(3, 25, 10);
         $pagination->setQueryParams(["date" => "2013-05-22"]);
         $this->assertEquals("?date=2013-05-22&p=0", $pagination->getNextQuery());
+    }
+
+    /** getQueryForPageNumber */
+
+    public function testGetQueryForPageNumber()
+    {
+        // given
+        $pagination = new Pagination(1, 25, 10);
+
+        // when
+        $queryForPageNumber = $pagination->getQueryForPageNumber(2);
+
+        // then
+        $this->assertEquals("?p=1", $queryForPageNumber);
+    }
+
+    public function testGetQueryForPageNumberForFirstPage()
+    {
+        // given
+        $pagination = new Pagination(1, 25, 10);
+
+        // when
+        $queryForPageNumber = $pagination->getQueryForPageNumber(1);
+
+        // then
+        $this->assertEquals("?p=0", $queryForPageNumber);
+    }
+
+    public function testGetQueryForPageNumberWithParams()
+    {
+        // given
+        $pagination = new Pagination(1, 25, 10);
+        $pagination->setQueryParams(["date" => "2013-05-22"]);
+
+        // when
+        $queryForPageNumber = $pagination->getQueryForPageNumber(2);
+
+        // then
+        $this->assertEquals("?date=2013-05-22&p=1", $queryForPageNumber);
     }
 }


### PR DESCRIPTION
## Corrections

- Le bouton d'export des commandes pouvait apparaître même si le mode d'expédition Mondial Relay n'était pas activé. C'est corrigé.
- Il n'était pas possible de remplacer une illustration de billet de blog sans supprimer au préalable. C'est désormais possible.
- Les articles sans titres provoquaient l'affichage d'une ligne vide sur la page "Catalogue" de l'administration. Désormais, la mention "Article sans titre" est affichée.
- Les liens "billet précédent" et "billet suivant" pouvaient pointer vers des billets hors-ligne. Désormais, ils pointent uniquement vers des billets publiés.
- La création d'une demande de paiement Stripe pouvait échouer si le commande contenait un article gratuit. Maintenant, ça marche.