### PR TITLE
Correctif 3.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Le flux RSS des actualités pouvait déclencher une erreur si un billet
   d'actualité n'avait pas de contenu. Désormais, les billets sans contenu sont
   ignorés lors de la génération du flux.
+- La création d'un article attribué à un éditeur hors du filtre éditeur pouvait
+  provoquer une erreur. C'est corrigé.
 
 ## 3.3.1 (19 février 2025)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Historique des modifications
 
+## 3.3.2 (DEV)
+
+### Corrections
+
+- Le flux RSS des actualités pouvait déclencher une erreur si un billet
+  d'actualité n'avait pas de contenu. Désormais, les billets sans contenu sont
+  ignorés lors de la génération du flux.
+
 ## 3.3.1 (19 février 2025)
 
 ### Corrections

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,6 @@ Notamment, remplacer :
 
 - `btn-default` par `btn-light`
 - `btn-xs` par `btn-sm`
-- `btn-default` par `btn-light`
 - `hidden-*` par `d-*-none`
 - les `navbar` : https://getbootstrap.com/docs/4.0/migration/#navbar
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Historique des modifications
 
-## 3.3.2 (DEV)
+## 3.3.2 (26 février 2025)
 
 ### Corrections
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
   ignorés lors de la génération du flux.
 - La création d'un article attribué à un éditeur hors du filtre éditeur pouvait
   provoquer une erreur. C'est corrigé.
+- Lors de l'import d'un article depuis nooSFere, les prix en euros n'étaient pas
+  importés. Maintenant, ils le sont.
 
 ## 3.3.1 (19 février 2025)
 

