### PR TITLE
Améliorer l'expérience de paiement avec Stripe

### DIFF
--- a/src/Biblys/Service/Config.php
+++ b/src/Biblys/Service/Config.php
@@ -162,6 +162,15 @@ class Config
         return false;
     }
 
+    public function isStripeEnabled(): bool
+    {
+        if ($this->get("stripe.secret_key") && $this->get("stripe.public_key") && $this->get("stripe.endpoint_secret")) {
+            return true;
+        }
+
+        return false;
+    }
+
     public function isPayPalEnabled(): bool
     {
         if ($this->get("paypal.client_id") && $this->get("paypal.client_secret")) {

--- a/src/Biblys/Service/PaymentService.php
+++ b/src/Biblys/Service/PaymentService.php
@@ -155,7 +155,7 @@ class PaymentService
         $payment->setOrder($order);
         $payment->setMode("stripe");
         $payment->setAmount($amountToPay);
-        $payment->setProviderId($session["id"]);
+        $payment->setProviderId($session->id);
 
         return $payment;
     }

--- a/src/Biblys/Test/EntityFactory.php
+++ b/src/Biblys/Test/EntityFactory.php
@@ -187,7 +187,7 @@ class EntityFactory
         int    $fee = 100,
     ): Shipping
     {
-        $shipping = ModelFactory::createShippingFee(
+        $shipping = ModelFactory::createShippingOption(
             type: $type,
             mode: $mode,
             fee: $fee,

--- a/src/Biblys/Test/ModelFactory.php
+++ b/src/Biblys/Test/ModelFactory.php
@@ -296,7 +296,7 @@ class ModelFactory
         ?Site           $site = null,
         ?User           $user = null,
         ?Customer       $customer = null,
-        ?ShippingOption $shippingFee = null,
+        ?ShippingOption $shippingOption = null,
         int             $amountToBePaid = 0,
         int             $shippingCost = 0,
         ?string         $axysAccountId = null,
@@ -323,8 +323,8 @@ class ModelFactory
         $order->setUser($user);
         $order->setAmountTobepaid($amountToBePaid);
         $order->setShippingCost($shippingCost);
-        $order->setShippingId($shippingFee?->getId());
-        $order->setShippingMode($shippingFee?->getType());
+        $order->setShippingId($shippingOption?->getId());
+        $order->setShippingMode($shippingOption?->getType());
         $order->setType("web");
         $order->setAxysAccountId($axysAccountId);
         $order->setSlug($slug ?? "order-slug");
@@ -513,7 +513,7 @@ class ModelFactory
     /**
      * @throws PropelException
      */
-    public static function createShippingFee(
+    public static function createShippingOption(
         ?Site    $site = null,
         string   $type = "normal",
         ?Country $country = null,
@@ -527,21 +527,21 @@ class ModelFactory
         bool     $isArchived = false,
     ): ShippingOption
     {
-        $shippingFee = new ShippingOption();
-        $shippingFee->setSiteId($site?->getId() ?? 1);
-        $shippingFee->setZoneCode($country?->getShippingZoneCode() ?? "ALL");
-        $shippingFee->setType($type);
-        $shippingFee->setMode($mode);
-        $shippingFee->setFee($fee);
-        $shippingFee->setMinAmount($minAmount);
-        $shippingFee->setMaxWeight($maxWeight);
-        $shippingFee->setMaxAmount($maxAmount);
-        $shippingFee->setMaxArticles($maxArticles);
-        $shippingFee->setInfo($info);
-        $shippingFee->setArchivedAt($isArchived ? new DateTime() : null);
-        $shippingFee->save();
+        $shippingOption = new ShippingOption();
+        $shippingOption->setSiteId($site?->getId() ?? 1);
+        $shippingOption->setZoneCode($country?->getShippingZoneCode() ?? "ALL");
+        $shippingOption->setType($type);
+        $shippingOption->setMode($mode);
+        $shippingOption->setFee($fee);
+        $shippingOption->setMinAmount($minAmount);
+        $shippingOption->setMaxWeight($maxWeight);
+        $shippingOption->setMaxAmount($maxAmount);
+        $shippingOption->setMaxArticles($maxArticles);
+        $shippingOption->setInfo($info);
+        $shippingOption->setArchivedAt($isArchived ? new DateTime() : null);
+        $shippingOption->save();
 
-        return $shippingFee;
+        return $shippingOption;
     }
 
     /**

--- a/src/Biblys/Test/ModelFactory.php
+++ b/src/Biblys/Test/ModelFactory.php
@@ -297,6 +297,8 @@ class ModelFactory
         ?User           $user = null,
         ?Customer       $customer = null,
         ?ShippingOption $shippingFee = null,
+        int             $amountToBePaid = 0,
+        int             $shippingCost = 0,
         ?string         $axysAccountId = null,
         ?string         $slug = null,
         string          $firstName = "Silas",
@@ -319,6 +321,8 @@ class ModelFactory
         $order = new Order();
         $order->setSite($site ?? ModelFactory::createSite());
         $order->setUser($user);
+        $order->setAmountTobepaid($amountToBePaid);
+        $order->setShippingCost($shippingCost);
         $order->setShippingId($shippingFee?->getId());
         $order->setShippingMode($shippingFee?->getType());
         $order->setType("web");

--- a/src/Framework/ArgumentResolver/PaymentServiceValueResolver.php
+++ b/src/Framework/ArgumentResolver/PaymentServiceValueResolver.php
@@ -24,6 +24,7 @@ use Biblys\Service\LoggerService;
 use Biblys\Service\PaymentService;
 use Exception;
 use Generator;
+use Stripe\StripeClient;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Controller\ArgumentValueResolverInterface;
 use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
@@ -51,6 +52,13 @@ class PaymentServiceValueResolver implements ArgumentValueResolverInterface
         $currentSite = CurrentSite::buildFromConfig($config);
         $loggerService = new LoggerService();
 
-        yield new PaymentService($config, $currentSite, $urlGenerator, $loggerService);
+        $stripe = null;
+        if ($config->isStripeEnabled()) {
+            $stripe = new StripeClient([
+                "api_key" => $config->get("stripe.secret_key"),
+            ]);
+        }
+
+        yield new PaymentService($config, $currentSite, $urlGenerator, $loggerService, $stripe);
     }
 }

--- a/tests/ApiBundle/Controller/OrderControllerTest.php
+++ b/tests/ApiBundle/Controller/OrderControllerTest.php
@@ -46,10 +46,10 @@ class OrderControllerTest extends TestCase
         $controller = new OrderController();
 
         $site = ModelFactory::createSite();
-        $shippingFee = ModelFactory::createShippingFee(site: $site, type: "mondial-relay");
+        $shippingFee = ModelFactory::createShippingOption(site: $site, type: "mondial-relay");
         $order = ModelFactory::createOrder(
             site: $site,
-            shippingFee: $shippingFee,
+            shippingOption: $shippingFee,
             firstName: "Éléonore",
             lastName: "Champollion",
             postalCode: "02330",

--- a/tests/ApiBundle/Controller/ShippingControllerTest.php
+++ b/tests/ApiBundle/Controller/ShippingControllerTest.php
@@ -167,7 +167,7 @@ class ShippingControllerTest extends TestCase
         $controller = new ShippingController();
         $content = '{"id":"","mode":"Colissimo","type":"suivi","zone":"OM2","max_weight":"21","min_amount":"71","max_amount":"76","max_articles":"90","fee":"57","info":"Expedition sous 72h"}';
         $request = RequestFactory::createAuthRequestForAdminUser($content);
-        $shippingFee = ModelFactory::createShippingFee();
+        $shippingFee = ModelFactory::createShippingOption();
         $config = new Config();
         $currentUser = Mockery::mock(CurrentUser::class);
         $currentUser->shouldReceive("authAdmin")->once()->andReturn(true);
@@ -208,7 +208,7 @@ class ShippingControllerTest extends TestCase
         $controller = new ShippingController();
         $content = '{"id":"","mode":"Colissimo","type":"suivi","zone":"OM2","max_weight":"21","min_amount":"71","max_amount":"76","max_articles":"90","fee":"57","info":"Expedition sous 72h"}';
         $request = RequestFactory::createAuthRequestForAdminUser($content);
-        $shippingFee = ModelFactory::createShippingFee();
+        $shippingFee = ModelFactory::createShippingOption();
         $shippingFee->setSiteId(2);
         $shippingFee->save();
         $config = new Config();
@@ -233,7 +233,7 @@ class ShippingControllerTest extends TestCase
     {
         // given
         $controller = new ShippingController();
-        $shippingFee = ModelFactory::createShippingFee();
+        $shippingFee = ModelFactory::createShippingOption();
         $currentUser = Mockery::mock(CurrentUser::class);
         $currentUser->shouldReceive("authAdmin")->once()->andReturn(true);
 
@@ -259,7 +259,7 @@ class ShippingControllerTest extends TestCase
     {
         // given
         $controller = new ShippingController();
-        $shippingFee = ModelFactory::createShippingFee();
+        $shippingFee = ModelFactory::createShippingOption();
         $config = new Config();
         $currentUser = Mockery::mock(CurrentUser::class);
         $currentUser->shouldReceive("authAdmin")->once()->andReturn(true);
@@ -282,7 +282,7 @@ class ShippingControllerTest extends TestCase
     {
         // given
         $controller = new ShippingController();
-        $shippingFee = ModelFactory::createShippingFee();
+        $shippingFee = ModelFactory::createShippingOption();
         $shippingFee->setSiteId(2);
         $shippingFee->save();
         $config = new Config();
@@ -308,7 +308,7 @@ class ShippingControllerTest extends TestCase
     {
         // given
         $site = ModelFactory::createSite();
-        $shippingFee = ModelFactory::createShippingFee(
+        $shippingFee = ModelFactory::createShippingOption(
             site: $site,
             type: "suivi",
             mode: "Colissimo",
@@ -405,7 +405,7 @@ class ShippingControllerTest extends TestCase
         // given
         $config = new Config();
         $country = ModelFactory::createCountry(zone: "Z2");
-        $shippingFee = ModelFactory::createShippingFee(
+        $shippingFee = ModelFactory::createShippingOption(
             type: "Type C",
             country: $country,
             mode: "Colissimo",

--- a/tests/AppBundle/Controller/Legacy/OrderDeliveryTest.php
+++ b/tests/AppBundle/Controller/Legacy/OrderDeliveryTest.php
@@ -58,7 +58,7 @@ class OrderDeliveryTest extends TestCase
         $cart = ModelFactory::createCart(site: $site);
         $article = ModelFactory::createArticle();
         ModelFactory::createStockItem(site: $site, article: $article, cart: $cart);
-        $shipping = ModelFactory::createShippingFee(type: "suivi");
+        $shipping = ModelFactory::createShippingOption(type: "suivi");
         $_POST["order_email"] = "customer@biblys.fr";
         $_POST["order_firstname"] = "Barnabé";
         $_POST["order_lastname"] = "Famagouste";
@@ -372,7 +372,7 @@ class OrderDeliveryTest extends TestCase
         ModelFactory::createStockItem(site: $site, article: $article, cart: $cart);
         $country = ModelFactory::createCountry();
 
-        $shipping = ModelFactory::createShippingFee(type: "suivi");
+        $shipping = ModelFactory::createShippingOption(type: "suivi");
         $_POST = [
             "order_email" => "customer@biblys.fr",
             "order_firstname" => "Barnabé",
@@ -457,7 +457,7 @@ class OrderDeliveryTest extends TestCase
         ModelFactory::createStockItem(site: $site, article: $article, cart: $cart);
         $country = ModelFactory::createCountry();
 
-        $shipping = ModelFactory::createShippingFee(type: "suivi");
+        $shipping = ModelFactory::createShippingOption(type: "suivi");
         $_POST = [
             "order_email" => "customer@biblys.fr",
             "order_firstname" => "Barnabé",

--- a/tests/Biblys/Service/ConfigTest.php
+++ b/tests/Biblys/Service/ConfigTest.php
@@ -181,7 +181,7 @@ class ConfigTest extends PHPUnit\Framework\TestCase
         $this->assertTrue($isEnabled);
     }
 
-    /** isAxysEnabled */
+    /** isMondialRelayEnabled */
 
     /**
      * @throws Exception
@@ -211,6 +211,42 @@ class ConfigTest extends PHPUnit\Framework\TestCase
 
         // then
         $isEnabled = $config->isMondialRelayEnabled();
+
+        // then
+        $this->assertTrue($isEnabled);
+    }
+
+    /** isStripeEnabled */
+
+    /**
+     * @throws Exception
+     */
+    public function testIsStripeEnabledWhenDisabled(): void
+    {
+        // given
+        $config = new Config([]);
+
+        // then
+        $isEnabled = $config->isStripeEnabled();
+
+        // then
+        $this->assertFalse($isEnabled);
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testIsStripeEnabledWhenEnabled(): void
+    {
+        // given
+        $config = new Config(["stripe"  => [
+            "public_key" => "abcd",
+            "secret_key" => "1234",
+            "endpoint_secret" => "!Ù€ô",
+        ]]);
+
+        // then
+        $isEnabled = $config->isStripeEnabled();
 
         // then
         $this->assertTrue($isEnabled);

--- a/tests/Biblys/Service/PaymentServiceTest.php
+++ b/tests/Biblys/Service/PaymentServiceTest.php
@@ -189,13 +189,12 @@ class PaymentServiceTest extends TestCase
         $productService->expects("create")->with([
             "name" => "Stripe Article",
             "metadata" => ["article_id" => $article->getId()],
-        ])->andReturn((object)["id" => "prod_5678"]);
+            "default_price_data" => [
+                "unit_amount" => 999,
+                "currency" => "EUR",
+            ]
+        ])->andReturn((object) ["id" => "prod_5678", "default_price" => "price_1234"]);
         $priceService = Mockery::mock(PriceService::class);
-        $priceService->expects("create")->with([
-            "product" => "prod_5678",
-            "unit_amount" => 999,
-            "currency" => "EUR",
-        ])->andReturn((object) ["id" => "6789"]);
         $session = Mockery::mock(Session::class);
         $session->expects("offsetGet")->with("id")->andReturn(1234);
         $sessionService = Mockery::mock(SessionService::class);
@@ -203,7 +202,7 @@ class PaymentServiceTest extends TestCase
             "payment_method_types" => ["card"],
             "line_items" => [
                 [
-                    "price" => "6789",
+                    "price" => "price_1234",
                     "quantity" => 1,
                 ],
             ],
@@ -250,19 +249,19 @@ class PaymentServiceTest extends TestCase
 
         $stripe = Mockery::mock(StripeClient::class);
         $productService = Mockery::mock(ProductService::class);
+        $priceService = Mockery::mock(PriceService::class);
+
         $productService->expects("search")
             ->with(["query" => "active:'true' AND metadata['article_id']:'{$article->getId()}'"])
-            ->andReturn((object) ["data" => [ (object)["id" => "prod_1234"]]]);
+            ->andReturn((object)["data" => [(object)["id" => "prod_1234", "default_price" => "price_1234"]]]);
+        $priceService->expects("retrieve")->with("price_1234")->andReturn((object)[
+            "id" => "price_1234",
+            "unit_amount" => 999,
+        ]);
         $productService->expects("update")->with(
             "prod_1234",
-            ["name" => "Stripe Article"]
-        )->andReturn((object) ["id" => "prod_5678"]);
-        $priceService = Mockery::mock(PriceService::class);
-        $priceService->expects("create")->with([
-            "product" => "prod_5678",
-            "unit_amount" => 999,
-            "currency" => "EUR",
-        ])->andReturn((object)["id" => "6789"]);
+            ["name" => "Stripe Article", "default_price" => "price_1234"]
+        )->andReturn((object)["id" => "prod_1234", "default_price" => "price_1234"]);
         $session = Mockery::mock(Session::class);
         $session->expects("offsetGet")->with("id")->andReturn(1234);
         $sessionService = Mockery::mock(SessionService::class);
@@ -270,7 +269,79 @@ class PaymentServiceTest extends TestCase
             "payment_method_types" => ["card"],
             "line_items" => [
                 [
-                    "price" => "6789",
+                    "price" => "price_1234",
+                    "quantity" => 1,
+                ],
+            ],
+            "mode" => "payment",
+            "success_url" => "https://www.biblys.fr/order/order-slug?payed=1",
+            "cancel_url" => "https://www.biblys.fr/payment/order-slug",
+            "customer_email" => "silas.coade@example.net",
+        ])->andReturn($session);
+        $checkoutServiceFactory = Mockery::mock(CheckoutServiceFactory::class);
+        $checkoutServiceFactory->sessions = $sessionService;
+        $stripe->expects("getService")->with("products")->andReturn($productService);
+        $stripe->expects("getService")->with("prices")->andReturn($priceService);
+        $stripe->expects("getService")->with("checkout")->andReturn($checkoutServiceFactory);
+
+        $paymentService = new PaymentService($config, $currentSite, $urlGenerator, $loggerService, $stripe);
+
+        // when
+        $payment = $paymentService->createStripePaymentForOrder($order);
+
+        // then
+        $this->assertInstanceOf(Payment::class, $payment);
+        $this->assertEquals($order, $payment->getOrder());
+        $this->assertEquals("stripe", $payment->getMode());
+        $this->assertEquals(999, $payment->getAmount());
+        $this->assertEquals(1234, $payment->getProviderId());
+        $this->assertNull($payment->getExecuted());
+    }
+
+    /**
+     * @throws PropelException
+     * @throws Exception
+     */
+    public function testCreateStripePaymentForOrderForExistingProductWithUpdatedPrice()
+    {
+        // given
+        $config = new Config();
+        $order = ModelFactory::createOrder(amountToBePaid: 999);
+        $article = ModelFactory::createArticle(title: "Stripe Article");
+        ModelFactory::createStockItem(article: $article, order: $order, sellingPrice: 999);
+
+        $currentSite = Mockery::mock(CurrentSite::class);
+        $urlGenerator = Mockery::mock(UrlGenerator::class);
+        $loggerService = Mockery::mock(LoggerService::class);
+
+        $stripe = Mockery::mock(StripeClient::class);
+        $productService = Mockery::mock(ProductService::class);
+        $priceService = Mockery::mock(PriceService::class);
+
+        $productService->expects("search")
+            ->with(["query" => "active:'true' AND metadata['article_id']:'{$article->getId()}'"])
+            ->andReturn((object)["data" => [(object)["id" => "prod_1234", "default_price" => "price_1234"]]]);
+        $priceService->expects("retrieve")->with("price_1234")->andReturn((object)[
+            "id" => "price_1234",
+            "unit_amount" => 899,
+        ]);
+        $priceService->expects("create")->with([
+            "product" => "prod_1234",
+            "unit_amount" => 999,
+            "currency" => "EUR",
+        ])->andReturn((object)["id" => "price_2345"]);
+        $productService->expects("update")->with(
+            "prod_1234",
+            ["name" => "Stripe Article", "default_price" => "price_2345"]
+        )->andReturn((object)["id" => "prod_1234", "default_price" => "price_1234"]);
+        $session = Mockery::mock(Session::class);
+        $session->expects("offsetGet")->with("id")->andReturn(1234);
+        $sessionService = Mockery::mock(SessionService::class);
+        $sessionService->expects("create")->with([
+            "payment_method_types" => ["card"],
+            "line_items" => [
+                [
+                    "price" => "price_1234",
                     "quantity" => 1,
                 ],
             ],
@@ -317,25 +388,23 @@ class PaymentServiceTest extends TestCase
 
         $stripe = Mockery::mock(StripeClient::class);
         $productService = Mockery::mock(ProductService::class);
-        $productService->expects("search")
-            ->with(["query" => "active:'true' AND metadata['article_id']:'{$article->getId()}'"])
-            ->andReturn((object) ["data" => []]);
-        $productService->expects("create")->with([
-            "name" => "Stripe Article",
-            "metadata" => ["article_id" => $article->getId()],
-        ])->andReturn((object) ["id" => "prod_5678"]);
-        $productService->expects("create")->with(["name" => "Frais de port"])->andReturn((object) ["id" => 9123]);
         $priceService = Mockery::mock(PriceService::class);
-        $priceService->expects("create")->with([
-            "product" => "prod_5678",
+
+        $productService->expects("search")
+            ->andReturn((object)["data" => [(object)["id" => "prod_1234", "default_price" => "price_1234"]]]);
+        $priceService->expects("retrieve")->with("price_1234")->andReturn((object)[
+            "id" => "price_1234",
             "unit_amount" => 999,
-            "currency" => "EUR",
-        ])->andReturn((object) ["id" => "6789"]);
+        ]);
+        $productService->expects("update")
+            ->andReturn((object)["id" => "prod_1234", "default_price" => "price_1234"]);
+        $productService->expects("create")->with(["name" => "Frais de port"])
+            ->andReturn((object)["id" => "prod_9123"]);
         $priceService->expects("create")->with([
-            "product" => 9123,
+            "product" => "prod_9123",
             "unit_amount" => 499,
             "currency" => "EUR",
-        ])->andReturn((object) ["id" => "3456"]);
+        ])->andReturn((object)["id" => "price_5678"]);
         $session = Mockery::mock(Session::class);
         $session->expects("offsetGet")->with("id")->andReturn(1234);
         $sessionService = Mockery::mock(SessionService::class);
@@ -343,10 +412,10 @@ class PaymentServiceTest extends TestCase
             "payment_method_types" => ["card"],
             "line_items" => [
                 [
-                    "price" => "6789",
+                    "price" => "price_1234",
                     "quantity" => 1,
-                ],[
-                    "price" => "3456",
+                ], [
+                    "price" => "price_5678",
                     "quantity" => 1,
                 ],
             ],

--- a/tests/Biblys/Service/PaymentServiceTest.php
+++ b/tests/Biblys/Service/PaymentServiceTest.php
@@ -183,6 +183,9 @@ class PaymentServiceTest extends TestCase
 
         $stripe = Mockery::mock(StripeClient::class);
         $productService = Mockery::mock(ProductService::class);
+        $priceService = Mockery::mock(PriceService::class);
+        $sessionService = Mockery::mock(SessionService::class);
+
         $productService->expects("search")
             ->with(["query" => "active:'true' AND metadata['article_id']:'{$article->getId()}'"])
             ->andReturn((object)["data" => []]);
@@ -194,10 +197,6 @@ class PaymentServiceTest extends TestCase
                 "currency" => "EUR",
             ]
         ])->andReturn((object) ["id" => "prod_5678", "default_price" => "price_1234"]);
