### PR TITLE
Améliorer la gestions des admins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
   trois caractères.
 - Une alerte de sécurité est envoyée par courriel à tous les admins lorsqu'un·e
   nouvel·le admin est ajouté·e.
+- Une alerte de sécurité est envoyée par courriel à tous les admins lorsqu'un·e
+  nouvel·le admin est ajouté·e.
 
 ## 3.2.1 (8 janvier 2025)
 

--- a/src/AppBundle/Controller/AdminsController.php
+++ b/src/AppBundle/Controller/AdminsController.php
@@ -29,6 +29,7 @@ use Framework\Controller;
 use Model\Right;
 use Model\RightQuery;
 use Model\UserQuery;
+use Propel\Runtime\ActiveQuery\Criteria;
 use Propel\Runtime\Exception\PropelException;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Response;
@@ -51,7 +52,14 @@ class AdminsController extends Controller
     {
         $currentUser->authAdmin();
 
-        return $templateService->renderResponse("AppBundle:Admins:new.html.twig");
+        $users = UserQuery::create()
+            ->orderByCreatedAt(Criteria::DESC)
+            ->limit(1000)
+            ->find();
+
+        return $templateService->renderResponse("AppBundle:Admins:new.html.twig", [
+            "users" => $users,
+        ]);
     }
 
     /**

--- a/src/AppBundle/Controller/AdminsController.php
+++ b/src/AppBundle/Controller/AdminsController.php
@@ -99,7 +99,7 @@ class AdminsController extends Controller
             }
 
             $isUserAlreadyAdmin = RightQuery::create()
-                ->isUserAdminForSite($user, $currentSite->getSite());
+                ->isUserAdmin($user, $currentSite->getSite());
             if ($isUserAlreadyAdmin) {
                 throw new BadRequestHttpException("L'utilisateur $userEmail a déjà un accès administrateur.");
             }

--- a/src/AppBundle/Controller/AdminsController.php
+++ b/src/AppBundle/Controller/AdminsController.php
@@ -28,6 +28,7 @@ use Biblys\Service\TemplateService;
 use Framework\Controller;
 use Model\Right;
 use Model\RightQuery;
+use Model\User;
 use Model\UserQuery;
 use Propel\Runtime\ActiveQuery\Criteria;
 use Propel\Runtime\Exception\PropelException;
@@ -90,9 +91,10 @@ class AdminsController extends Controller
                 ->filterBySite($currentSite->getSite())
                 ->findOneByEmail($userEmail);
             if (!$user) {
-                throw new BadRequestHttpException(
-                    "L'adresse e-mail doit correspondre à un compte utilisateur existant."
-                );
+                $user = new User();
+                $user->setEmail($userEmail);
+                $user->setSite($currentSite->getSite());
+                $flashMessages->add("info", "Un compte utilisateur a été créé pour $userEmail.");
             }
 
             $isUserAlreadyAdmin = RightQuery::create()
@@ -121,9 +123,7 @@ class AdminsController extends Controller
             . $currentSite->getSite()->getTitle() . '</a>.
             </p>
             <p>
-                Vos identifiants de connexion sont votre adresse e-mail (' . $user->getEmail() . ') 
-                et le mot de passe que vous avez défini au moment de la création de votre compte 
-                (vous pourrez demander à en recevoir un nouveau si besoin).
+                Vous pourrez vous connecter sur le site à l’aide de votre adresse e-mail ' . $user->getEmail() . '.
             </p>
         ';
 

--- a/src/AppBundle/Controller/AdminsController.php
+++ b/src/AppBundle/Controller/AdminsController.php
@@ -21,6 +21,7 @@ namespace AppBundle\Controller;
 use Biblys\Exception\InvalidEmailAddressException;
 use Biblys\Service\BodyParamsService;
 use Biblys\Service\CurrentSite;
+use Biblys\Service\CurrentUser;
 use Biblys\Service\FlashMessagesService;
 use Biblys\Service\Mailer;
 use Biblys\Service\TemplateService;
@@ -44,9 +45,12 @@ class AdminsController extends Controller
      * @throws LoaderError
      * @throws SyntaxError
      * @throws RuntimeError
+     * @throws PropelException
      */