--- a/controllers/common/php/article_edit.php
+++ b/controllers/common/php/article_edit.php
@@ -768,7 +768,7 @@ return function (
             </div>
             <p>
                 <label class="floating" for="article_price">Prix :</label>
-                <input type="number" step="1" id="article_price" name="article_price" value="' . $a['article_price'] . '" class="mini" required ' . $article_price_readonly . ' data-html="true" data-toggle="popover" data-trigger="focus" data-content="Entrez le prix de l\'article en centimes. Par exemple, pour article à 14,00 €, entrez <strong>1400</strong> ; pour un article à 8,50 €, entrez <strong>850</strong>."> centimes
+                <input type="number" step="1" id="article_price" name="article_price" value="' . $a['article_price'] . '" class="short" required ' . $article_price_readonly . ' data-html="true" data-toggle="popover" data-trigger="focus" data-content="Entrez le prix de l\'article en centimes. Par exemple, pour article à 14,00 €, entrez <strong>1400</strong> ; pour un article à 8,50 €, entrez <strong>850</strong>."> centimes
             </p>
             <p>
                 <label class="floating" for="article_price_editable">Prix libre :</label>

--- a/controllers/common/php/article_edit.php
+++ b/controllers/common/php/article_edit.php
@@ -256,6 +256,12 @@ return function (
             } elseif (isset($redirect_to_new)) {
                 return new RedirectResponse('/pages/article_edit');
             } else {
+
+                $shouldUseLegacyArticleController = $currentSite->getOption("use_old_article_controller");
+                if ($shouldUseLegacyArticleController) {
+                    return new RedirectResponse("/legacy/a/".$articleEntity->get("url"));
+                }
+
                 $articleUrl = $urlGenerator->generate('article_show', ['slug' => $articleEntity->get('url')]);
                 return new RedirectResponse($articleUrl);
             }

--- a/controllers/common/php/article_edit.php
+++ b/controllers/common/php/article_edit.php
@@ -482,20 +482,16 @@ return function (
     ';
     }
 
-    // Current publisher id (from site or from rights)
-    $publisher_id = $currentSite->getSite()->getPublisherId();
-    if (!$publisher_id && !$currentUser->isAdmin() && $currentUser->hasPublisherRight()) {
-        $publisher_id = $currentUser->getCurrentRight()->getPublisherId();
-    }
-
     $bonus_fieldset_class = null;
 
     $createCollectionPublisher = '
-    <input type="text" id="collection_publisher" name="collection_publisher" class="long uncompleted" required>
-    <input type="hidden" id="collection_publisher_id" name="collection_publisher_id" required>
-';
-    if ($publisher_id) {
-        $pub = $pm->getById($publisher_id);
+        <input type="text" id="collection_publisher" name="collection_publisher" class="long uncompleted" required>
+        <input type="hidden" id="collection_publisher_id" name="collection_publisher_id" required>
+    ';
+
+    if ($currentUser->hasPublisherRight()) {
+        $currentUserPublisherId = $currentUser->getCurrentRight()->getPublisherId();
+        $pub = $pm->getById($currentUserPublisherId);
         if ($pub) {
             $createCollectionPublisher = '
                 <input type="text" id="collection_publisher" name="collection_publisher" value="' . $pub->get('name') . '" class="long uncompleted" required readonly>

--- a/controllers/common/php/article_edit.php
+++ b/controllers/common/php/article_edit.php
@@ -27,6 +27,7 @@ use Biblys\Service\Images\ImagesService;
 use Model\ArticleCategory;
 use Model\ArticleCategoryQuery;
 use Model\ArticleQuery;
+use Model\BookCollectionQuery;
 use Model\LinkQuery;
 use Model\PublisherQuery;
 use Propel\Runtime\ActiveQuery\Criteria;
@@ -191,14 +192,14 @@ return function (
         unset($_POST['article_cover_import']);
         unset($_POST['article_cover_delete']);
 
-        // Set article collection and publisher
         $collectionId = $request->request->get('collection_id');
-        /** @var Collection $collection */
-        $collection = $cm->getById($collectionId);
-        if (!$collection) {
-            throw new Exception('Collection unknown');
-        }
-        $articleEntity->setCollection($collection);
+        $collection = BookCollectionQuery::create()->findPk($collectionId);
+        $articleEntity->set("collection_id", $collection->getId());
+        $articleEntity->set("collection", $collection->getName());
+
+        $publisher = PublisherQuery::create()->findPk($collection->getPublisherId());
+        $articleEntity->set("publisher_id", $publisher->getId());
+        $articleEntity->set("publisher", $publisher->getName());
 
         // VALIDATION
         foreach ($_POST as $key => $val) {

--- a/controllers/common/php/article_edit.php
+++ b/controllers/common/php/article_edit.php
@@ -24,6 +24,7 @@ use Biblys\Exception\InvalidEntityException;
 use Biblys\Isbn\IsbnParsingException;
 use Biblys\Service\Config;
 use Biblys\Service\Images\ImagesService;
+use Biblys\Service\StringService;
 use Model\ArticleCategory;
 use Model\ArticleCategoryQuery;
 use Model\ArticleQuery;
@@ -52,7 +53,6 @@ return function (
     $am = new ArticleManager();
     $sm = new SiteManager();
     $pm = new PublisherManager();
-    $cm = new CollectionManager();
 
     $currentUser->authPublisher();
 
@@ -156,7 +156,8 @@ return function (
         }
 
         // Titre alphabétique
-        $_POST['article_title_alphabetic'] = alphabetize($_POST['article_title']);
+        $stringService = new StringService($_POST['article_title']);
+        $_POST['article_title_alphabetic'] = $stringService->alphabetize();
 
         // Retirer les liens dans article_summary
         $_POST['article_summary'] = preg_replace('/<a href=\"(.*?)\">(.*?)<\/a>/', '\\2', $_POST['article_summary']);

--- a/inc/Article.class.php
+++ b/inc/Article.class.php
@@ -1019,22 +1019,6 @@ class Article extends Entity
         return $tax->getTaxRate();
     }
 
-    public function setPublisher(Publisher $publisher): Article
-    {
-        $this->set('publisher_id', $publisher->get('id'));
-        $this->set('article_publisher', $publisher->get('name'));
-
-        return $this;
-    }
-
-    public function setCollection(Collection $collection): Article
-    {
-        $this->set('collection_id', $collection->get('id'));
-        $this->set('article_collection', $collection->get('name'));
-
-        return $this->setPublisher($collection->getPublisher());
-    }
-
     /**
      * Get article's formatted age min and max
      * @throws Exception
@@ -1727,10 +1711,6 @@ class ArticleManager extends EntityManager
         );
         if ($other) {
             throw new InvalidEntityException('Il existe déjà un article avec l\'url ' . $article->get('url'));
-        }
-
-        if ($article->has("publisher_id") && !$this->site->allowsPublisherWithId($article->get("publisher_id"))) {
-            throw new InvalidEntityException("Cet éditeur ne fait pas partie des éditeurs autorisés.");
         }
     }
 

--- a/inc/constants.php
+++ b/inc/constants.php
@@ -15,4 +15,4 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-const BIBLYS_VERSION = "3.3.1";
+const BIBLYS_VERSION = "3.3.2-dev";

--- a/inc/constants.php
+++ b/inc/constants.php
@@ -15,4 +15,4 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-const BIBLYS_VERSION = "3.3.2-dev.2";
+const BIBLYS_VERSION = "3.3.2";

--- a/inc/constants.php
+++ b/inc/constants.php
@@ -15,4 +15,4 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-const BIBLYS_VERSION = "3.3.2-dev.1";
+const BIBLYS_VERSION = "3.3.2-dev.2";

--- a/inc/constants.php
+++ b/inc/constants.php
@@ -15,4 +15,4 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-const BIBLYS_VERSION = "3.3.2-dev";
+const BIBLYS_VERSION = "3.3.2-dev.1";

--- a/public/common/js/article_edit.js
+++ b/public/common/js/article_edit.js
@@ -872,7 +872,7 @@ function _addContribution(peopleId, jobId) {
     return response.json();
   }).then(function (data) {
     if (data.error) {
-      return _alert(data.error);
+      return _alert(data.error.message);
     }
 
     _addContributorLine(data.contributor);

--- a/src/AppBundle/Controller/FeedController.php
+++ b/src/AppBundle/Controller/FeedController.php
@@ -59,11 +59,15 @@ class FeedController extends Controller
 
         /** @var Post $post */
         foreach ($posts as $post) {
+            if (empty($post->getContent())) {
+                continue;
+            }
+
             $entry = $feed->createEntry();
             $entry->setTitle($post->getTitle());
             $entry->setLink($urlGenerator->generate("post_show", ["slug" => $post->getUrl()], UrlGeneratorInterface::ABSOLUTE_URL));
             $entry->setDateCreated($post->getDate());
-            $entry->setContent($post->getContent());
+            $entry->setContent($post->getContent() ?? "Pas de contenu");
             $feed->addEntry($entry);
         }
 

--- a/src/Biblys/Noosfere/Noosfere.php
+++ b/src/Biblys/Noosfere/Noosfere.php
@@ -464,16 +464,8 @@ class Noosfere
             }
 
             // Prix
-            $categorie = (string)$n->Categorie;
-            $price = null;
-            if (preg_match("/(\d+,?\d*) FF$/", $categorie, $matches)) {
-                $price = $matches[1];
-                $price = str_replace(",", ".", $price);
-                $price = round((float)$price / 6.55957 * 100);
-            } elseif ($price !== null) {
-                $price = str_replace(",", ".", $price);
-                $price = (float)$price * 100;
-            }
+            $category = (string) $n->Categorie;
+            $price = self::parsePriceFromCategory($category);
             $a["article_price"] = $price;
 
             $a["article_people"] = $people;
@@ -484,5 +476,20 @@ class Noosfere
         }
 
         return $articles;
+    }
+
+    public static function parsePriceFromCategory(string $category): int
+    {
+        if (str_ends_with($category, " FF")) {
+            return 0;
+        }
+
+        if (preg_match("/^(\d+,?\d*) /", $category, $matches)) {
+            $priceString = $matches[1];
+            $priceFloat = (float) str_replace(",", ".", $priceString);
+            return round($priceFloat * 100);
+        }
+
+        return "0";
     }
 }

--- a/src/Biblys/Test/ModelFactory.php
+++ b/src/Biblys/Test/ModelFactory.php
@@ -771,6 +771,7 @@ class ModelFactory
         bool     $status = Post::STATUS_ONLINE,
         DateTime $date = new DateTime(),
         ?string  $axysAccountId = null,
+        ?string  $content = "Un contenu d'actualité qui va vous étonner.",
     ): Post
     {
         $slugService = new SlugService();
@@ -782,7 +783,7 @@ class ModelFactory
         $post->setUrl($slugService->slugify($title));
         $post->setStatus($status);
         $post->setDate($date);
-        $post->setContent("Un contenu d'actualité qui va vous étonner.");
+        $post->setContent($content);
         $post->setCreatedAt(new DateTime());
         $post->setUpdatedAt(new DateTime());
         $post->setAxysAccountId($axysAccountId);

--- a/tests/AppBundle/Controller/FeedControllerTest.php
+++ b/tests/AppBundle/Controller/FeedControllerTest.php
@@ -127,4 +127,45 @@ XML
 XML
             , $response->getContent());
     }