-        $priceService = Mockery::mock(PriceService::class);
-        $session = Mockery::mock(Session::class);
-        $session->expects("offsetGet")->with("id")->andReturn(1234);
-        $sessionService = Mockery::mock(SessionService::class);
         $sessionService->expects("create")->with([
             "payment_method_types" => ["card"],
             "line_items" => [
@@ -210,7 +209,7 @@ class PaymentServiceTest extends TestCase
             "success_url" => "https://www.biblys.fr/order/order-slug?payed=1",
             "cancel_url" => "https://www.biblys.fr/payment/order-slug",
             "customer_email" => "silas.coade@example.net",
-        ])->andReturn($session);
+        ])->andReturn((object)["id" => "cs_1234"]);
         $checkoutServiceFactory = Mockery::mock(CheckoutServiceFactory::class);
         $checkoutServiceFactory->sessions = $sessionService;
         $stripe->expects("getService")->with("products")->andReturn($productService);
@@ -227,7 +226,7 @@ class PaymentServiceTest extends TestCase
         $this->assertEquals($order, $payment->getOrder());
         $this->assertEquals("stripe", $payment->getMode());
         $this->assertEquals(999, $payment->getAmount());
-        $this->assertEquals(1234, $payment->getProviderId());
+        $this->assertEquals("cs_1234", $payment->getProviderId());
         $this->assertNull($payment->getExecuted());
     }
 