-    public function newAction(TemplateService $templateService): Response
+    public function newAction(CurrentUser $currentUser , TemplateService $templateService): Response
     {
+        $currentUser->authAdmin();
+
         return $templateService->renderResponse("AppBundle:Admins:new.html.twig");
     }
 
@@ -60,6 +64,7 @@ class AdminsController extends Controller
      */
     public function createAction(
         BodyParamsService $bodyParams,
+        CurrentUser $currentUser,
         CurrentSite $currentSite,
         UrlGenerator $urlGenerator,
         FlashMessagesService $flashMessages,
@@ -67,6 +72,7 @@ class AdminsController extends Controller
         TemplateService $templateService,
     ): RedirectResponse
     {
+        $currentUser->authAdmin();
 
         $bodyParams->parse(["user_email" => ["type" => "string"]]);
         $userEmail = $bodyParams->get("user_email");

--- a/src/AppBundle/Resources/layout/email-layout.html.twig
+++ b/src/AppBundle/Resources/layout/email-layout.html.twig
@@ -264,7 +264,12 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
       }
 
       .powered-by a {
-          text-decoration: none;
+        background: #ff6600;
+        border-radius: 4px;
+        color: white;
+        display: inline-block;
+        padding: 2px 4px;
+        text-decoration: none;
       }
 
       hr {
@@ -407,7 +412,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
             </tr>
             <tr>
               <td class="content-block powered-by">
-                Propulsé par <a href="https://biblys.fr">Biblys</a>, logiciel libre
+                propulsé par <a href="https://biblys.org">biblys</a> · logiciel libre
               </td>
             </tr>
           </table>

--- a/src/AppBundle/Resources/views/Admins/admin-welcome_email.html.twig
+++ b/src/AppBundle/Resources/views/Admins/admin-welcome_email.html.twig
@@ -1,0 +1,57 @@
+{#
+Copyright (C) 2024 Clément Latzarus
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, version 3.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#}
+
+{% extends "layout:email-layout.html.twig" %}
+
+{% block subject %}
+  Votre accès admin a été créé
+{% endblock %}
+
+{% block preview %}
+  {{ email }} a été ajouté·e aux admins de {{ app.currentSite.title }}
+{% endblock %}
+
+{% block content %}
+  <h1>
+    Votre accès admin a été créé
+  </h1>
+  <p>Bonjour,</p>
+  <p>
+    Votre accès admin a été créé sur le site {{ app.currentSite.title }}.
+  </p>
+  <p>
+    Vous pourrez vous connecter sur le site à l’aide de votre adresse e-mail {{ email }}.
+  </p>
+  <table role="presentation" border="0" cellpadding="0" cellspacing="0" class="btn btn-primary">
+    <tbody>
+    <tr>
+      <td align="center">
+        <table role="presentation" border="0" cellpadding="0" cellspacing="0">
+          <tbody>
+          <tr>
+            <td>
+              <a href="{{ adminUrl }}" target="_blank">
+                Accéder à l'administration
+              </a>
+            </td>
+          </tr>
+          </tbody>
+        </table>
+      </td>
+    </tr>
+    </tbody>
+  </table>
+{% endblock %}

--- a/src/AppBundle/Resources/views/Admins/new.html.twig
+++ b/src/AppBundle/Resources/views/Admins/new.html.twig
@@ -28,13 +28,6 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
     L’utilisateur·ice obtiendra tous les droits d’administration sur le site.
   </p>
 
-  <p class="alert alert-info">
-    <span class="fa fa-info-circle"></span>&nbsp;
-    L’adresse e-mail doit correspondre à un compte utilisateur existant.
-    Si ce n’est pas le cas, invitez le futur administrateur à créer au préalable
-    un compte utilisateur et à vous communiquer l’adresse e-mail utilisée.
-  </p>
-
   <form action="{{ path("admins_create") }}" method="post" class="form-inline">
     <label class="sr-only" for="inlineFormInputGroupUsername2">Adresse e-mail</label>
     <div class="input-group mb-2 mr-sm-2">

--- a/src/AppBundle/Resources/views/Admins/new.html.twig
+++ b/src/AppBundle/Resources/views/Admins/new.html.twig
@@ -35,15 +35,21 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
     un compte utilisateur et à vous communiquer l’adresse e-mail utilisée.
   </p>
 
-  <form action="{{ path("admins_create") }}" method="post" class="check">
-    <fieldset>
-      <div class="form-group">
-      <label for="user_email">Adresse e-mail :</label>
-      <input type="email"  class="form-control" name="user_email" id="user_email" required>&nbsp;
+  <form action="{{ path("admins_create") }}" method="post" class="form-inline">
+    <label class="sr-only" for="inlineFormInputGroupUsername2">Adresse e-mail</label>
+    <div class="input-group mb-2 mr-sm-2">
+      <div class="input-group-prepend">
+        <label class="input-group-text" for="user_email">Adresse e-mail</label>
       </div>
-      <div class="center">
-        <button class="btn btn-primary" type="submit">Ajouter un·e admin</button>
-      </div>
-    </fieldset>
+
+      <input type="email" id="user_email" class="form-control" name="user_email" placeholder="admin@paronymie.fr" list="user_emails" required>
+      <datalist id="user_emails">
+        {% for user in users %}
+        <option value="{{ user.email }}">
+          {% endfor %}
+      </datalist>
+    </div>
+
+    <button type="submit" class="btn btn-primary mb-2">Ajouter un·e admin</button>
   </form>
 {% endblock %}

--- a/src/Biblys/Service/CurrentUser.php
+++ b/src/Biblys/Service/CurrentUser.php
@@ -162,7 +162,7 @@ class CurrentUser
 
         $site = $this->getCurrentSite()->getSite();
 
-        return RightQuery::create()->isUserAdminForSite($this->user, $site);
+        return RightQuery::create()->isUserAdmin($this->user, $site);
     }
 
     /**

--- a/src/Biblys/Test/ModelFactory.php
+++ b/src/Biblys/Test/ModelFactory.php
@@ -659,7 +659,7 @@ class ModelFactory
         $site = $site ?? self::createSite();
 
         $user = self::createUser(site: $site, email: $email);
-        self::createRight(user: $user, site: $site, isAdmin: true);
+        self::createRight(user: $user, isAdmin: true);
 
         return $user;
     }

--- a/src/Model/RightQuery.php
+++ b/src/Model/RightQuery.php
@@ -35,11 +35,10 @@ class RightQuery extends BaseRightQuery
     /**
      * @throws PropelException
      */
-    public function isUserAdminForSite(User $user, Site $site): bool
+    public function isUserAdmin(User $user): bool
     {
         $adminRight = RightQuery::create()
             ->filterByUser($user)
-            ->filterBySite($site)
             ->filterByIsAdmin(true)
             ->findOne();
 

--- a/tests/AppBundle/Controller/AdminsControllerTest.php
+++ b/tests/AppBundle/Controller/AdminsControllerTest.php
@@ -59,6 +59,8 @@ class AdminsControllerTest extends TestCase
     {
         // given
         $controller = new AdminsController();
+        ModelFactory::createUser(email: "admin-to-add@example.org");
+
         $currentUser = Mockery::mock(CurrentUser::class);
         $currentUser->shouldReceive("authAdmin")->once();
         $templateService = Helpers::getTemplateService();
@@ -68,6 +70,7 @@ class AdminsControllerTest extends TestCase
 
         // then
         $this->assertEquals(200, $response->getStatusCode());
+        $this->assertStringContainsString("admin-to-add@example.org", $response->getContent());
     }
 
     /* createAction */

--- a/tests/AppBundle/Controller/AdminsControllerTest.php
+++ b/tests/AppBundle/Controller/AdminsControllerTest.php
@@ -20,6 +20,7 @@ namespace AppBundle\Controller;
 
 use Biblys\Service\BodyParamsService;
 use Biblys\Service\CurrentSite;
+use Biblys\Service\CurrentUser;
 use Biblys\Service\FlashMessagesService;
 use Biblys\Service\Mailer;
 use Biblys\Test\Helpers;
@@ -58,10 +59,12 @@ class AdminsControllerTest extends TestCase
     {
         // given
         $controller = new AdminsController();
+        $currentUser = Mockery::mock(CurrentUser::class);
+        $currentUser->shouldReceive("authAdmin")->once();
         $templateService = Helpers::getTemplateService();
 
         // when
-        $response = $controller->newAction($templateService);
+        $response = $controller->newAction($currentUser, $templateService);
 
         // then
         $this->assertEquals(200, $response->getStatusCode());
@@ -85,6 +88,8 @@ class AdminsControllerTest extends TestCase
         $bodyParams = Mockery::mock(BodyParamsService::class);
         $bodyParams->shouldReceive("parse")->with(["user_email" => ["type" => "string"]]);
         $bodyParams->shouldReceive("get")->with("user_email")->andReturn("new-admin@example.org");
+        $currentUser = Mockery::mock(CurrentUser::class);
+        $currentUser->shouldReceive("authAdmin")->once();
         $currentSite = Mockery::mock(CurrentSite::class);
         $currentSite->shouldReceive("getSite")->andReturn($site);
         $urlGenerator = Mockery::mock(UrlGenerator::class);
@@ -99,7 +104,7 @@ class AdminsControllerTest extends TestCase
         $templateService = Helpers::getTemplateService();
 
         // when
-        $response = $controller->createAction($bodyParams, $currentSite, $urlGenerator, $flashMessages, $mailer, $templateService);
+        $response = $controller->createAction($bodyParams, $currentUser, $currentSite, $urlGenerator, $flashMessages, $mailer, $templateService);
 
         // then
         $this->assertInstanceOf(RedirectResponse::class, $response);

--- a/tests/Model/RightQueryTest.php
+++ b/tests/Model/RightQueryTest.php
@@ -41,7 +41,7 @@ class RightQueryTest extends TestCase
         $site = ModelFactory::createSite();
 
         // when
-        $isAdmin = RightQuery::create()->isUserAdminForSite($user, $site);
+        $isAdmin = RightQuery::create()->isUserAdmin($user, $site);
 
         // then
         $this->assertFalse($isAdmin);
@@ -57,7 +57,7 @@ class RightQueryTest extends TestCase
         $user = ModelFactory::createPublisherUser(site: $site);
 
         // when
-        $isAdmin = RightQuery::create()->isUserAdminForSite($user, $site);
+        $isAdmin = RightQuery::create()->isUserAdmin($user, $site);
 
         // then
         $this->assertFalse($isAdmin);
@@ -73,7 +73,7 @@ class RightQueryTest extends TestCase
         $user = ModelFactory::createAdminUser(site: $site);
 
         // when
-        $isAdmin = RightQuery::create()->isUserAdminForSite($user, $site);
+        $isAdmin = RightQuery::create()->isUserAdmin($user, $site);
 
         // then
         $this->assertTrue($isAdmin);


### PR DESCRIPTION
- [x] Lors de l'ajout d'un nouvel admin, envoyer une alerte de sécurité aux autres admins
- [x] Suggérer une liste d'utilisateur·ices
- [x] Créer un nouveau compte si l'email utilisé ne correspond pas à un compte existant
- [x] Utiliser un template pour l'email envoyé au nouvel admin
- [x] Ne plus dépendre du `currentSite` pour savoir si l'utilisateur est admin