+
+    /**
+     * @throws PropelException
+     * @throws Exception
+     */
+    public function testBlogActionWithEmptyPosts()
+    {
+        // given
+        $controller = new FeedController();
+        $site = ModelFactory::createSite();
+
+        ModelFactory::createPost(date: new DateTime("2019-04-28 02:42:00"), content: "");
+
+        $currentSite = new CurrentSite($site);
+        $currentUrl = $this->createMock(CurrentUrlService::class);
+        $currentUrl->method("getAbsoluteUrl")->willReturn("https://example.com/feed");
+        $urlGenerator = $this->createMock(UrlGenerator::class);
+        $urlGenerator->method("generate")->willReturn("https://example.com/post/1");
+
+        // when
+        $response = $controller->blogAction($currentSite, $currentUrl, $urlGenerator);
+
+        // then
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals("application/rss+xml", $response->headers->get("Content-Type"));
+        $this->assertEquals(<<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>Éditions Paronymie</title>
+    <description>Les derniers billets du blog</description>
+    <pubDate>Sun, 28 Apr 2019 02:42:00 +0000</pubDate>
+    <generator>Laminas_Feed_Writer 2 (https://getlaminas.org)</generator>
+    <link>https://paronymie.fr</link>
+    <atom:link rel="self" type="application/rss+xml" href="https://example.com/feed"/>
+  </channel>
+</rss>
+
+XML
+            , $response->getContent());
+    }
 }