@@ -250,6 +249,7 @@ class PaymentServiceTest extends TestCase
         $stripe = Mockery::mock(StripeClient::class);
         $productService = Mockery::mock(ProductService::class);
         $priceService = Mockery::mock(PriceService::class);
+        $sessionService = Mockery::mock(SessionService::class);
 
         $productService->expects("search")
             ->with(["query" => "active:'true' AND metadata['article_id']:'{$article->getId()}'"])
@@ -262,9 +262,6 @@ class PaymentServiceTest extends TestCase
             "prod_1234",
             ["name" => "Stripe Article", "default_price" => "price_1234"]
         )->andReturn((object)["id" => "prod_1234", "default_price" => "price_1234"]);
-        $session = Mockery::mock(Session::class);
-        $session->expects("offsetGet")->with("id")->andReturn(1234);
-        $sessionService = Mockery::mock(SessionService::class);
         $sessionService->expects("create")->with([
             "payment_method_types" => ["card"],
             "line_items" => [
@@ -277,7 +274,7 @@ class PaymentServiceTest extends TestCase
             "success_url" => "https://www.biblys.fr/order/order-slug?payed=1",
             "cancel_url" => "https://www.biblys.fr/payment/order-slug",
             "customer_email" => "silas.coade@example.net",
-        ])->andReturn($session);
+        ])->andReturn((object)["id" => "cs_1234"]);
         $checkoutServiceFactory = Mockery::mock(CheckoutServiceFactory::class);
         $checkoutServiceFactory->sessions = $sessionService;
         $stripe->expects("getService")->with("products")->andReturn($productService);