--- a/tests/AppBundle/Controller/Legacy/ArticleEditTest.php
+++ b/tests/AppBundle/Controller/Legacy/ArticleEditTest.php
@@ -59,6 +59,7 @@ class ArticleEditTest extends TestCase
         $currentSite->shouldReceive("getSite")->andReturn($site);
         $currentSite->shouldReceive("getOption")->andReturn("null");
         $currentUser->shouldReceive("authPublisher")->andReturn(true);
+        $currentUser->shouldReceive("hasPublisherRight")->andReturn(false);
 
         $urlGenerator = Mockery::mock(UrlGenerator::class);
         $urlGenerator->shouldReceive("generate")->andReturn("url");

--- a/tests/ArticleTest.php
+++ b/tests/ArticleTest.php
@@ -632,54 +632,6 @@ class ArticleTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * Test setting a publisher
-     * @depends testGet
-     * @throws Exception
-     */
-    public function testSetPublisher(Article $article)
-    {
-        $pm = new PublisherManager();
-        /** @var Publisher $publisher */
-        $publisher = $pm->create(['publisher_name' => 'The Publisher']);
-
-        $article->setPublisher($publisher);
-
-        $this->assertEquals($article->get('publisher_id'), $publisher->get('id'));
-        $this->assertEquals($article->get('article_publisher'), $publisher->get('name'));
-
-        $pm->delete($publisher);
-    }
-
-
-    /**
-     * Test setting a collection
-     * @depends testGet
-     * @throws Exception
-     */
-    public function testSetCollection(Article $article)
-    {
-        $pm = new PublisherManager();
-        $publisher = $pm->create(['publisher_name' => 'The Publisher']);
-
-        $cm = new CollectionManager();
-        $collection = $cm->create([
-            'collection_name' => 'The Collection',
-            'publisher_id' => $publisher->get('id')
-        ]);
-
-        /** @var Collection $collection */
-        $article->setCollection($collection);
-
-        $this->assertEquals($article->get('collection_id'), $collection->get('id'));
-        $this->assertEquals($article->get('article_collection'), $collection->get('name'));
-        $this->assertEquals($article->get('publisher_id'), $publisher->get('id'));
-        $this->assertEquals($article->get('article_publisher'), $publisher->get('name'));
-
-        $cm->delete($collection);
-        $pm->delete($publisher);
-    }
-
-    /**
      * Test that adding a too long string as article_authors does not validate
      * @throws Exception
      */