@@ -294,7 +291,7 @@ class PaymentServiceTest extends TestCase
         $this->assertEquals($order, $payment->getOrder());
         $this->assertEquals("stripe", $payment->getMode());
         $this->assertEquals(999, $payment->getAmount());
-        $this->assertEquals(1234, $payment->getProviderId());
+        $this->assertEquals("cs_1234", $payment->getProviderId());
         $this->assertNull($payment->getExecuted());
     }
 
@@ -317,6 +314,7 @@ class PaymentServiceTest extends TestCase
         $stripe = Mockery::mock(StripeClient::class);
         $productService = Mockery::mock(ProductService::class);
         $priceService = Mockery::mock(PriceService::class);
+        $sessionService = Mockery::mock(SessionService::class);
 
         $productService->expects("search")
             ->with(["query" => "active:'true' AND metadata['article_id']:'{$article->getId()}'"])
@@ -334,9 +332,6 @@ class PaymentServiceTest extends TestCase
             "prod_1234",
             ["name" => "Stripe Article", "default_price" => "price_2345"]
         )->andReturn((object)["id" => "prod_1234", "default_price" => "price_1234"]);
-        $session = Mockery::mock(Session::class);
-        $session->expects("offsetGet")->with("id")->andReturn(1234);
-        $sessionService = Mockery::mock(SessionService::class);
         $sessionService->expects("create")->with([
             "payment_method_types" => ["card"],
             "line_items" => [
@@ -349,7 +344,7 @@ class PaymentServiceTest extends TestCase
             "success_url" => "https://www.biblys.fr/order/order-slug?payed=1",
             "cancel_url" => "https://www.biblys.fr/payment/order-slug",
             "customer_email" => "silas.coade@example.net",
-        ])->andReturn($session);
+        ])->andReturn((object)["id" => "cs_1234"]);
         $checkoutServiceFactory = Mockery::mock(CheckoutServiceFactory::class);
         $checkoutServiceFactory->sessions = $sessionService;
         $stripe->expects("getService")->with("products")->andReturn($productService);
@@ -366,7 +361,7 @@ class PaymentServiceTest extends TestCase
         $this->assertEquals($order, $payment->getOrder());
         $this->assertEquals("stripe", $payment->getMode());
         $this->assertEquals(999, $payment->getAmount());
-        $this->assertEquals(1234, $payment->getProviderId());
+        $this->assertEquals("cs_1234", $payment->getProviderId());
         $this->assertNull($payment->getExecuted());
     }
 
@@ -389,6 +384,7 @@ class PaymentServiceTest extends TestCase
         $stripe = Mockery::mock(StripeClient::class);
         $productService = Mockery::mock(ProductService::class);
         $priceService = Mockery::mock(PriceService::class);
+        $sessionService = Mockery::mock(SessionService::class);
 
         $productService->expects("search")
             ->andReturn((object)["data" => [(object)["id" => "prod_1234", "default_price" => "price_1234"]]]);
@@ -405,9 +401,6 @@ class PaymentServiceTest extends TestCase
             "unit_amount" => 499,
             "currency" => "EUR",
         ])->andReturn((object)["id" => "price_5678"]);
-        $session = Mockery::mock(Session::class);
-        $session->expects("offsetGet")->with("id")->andReturn(1234);
-        $sessionService = Mockery::mock(SessionService::class);
         $sessionService->expects("create")->with([
             "payment_method_types" => ["card"],
             "line_items" => [
@@ -423,7 +416,7 @@ class PaymentServiceTest extends TestCase
             "success_url" => "https://www.biblys.fr/order/order-slug?payed=1",
             "cancel_url" => "https://www.biblys.fr/payment/order-slug",
             "customer_email" => "silas.coade@example.net",
-        ])->andReturn($session);
+        ])->andReturn((object)["id" => "cs_1234"]);
         $checkoutServiceFactory = Mockery::mock(CheckoutServiceFactory::class);
         $checkoutServiceFactory->sessions = $sessionService;
         $stripe->expects("getService")->with("products")->andReturn($productService);