@@ -750,33 +702,6 @@ class ArticleTest extends PHPUnit\Framework\TestCase
         $am = new ArticleManager();
         EntityFactory::createArticle(["article_url" => "anne-onyme/hous"]);
         $article = $am->create(["article_url" => "anne-onyme/hous"]);
-
-        // when
-        $am->update($article);
-    }
-
-    /**
-     * Test that updating an article for an unauthorized publisher throws
-     * @throws Exception
-     */
-    public function testUpdatingArticleWithFilteredPublisher()
-    {
-        // then
-        $this->expectException("Biblys\Exception\InvalidEntityException");
-        $this->expectExceptionMessage("Cet éditeur ne fait pas partie des éditeurs autorisés.");
-
-        // given
-        $pm = new PublisherManager();
-        $publisherFiltered = $pm->create(["publisher_name" => "Un éditeur filtré"]);
-        $publisherAllowed = $pm->create(["publisher_name" => "Un éditeur autorisé"]);
-        $GLOBALS["LEGACY_CURRENT_SITE"] = EntityFactory::createSite();
-        $GLOBALS["LEGACY_CURRENT_SITE"]->setOpt("publisher_filter", $publisherAllowed->get("id"));
-        $am = new ArticleManager();
-
-        $article = $am->create([
-            "article_url" => "jean-bon/de-bayonne",
-            "publisher_id" => $publisherFiltered->get("id")
-        ]);
 
         // when
         $am->update($article);

--- a/tests/Biblys/Noosfere/NoosfereTest.php
+++ b/tests/Biblys/Noosfere/NoosfereTest.php
@@ -294,7 +294,7 @@ class NoosfereTest extends TestCase
 <TitreBase>Un long voyage</TitreBase>
 <Titre>Un long voyage</Titre>
 <TitreOriginal/>
-<Categorie>19 €</Categorie>
+<Categorie>19,90 €</Categorie>
 <Reference/>
 <ParutionOriginale/>
 <Editeur IdEditeur="2078945151">AUX FORGES DE VULCAIN</Editeur>
@@ -348,7 +348,7 @@ XML;
                 "article_copyright" => "",
                 "article_authors" => "Claire DUVIVIER",
                 "article_ean" => "9782373050806",
-                "article_price" => null,
+                "article_price" => 1990,
                 "article_people" => [
                     [
                         "people_first_name" => "Claire",
@@ -409,5 +409,43 @@ XML;
 
         // then
         $this->assertEquals(null, $articles[0]["article_authors"]);
+    }
+
+    /** parsePriceFromCategory */
+
+    public function testParsePriceFromCategory(): void
+    {
+        // given
+        $category = "19 €";
+
+        // when
+        $price = Noosfere::parsePriceFromCategory($category);
+
+        // then
+        $this->assertEquals(1900, $price);
+    }
+
+    public function testParsePriceFromCategoryWithCents(): void
+    {
+        // given
+        $category = "15,90 €";
+
+        // when
+        $price = Noosfere::parsePriceFromCategory($category);
+
+        // then
+        $this->assertEquals(1590, $price);
+    }
+
+    public function testParsePriceFromCategoryWithFrancs(): void
+    {
+        // given
+        $category = "99,99 FF";
+
+        // when
+        $price = Noosfere::parsePriceFromCategory($category);
+
+        // then
+        $this->assertEquals(0, $price);
     }
 }


### PR DESCRIPTION
### Corrections

- Le flux RSS des actualités pouvait déclencher une erreur si un billet
  d'actualité n'avait pas de contenu. Désormais, les billets sans contenu sont
  ignorés lors de la génération du flux.
- La création d'un article attribué à un éditeur hors du filtre éditeur pouvait
  provoquer une erreur. C'est corrigé.
- Lors de l'import d'un article depuis nooSFere, les prix en euros n'étaient pas
  importés. Maintenant, ils le sont.