--- a/tests/Biblys/Service/PaymentServiceTest.php
+++ b/tests/Biblys/Service/PaymentServiceTest.php
@@ -25,8 +25,15 @@ use DateTime;
 use Exception;
 use Mockery;
 use Model\OrderQuery;
+use Model\Payment;
 use PHPUnit\Framework\TestCase;
 use Propel\Runtime\Exception\PropelException;
+use Stripe\Checkout\Session;
+use Stripe\Service\Checkout\CheckoutServiceFactory;
+use Stripe\Service\Checkout\SessionService;
+use Stripe\Service\PriceService;
+use Stripe\Service\ProductService;
+use Stripe\StripeClient;
 use Symfony\Component\Routing\Generator\UrlGenerator;
 
 class PaymentServiceTest extends TestCase
@@ -38,6 +45,8 @@ class PaymentServiceTest extends TestCase
     {
         OrderQuery::create()->deleteAll();
     }
+
+    /** getPayableOrderBySlug */
 
     /**
      * @throws PropelException
@@ -131,4 +140,157 @@ class PaymentServiceTest extends TestCase
         // then
         $this->assertEquals($order, $returnedOrder);
     }
+
+    /** createStripePaymentForOrder */
+
+    /**
+     * @throws PropelException
+     * @throws Exception
+     */
+    public function testCreateStripePaymentForOrderWithoutStripeClient()
+    {
+        // given
+        $config = new Config();
+        $currentSite = Mockery::mock(CurrentSite::class);
+        $urlGenerator = Mockery::mock(UrlGenerator::class);
+        $loggerService = Mockery::mock(LoggerService::class);
+        $paymentService = new PaymentService($config, $currentSite, $urlGenerator, $loggerService);
+        $order = ModelFactory::createOrder();
+
+        // when
+        $exception = Helpers::runAndCatchException(fn() => $paymentService->createStripePaymentForOrder($order));
+
+        // then
+        $this->assertInstanceOf(Exception::class, $exception);
+        $this->assertEquals("Stripe n’est pas configuré.", $exception->getMessage());
+    }
+
+    /**
+     * @throws PropelException
+     * @throws Exception
+     */
+    public function testCreateStripePaymentForOrder()
+    {
+        // given
+        $config = new Config();
+        $order = ModelFactory::createOrder(amountToBePaid: 999);
+        $article = ModelFactory::createArticle(title: "Stripe Article");
+        ModelFactory::createStockItem(article: $article, order: $order, sellingPrice: 999);
+
+        $currentSite = Mockery::mock(CurrentSite::class);
+        $urlGenerator = Mockery::mock(UrlGenerator::class);
+        $loggerService = Mockery::mock(LoggerService::class);
+
+        $stripe = Mockery::mock(StripeClient::class);
+        $productService = Mockery::mock(ProductService::class);
+        $productService->expects("create")->with(["name" => "Stripe Article"])->andReturn((object) ["id" => 5678]);
+        $priceService = Mockery::mock(PriceService::class);
+        $priceService->expects("create")->with([
+            "product" => 5678,
+            "unit_amount" => 999,
+            "currency" => "EUR",
+        ])->andReturn((object)["id" => "6789"]);
+        $session = Mockery::mock(Session::class);
+        $session->expects("offsetGet")->with("id")->andReturn(1234);
+        $sessionService = Mockery::mock(SessionService::class);
+        $sessionService->expects("create")->with([
+            "payment_method_types" => ["card"],
+            "line_items" => [
+                [
+                    "price" => "6789",
+                    "quantity" => 1,
+                ],
+            ],
+            "mode" => "payment",
+            "success_url" => "https://www.biblys.fr/order/order-slug?payed=1",
+            "cancel_url" => "https://www.biblys.fr/payment/order-slug",
+            "customer_email" => "silas.coade@example.net",
+        ])->andReturn($session);
+        $checkoutServiceFactory = Mockery::mock(CheckoutServiceFactory::class);
+        $checkoutServiceFactory->sessions = $sessionService;
+        $stripe->expects("getService")->with("products")->andReturn($productService);
+        $stripe->expects("getService")->with("prices")->andReturn($priceService);
+        $stripe->expects("getService")->with("checkout")->andReturn($checkoutServiceFactory);
+
+        $paymentService = new PaymentService($config, $currentSite, $urlGenerator, $loggerService, $stripe);
+
+        // when
+        $payment = $paymentService->createStripePaymentForOrder($order);
+
+        // then
+        $this->assertInstanceOf(Payment::class, $payment);
+        $this->assertEquals($order, $payment->getOrder());
+        $this->assertEquals("stripe", $payment->getMode());
+        $this->assertEquals(999, $payment->getAmount());
+        $this->assertEquals(1234, $payment->getProviderId());
+        $this->assertNull($payment->getExecuted());
+    }
+
+    /**
+     * @throws PropelException
+     * @throws Exception
+     */
+    public function testCreateStripePaymentForOrderWithShipping()
+    {
+        // given
+        $config = new Config();
+        $order = ModelFactory::createOrder(amountToBePaid: 1498, shippingCost: 499);
+        $article = ModelFactory::createArticle(title: "Stripe Article");
+        ModelFactory::createStockItem(article: $article, order: $order, sellingPrice: 999);
+
+        $currentSite = Mockery::mock(CurrentSite::class);
+        $urlGenerator = Mockery::mock(UrlGenerator::class);
+        $loggerService = Mockery::mock(LoggerService::class);
+
+        $stripe = Mockery::mock(StripeClient::class);
+        $productService = Mockery::mock(ProductService::class);
+        $productService->expects("create")->with([
+            "name" => "Stripe Article",
+        ])->andReturn((object) ["id" => 5678]);
+        $productService->expects("create")->with(["name" => "Frais de port"])->andReturn((object) ["id" => 9123]);
+        $priceService = Mockery::mock(PriceService::class);
+        $priceService->expects("create")->with([
+            "product" => 5678,
+            "unit_amount" => 999,
+            "currency" => "EUR",
+        ])->andReturn((object) ["id" => "6789"]);
+        $priceService->expects("create")->with([
+            "product" => 9123,
+            "unit_amount" => 499,
+            "currency" => "EUR",
+        ])->andReturn((object) ["id" => "3456"]);
+        $session = Mockery::mock(Session::class);
+        $session->expects("offsetGet")->with("id")->andReturn(1234);
+        $sessionService = Mockery::mock(SessionService::class);
+        $sessionService->expects("create")->with([
+            "payment_method_types" => ["card"],
+            "line_items" => [
+                [
+                    "price" => "6789",
+                    "quantity" => 1,
+                ],[
+                    "price" => "3456",
+                    "quantity" => 1,
+                ],
+            ],
+            "mode" => "payment",
+            "success_url" => "https://www.biblys.fr/order/order-slug?payed=1",
+            "cancel_url" => "https://www.biblys.fr/payment/order-slug",
+            "customer_email" => "silas.coade@example.net",
+        ])->andReturn($session);
+        $checkoutServiceFactory = Mockery::mock(CheckoutServiceFactory::class);
+        $checkoutServiceFactory->sessions = $sessionService;
+        $stripe->expects("getService")->with("products")->andReturn($productService);
+        $stripe->expects("getService")->with("prices")->andReturn($priceService);
+        $stripe->expects("getService")->with("checkout")->andReturn($checkoutServiceFactory);
+
+        $paymentService = new PaymentService($config, $currentSite, $urlGenerator, $loggerService, $stripe);
+
+        // when
+        $payment = $paymentService->createStripePaymentForOrder($order);
+
+        // then
+        $this->assertInstanceOf(Payment::class, $payment);
+    }
+
 }

--- a/tests/Model/OrderTest.php
+++ b/tests/Model/OrderTest.php
@@ -201,8 +201,8 @@ class OrderTest extends TestCase
     public function testGetTotalAmountWithShipping(): void
     {
         // given
-        $shippingFee = ModelFactory::createShippingFee(fee: 789);
-        $order = ModelFactory::createOrder(shippingFee: $shippingFee);
+        $shippingFee = ModelFactory::createShippingOption(fee: 789);
+        $order = ModelFactory::createOrder(shippingOption: $shippingFee);
         ModelFactory::createStockItem(order: $order, sellingPrice: 123);
         ModelFactory::createStockItem(order: $order, sellingPrice: 456);
 

--- a/tests/Model/ShippingFeeQueryTest.php
+++ b/tests/Model/ShippingFeeQueryTest.php
@@ -37,7 +37,7 @@ class ShippingFeeQueryTest extends TestCase
         // given
         $site = ModelFactory::createSite();
         $country = ModelFactory::createCountry();
-        $fee = ModelFactory::createShippingFee(
+        $fee = ModelFactory::createShippingOption(
             site: $site,
             country: $country,
         );
@@ -70,12 +70,12 @@ class ShippingFeeQueryTest extends TestCase
         // given
         $site = ModelFactory::createSite();
         $country = ModelFactory::createCountry();
-        ModelFactory::createShippingFee(
+        ModelFactory::createShippingOption(
             site: $site,
             country: $country,
             maxArticles: 1
         );
-        $feeForTwoArticles = ModelFactory::createShippingFee(
+        $feeForTwoArticles = ModelFactory::createShippingOption(
             site: $site,
             country: $country,
             maxArticles: 2
@@ -109,8 +109,8 @@ class ShippingFeeQueryTest extends TestCase
         // given
         $site = ModelFactory::createSite();
         $country = ModelFactory::createCountry();
-        $archivedFee = ModelFactory::createShippingFee(site: $site, country: $country, isArchived: true);
-        $activeFee = ModelFactory::createShippingFee(site: $site, country: $country);
+        $archivedFee = ModelFactory::createShippingOption(site: $site, country: $country, isArchived: true);
+        $activeFee = ModelFactory::createShippingOption(site: $site, country: $country);
         $orderWeight = 500;
         $orderAmount = 1500;
         $currentSite = new CurrentSite($site);

--- a/tests/Model/ShippingFeeTest.php
+++ b/tests/Model/ShippingFeeTest.php
@@ -155,7 +155,7 @@ class ShippingFeeTest extends TestCase
     public function testDeleteWithoutRelatedOrders(): void
     {
         // given
-        $shippingFee = ModelFactory::createShippingFee();
+        $shippingFee = ModelFactory::createShippingOption();
 
         // when
         $shippingFee->delete();
@@ -171,8 +171,8 @@ class ShippingFeeTest extends TestCase
     public function testDeleteWithRelatedOrders(): void
     {
         // given
-        $shippingFee = ModelFactory::createShippingFee();
-        ModelFactory::createOrder(shippingFee: $shippingFee);
+        $shippingFee = ModelFactory::createShippingOption();
+        ModelFactory::createOrder(shippingOption: $shippingFee);
 
         // when
         $exception = Helpers::runAndCatchException(fn() => $shippingFee->delete());

--- a/tests/Usecase/MarkOrderAsShippedUsecaseTest.php
+++ b/tests/Usecase/MarkOrderAsShippedUsecaseTest.php
@@ -45,8 +45,8 @@ class MarkOrderAsShippedUsecaseTest extends TestCase
     public function testExecute()
     {
         // given
-        $shipping = ModelFactory::createShippingFee();
-        $order = ModelFactory::createOrder(shippingFee: $shipping, email: "customer@paronymie.fr");
+        $shipping = ModelFactory::createShippingOption();
+        $order = ModelFactory::createOrder(shippingOption: $shipping, email: "customer@paronymie.fr");
         $site = ModelFactory::createSite(domain: "paronymie-expeditions.fr");
 
         $currentSite = Mockery::mock(CurrentSite::class);
@@ -84,8 +84,8 @@ class MarkOrderAsShippedUsecaseTest extends TestCase
     public function testExecuteWithCustomShippingMessage()
     {
         // given
-        $shipping = ModelFactory::createShippingFee();
-        $order = ModelFactory::createOrder(shippingFee: $shipping, email: "customer@paronymie.fr");
+        $shipping = ModelFactory::createShippingOption();
+        $order = ModelFactory::createOrder(shippingOption: $shipping, email: "customer@paronymie.fr");
         $site = ModelFactory::createSite();
 
         $currentSite = Mockery::mock(CurrentSite::class);
@@ -121,8 +121,8 @@ class MarkOrderAsShippedUsecaseTest extends TestCase
     public function testExecuteWithTrackedShipping()
     {
         // given
-        $shipping = ModelFactory::createShippingFee(type: "suivi");
-        $order = ModelFactory::createOrder(shippingFee: $shipping, email: "customer@paronymie.fr");
+        $shipping = ModelFactory::createShippingOption(type: "suivi");
+        $order = ModelFactory::createOrder(shippingOption: $shipping, email: "customer@paronymie.fr");
         $site = ModelFactory::createSite();
 
         $currentSite = Mockery::mock(CurrentSite::class);
@@ -160,8 +160,8 @@ class MarkOrderAsShippedUsecaseTest extends TestCase
     public function testExecuteWithPickupShipping()
     {
         // given
-        $shipping = ModelFactory::createShippingFee(type: "magasin");
-        $order = ModelFactory::createOrder(shippingFee: $shipping, email: "customer@paronymie.fr");
+        $shipping = ModelFactory::createShippingOption(type: "magasin");
+        $order = ModelFactory::createOrder(shippingOption: $shipping, email: "customer@paronymie.fr");
         $site = ModelFactory::createSite();
 
         $currentSite = Mockery::mock(CurrentSite::class);


### PR DESCRIPTION
## TODO

- [x] Réutiliser et mettre à jour les produits Stripe déjà existants
- [x] Réutiliser les prix Stripe déjà existants
- [x] Vérifier le montant du prix et en créer un nouveau si besoin
- [ ] Utiliser `ShippingRate` pour les frais de port plutôt que `Product`
- [ ] Embedded form