### PR TITLE
Améliorer l'expérience de paiement avec Stripe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,11 @@
 composer propel migrate
 ```
 
+#### Stripe
+
+Ajouter l'évènement `payment_intent.succeeded` à la liste des évènements à 
+transmettre au webhook endpoint de Biblys.
+
 #### Swiper
 
 La librairie "swiper" a été supprimée. Si votre thème utilise swiper, vous

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,16 @@
 
 ## 3.5.0 (DEV)
 
-### Améliorations
+### Expérience de paiement
 
 - La page de choix d'un mode de paiement a été entièrement revue pour améliorer
   son ergonomie.
+- Le formulaire de paiement par carte bancaire via Stripe est désormais intégré
+  à la page de choix du mode de paiement de manière sécurisée, ce qui permet 
+  d'éviter une redirection vers le site de paiement.
+
+### Autres améliorations
+
 - Les "tranches de frais de port" ont été renommées "option d'expédition".
 - Des pages ont été ajoutées à l'administration pour afficher les pays de
   destination et les différentes zones tarifaires pour l'expédition.

--- a/public/assets/js/payment-methods.js
+++ b/public/assets/js/payment-methods.js
@@ -36,17 +36,17 @@ async function loadStripeForm(paymentForm) {
   });
   /**
    * @var responseData {object}
-   * @var responseData.client_secret {string} The client secret of the payment intent
+   * @var responseData.payment_intent_client_secret {string} The client secret for the payment intent
+   * @var responseData.customer_session_client_secret {string} The client secret for the customer session
    */
   const responseData = await response.json();
-  const clientSecret = responseData.client_secret;
-
-  const stripe = window.Stripe(publicKey);
-
   if (responseData.error) {
     window._alert(responseData.error.message);
   } else {
-    const elements = stripe.elements({ clientSecret });
+    const stripe = window.Stripe(publicKey);
+    const paymentIntentClientSecret = responseData.payment_intent_client_secret;
+    const customerSessionClientSecret = responseData.customer_session_client_secret;
+    const elements = stripe.elements({ clientSecret: paymentIntentClientSecret, customerSessionClientSecret });
     const paymentElement = elements.create('payment', {
       disableLink: true,
     });

--- a/public/assets/js/payment-methods.js
+++ b/public/assets/js/payment-methods.js
@@ -16,7 +16,6 @@
 
 document.addEventListener('DOMContentLoaded', function() {
   const firstPaymentOption = document.querySelector('.payment-option a');
-  console.log(firstPaymentOption);
   if (firstPaymentOption) {
     firstPaymentOption.click();
   }

--- a/schema.xml
+++ b/schema.xml
@@ -841,9 +841,12 @@
     <column name="site_id" phpName="SiteId" type="INTEGER"/>
     <column name="axys_account_id" phpName="AxysAccountId" type="INTEGER" sqlType="int unsigned"/>
     <column name="user_id" phpName="UserId" type="INTEGER" sqlType="int unsigned"/>
-    <column name="customer_id" phpName="CustomerId" type="INTEGER" sqlType="int unsigned"/>
     <foreign-key foreignTable="users" skipSql="true">
       <reference local="user_id" foreign="id"/>
+    </foreign-key>
+    <column name="customer_id" phpName="CustomerId" type="INTEGER" sqlType="int unsigned"/>
+    <foreign-key foreignTable="customers" skipSql="true">
+      <reference local="customer_id" foreign="customer_id"/>
     </foreign-key>
     <column name="seller_id" phpName="SellerId" type="INTEGER" sqlType="int unsigned"/>
     <column name="order_type" phpName="Type" type="VARCHAR" size="8" defaultValue=""/>

--- a/src/ApiBundle/Controller/PaymentController.php
+++ b/src/ApiBundle/Controller/PaymentController.php
@@ -186,12 +186,11 @@ class PaymentController extends Controller
     {
         try {
             $order = $paymentService->getPayableOrderBySlug($slug);
-            $paymentIntentClientSecret = $paymentService->createStripePaymentForOrder($order);
+            $secrets = $paymentService->createStripePaymentForOrder($order);
 
-            return new JsonResponse(["client_secret" => $paymentIntentClientSecret]);
+            return new JsonResponse($secrets);
         } catch (CannotFindPayableOrderException $exception) {
             throw new NotFoundHttpException($exception->getMessage(), $exception);
         }
-
     }
 }

--- a/src/ApiBundle/Controller/PaymentController.php
+++ b/src/ApiBundle/Controller/PaymentController.php
@@ -186,9 +186,9 @@ class PaymentController extends Controller
     {
         try {
             $order = $paymentService->getPayableOrderBySlug($slug);
-            $payment = $paymentService->createStripePaymentForOrder($order);
+            $paymentIntentClientSecret = $paymentService->createStripePaymentForOrder($order);
 
-            return new JsonResponse(["session_id" => $payment->getProviderId()]);
+            return new JsonResponse(["client_secret" => $paymentIntentClientSecret]);
         } catch (CannotFindPayableOrderException $exception) {
             throw new NotFoundHttpException($exception->getMessage(), $exception);
         }

--- a/src/AppBundle/Controller/PaymentController.php
+++ b/src/AppBundle/Controller/PaymentController.php
@@ -166,19 +166,17 @@ class PaymentController extends Controller
                 throw new BadRequestHttpException('stripe-signature header is missing');
             }
 
-            $event = Webhook::constructEvent(
-                $payload, $sigHeader, $stripe['endpoint_secret']
-            );
+            $event = Webhook::constructEvent($payload, $sigHeader, $stripe['endpoint_secret']);
 
-            if ($event->type !== 'checkout.session.completed') {
-                $loggerService->log("stripe", "INFO", 'Webhook is not of type checkout.session.completed, ignoring.');
+            if ($event->type !== "payment_intent.succeeded") {
+                $loggerService->log("stripe", "INFO", "Webhook is not of type payment_intent.succeeded, ignoring.");
                 return new JsonResponse();
             }
 
-            // Handle the checkout.session.completed event
+            // Handle the payment_intent.succeeded event
             /** @noinspection PhpPossiblePolymorphicInvocationInspection */
             $session = $event->data->object;
-            $loggerService->log("stripe", "INFO", 'Handling Checkout session…', ["id" => $session->id]);
+            $loggerService->log("stripe", "INFO", 'Handling payment intent…', ["id" => $session->id]);
 
             // Retrieve payment associated with session id
             $pm = new PaymentManager();

--- a/src/AppBundle/Resources/views/Payment/select-method.html.twig
+++ b/src/AppBundle/Resources/views/Payment/select-method.html.twig
@@ -55,20 +55,27 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
               </p>
             {% endif %}
 
-            <p>
-              Payez par carte bancaire via le serveur sécurisé de notre partenaire Stripe.
-            </p>
-
-            <button type="submit" class="btn btn-primary" id="pay-with-stripe"
-                    {% if order.amountTobepaid < 50 %}disabled{% endif %}
-                    data-payment-url="{{ path('api_stripe_create_payment', { slug: order.slug }) }}"
-                    data-public-key="{{ stripePublicKey }}"
+            <form id="stripe-payment-form"
+              data-public-key="{{ stripePublicKey }}"
+              data-payment-url="{{ path('api_stripe_create_payment', { slug: order.slug }) }}"
+              data-order-url="{{ url('legacy_order', { url: order.slug }) }}"
             >
-              Payer par carte bancaire
-              <div class="spinner-border spinner-border-sm ml-1 d-none" role="status" id="pay-with-stripe-loader">
-                <span class="sr-only">Redirection en cours...</span>
+              <div id="payment-element">
+                <span class="spinner-border spinner-border-sm ml-1" role="status" id="spinner"></span>
+                Chargement du formulaire de paiement sécurisé…
               </div>
-            </button>
+
+              <button id="stripe-payment-button" class="btn btn-primary mt-4 d-none" id="submit"
+                  {% if order.amountTobepaid < 50 %}disabled{% endif %}
+                >
+                <div class="spinner-border spinner-border-sm ml-1 d-none" role="status" id="stripe-payment-button-loader">
+                  <span class="sr-only">Paiement en cours…</span>
+                </div>
+                <span id="button-text">Payer</span>
+              </button>
+
+              <div id="payment-message" class="hidden"></div>
+            </form>
           </div>
         </div>
       </div>

--- a/src/AppBundle/Resources/views/Payment/select-method.html.twig
+++ b/src/AppBundle/Resources/views/Payment/select-method.html.twig
@@ -244,9 +244,15 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
     {% endif %}
   </div>
 
-  <script src="https://js.stripe.com/v3/"></script>
-  <script
-    src="https://www.paypal.com/sdk/js?components=buttons&disable-funding=card&client-id={{ paypalClientId }}&currency=EUR">
-  </script>
+  {% if stripeIsAvailable %}
+    <script src="https://js.stripe.com/v3/"></script>
+  {% endif %}
+
+  {% if paypalIsAvailable %}
+    <script
+      src="https://www.paypal.com/sdk/js?components=buttons&disable-funding=card&client-id={{ paypalClientId }}&currency=EUR">
+    </script>
+  {% endif %}
+
   <script src="{{ asset('/assets/js/payment-methods.js') }}"></script>
 {% endblock %}

--- a/src/Biblys/Service/PaymentService.php
+++ b/src/Biblys/Service/PaymentService.php
@@ -32,6 +32,7 @@ use Payplug\Payplug;
 use Propel\Runtime\Exception\PropelException;
 use Stripe\Customer as StripeCustomer;
 use Stripe\Exception\ApiErrorException;
+use Stripe\PaymentIntent;
 use Stripe\StripeClient;
 use Symfony\Component\Routing\Generator\UrlGenerator;
 
@@ -249,5 +250,27 @@ class PaymentService
         }
 
         return $this->stripe->customers->retrieve($searchResults->data[0]->id);
+    }
+
+    /**
+     * @throws InvalidConfigurationException
+     * @throws ApiErrorException
+     */
+    public function createStripePaymentIntentForOrder(Order $order, StripeCustomer $customer): PaymentIntent
+    {
+        if (!$this->stripe) {
+            throw new InvalidConfigurationException("Stripe n’est pas configuré.");
+        }
+
+        return $this->stripe->paymentIntents->create([
+            "amount" => $order->getAmountTobepaid(),
+            "currency" => "eur",
+            "customer" => $customer->id,
+            "payment_method_types" => ["card"],
+            "metadata" => [
+                "order_id" => $order->getId(),
+            ],
+        ]);
+
     }
 }

--- a/src/Biblys/Test/EntityFactory.php
+++ b/src/Biblys/Test/EntityFactory.php
@@ -187,7 +187,7 @@ class EntityFactory
         int    $fee = 100,
     ): Shipping
     {
-        $shipping = ModelFactory::createShippingFee(
+        $shipping = ModelFactory::createShippingOption(
             type: $type,
             mode: $mode,
             fee: $fee,

--- a/src/Biblys/Test/ModelFactory.php
+++ b/src/Biblys/Test/ModelFactory.php
@@ -734,6 +734,9 @@ class ModelFactory
         ?Site   $site = null,
         ?User   $user = null,
         ?string $axysAccountId = null,
+        string  $firstName = "Silas",
+        string  $lastName = "Coade",
+        string  $email = "silas.coade@example.net",
     ): Customer
     {
         $customer = new Customer();
@@ -741,6 +744,9 @@ class ModelFactory
         $customer->setSite($site);
         $customer->setUser($user);
         $customer->setAxysAccountId($axysAccountId);
+        $customer->setFirstname($firstName);
+        $customer->setLastname($lastName);
+        $customer->setEmail($email);
         $customer->save();
 
         return $customer;

--- a/src/Biblys/Test/ModelFactory.php
+++ b/src/Biblys/Test/ModelFactory.php
@@ -296,7 +296,7 @@ class ModelFactory
         ?Site           $site = null,
         ?User           $user = null,
         ?Customer       $customer = null,
-        ?ShippingOption $shippingFee = null,
+        ?ShippingOption $shippingOption = null,
         int             $amountToBePaid = 0,
         int             $shippingCost = 0,
         ?string         $axysAccountId = null,
@@ -323,8 +323,8 @@ class ModelFactory
         $order->setUser($user);
         $order->setAmountTobepaid($amountToBePaid);
         $order->setShippingCost($shippingCost);
-        $order->setShippingId($shippingFee?->getId());
-        $order->setShippingMode($shippingFee?->getType());
+        $order->setShippingId($shippingOption?->getId());
+        $order->setShippingMode($shippingOption?->getType());
         $order->setType("web");
         $order->setAxysAccountId($axysAccountId);
         $order->setSlug($slug ?? "order-slug");
@@ -513,7 +513,7 @@ class ModelFactory
     /**
      * @throws PropelException
      */
-    public static function createShippingFee(
+    public static function createShippingOption(
         ?Site    $site = null,
         string   $type = "normal",
         ?Country $country = null,
@@ -527,21 +527,21 @@ class ModelFactory
         bool     $isArchived = false,
     ): ShippingOption
     {
-        $shippingFee = new ShippingOption();
-        $shippingFee->setSiteId($site?->getId() ?? 1);
-        $shippingFee->setZoneCode($country?->getShippingZoneCode() ?? "ALL");
-        $shippingFee->setType($type);
-        $shippingFee->setMode($mode);
-        $shippingFee->setFee($fee);
-        $shippingFee->setMinAmount($minAmount);
-        $shippingFee->setMaxWeight($maxWeight);
-        $shippingFee->setMaxAmount($maxAmount);
-        $shippingFee->setMaxArticles($maxArticles);
-        $shippingFee->setInfo($info);
-        $shippingFee->setArchivedAt($isArchived ? new DateTime() : null);
-        $shippingFee->save();
+        $shippingOption = new ShippingOption();
+        $shippingOption->setSiteId($site?->getId() ?? 1);
+        $shippingOption->setZoneCode($country?->getShippingZoneCode() ?? "ALL");
+        $shippingOption->setType($type);
+        $shippingOption->setMode($mode);
+        $shippingOption->setFee($fee);
+        $shippingOption->setMinAmount($minAmount);
+        $shippingOption->setMaxWeight($maxWeight);
+        $shippingOption->setMaxAmount($maxAmount);
+        $shippingOption->setMaxArticles($maxArticles);
+        $shippingOption->setInfo($info);
+        $shippingOption->setArchivedAt($isArchived ? new DateTime() : null);
+        $shippingOption->save();
 
-        return $shippingFee;
+        return $shippingOption;
     }
 
     /**

--- a/src/Model/Base/Country.php
+++ b/src/Model/Base/Country.php
@@ -1716,6 +1716,32 @@ abstract class Country implements ActiveRecordInterface
      * @return ObjectCollection|ChildOrder[] List of ChildOrder objects
      * @phpstan-return ObjectCollection&\Traversable<ChildOrder}> List of ChildOrder objects
      */
+    public function getOrdersJoinCustomer(?Criteria $criteria = null, ?ConnectionInterface $con = null, $joinBehavior = Criteria::LEFT_JOIN)
+    {
+        $query = ChildOrderQuery::create(null, $criteria);
+        $query->joinWith('Customer', $joinBehavior);
+
+        return $this->getOrders($query, $con);
+    }
+
+
+    /**
+     * If this collection has already been initialized with
+     * an identical criteria, it returns the collection.
+     * Otherwise if this Country is new, it will return
+     * an empty collection; or if this Country has previously
+     * been saved, it will retrieve related Orders from storage.
+     *
+     * This method is protected by default in order to keep the public
+     * api reasonable.  You can provide public methods for those you
+     * actually need in Country.
+     *
+     * @param Criteria $criteria optional Criteria object to narrow the query
+     * @param ConnectionInterface $con optional connection object
+     * @param string $joinBehavior optional join type to use (defaults to Criteria::LEFT_JOIN)
+     * @return ObjectCollection|ChildOrder[] List of ChildOrder objects
+     * @phpstan-return ObjectCollection&\Traversable<ChildOrder}> List of ChildOrder objects
+     */
     public function getOrdersJoinShippingOption(?Criteria $criteria = null, ?ConnectionInterface $con = null, $joinBehavior = Criteria::LEFT_JOIN)
     {
         $query = ChildOrderQuery::create(null, $criteria);

--- a/src/Model/Base/CustomerQuery.php
+++ b/src/Model/Base/CustomerQuery.php
@@ -79,7 +79,17 @@ use Propel\Runtime\Exception\PropelException;
  * @method     ChildCustomerQuery rightJoinWithUser() Adds a RIGHT JOIN clause and with to the query using the User relation
  * @method     ChildCustomerQuery innerJoinWithUser() Adds a INNER JOIN clause and with to the query using the User relation
  *
- * @method     \Model\SiteQuery|\Model\UserQuery endUse() Finalizes a secondary criteria and merges it with its primary Criteria
+ * @method     ChildCustomerQuery leftJoinOrder($relationAlias = null) Adds a LEFT JOIN clause to the query using the Order relation
+ * @method     ChildCustomerQuery rightJoinOrder($relationAlias = null) Adds a RIGHT JOIN clause to the query using the Order relation
+ * @method     ChildCustomerQuery innerJoinOrder($relationAlias = null) Adds a INNER JOIN clause to the query using the Order relation
+ *
+ * @method     ChildCustomerQuery joinWithOrder($joinType = Criteria::INNER_JOIN) Adds a join clause and with to the query using the Order relation
+ *
+ * @method     ChildCustomerQuery leftJoinWithOrder() Adds a LEFT JOIN clause and with to the query using the Order relation
+ * @method     ChildCustomerQuery rightJoinWithOrder() Adds a RIGHT JOIN clause and with to the query using the Order relation
+ * @method     ChildCustomerQuery innerJoinWithOrder() Adds a INNER JOIN clause and with to the query using the Order relation
+ *
+ * @method     \Model\SiteQuery|\Model\UserQuery|\Model\OrderQuery endUse() Finalizes a secondary criteria and merges it with its primary Criteria
  *
  * @method     ChildCustomer|null findOne(?ConnectionInterface $con = null) Return the first ChildCustomer matching the query
  * @method     ChildCustomer findOneOrCreate(?ConnectionInterface $con = null) Return the first ChildCustomer matching the query, or a new ChildCustomer object populated from the query conditions when no match is found
@@ -1276,6 +1286,179 @@ abstract class CustomerQuery extends ModelCriteria
     {
         /** @var $q \Model\UserQuery */
         $q = $this->useInQuery('User', $modelAlias, $queryClass, 'NOT IN');
+        return $q;
+    }
+
+    /**
+     * Filter the query by a related \Model\Order object
+     *
+     * @param \Model\Order|ObjectCollection $order the related object to use as filter
+     * @param string|null $comparison Operator to use for the column comparison, defaults to Criteria::EQUAL
+     *
+     * @return $this The current query, for fluid interface
+     */
+    public function filterByOrder($order, ?string $comparison = null)
+    {
+        if ($order instanceof \Model\Order) {
+            $this
+                ->addUsingAlias(CustomerTableMap::COL_CUSTOMER_ID, $order->getCustomerId(), $comparison);
+
+            return $this;
+        } elseif ($order instanceof ObjectCollection) {
+            $this
+                ->useOrderQuery()
+                ->filterByPrimaryKeys($order->getPrimaryKeys())
+                ->endUse();
+
+            return $this;
+        } else {
+            throw new PropelException('filterByOrder() only accepts arguments of type \Model\Order or Collection');
+        }
+    }
+
+    /**
+     * Adds a JOIN clause to the query using the Order relation
+     *
+     * @param string|null $relationAlias Optional alias for the relation
+     * @param string|null $joinType Accepted values are null, 'left join', 'right join', 'inner join'
+     *
+     * @return $this The current query, for fluid interface
+     */
+    public function joinOrder(?string $relationAlias = null, ?string $joinType = Criteria::LEFT_JOIN)
+    {
+        $tableMap = $this->getTableMap();
+        $relationMap = $tableMap->getRelation('Order');
+
+        // create a ModelJoin object for this join
+        $join = new ModelJoin();
+        $join->setJoinType($joinType);
+        $join->setRelationMap($relationMap, $this->useAliasInSQL ? $this->getModelAlias() : null, $relationAlias);
+        if ($previousJoin = $this->getPreviousJoin()) {
+            $join->setPreviousJoin($previousJoin);
+        }
+
+        // add the ModelJoin to the current object
+        if ($relationAlias) {
+            $this->addAlias($relationAlias, $relationMap->getRightTable()->getName());
+            $this->addJoinObject($join, $relationAlias);
+        } else {
+            $this->addJoinObject($join, 'Order');
+        }
+
+        return $this;
+    }
+
+    /**
+     * Use the Order relation Order object
+     *
+     * @see useQuery()
+     *
+     * @param string $relationAlias optional alias for the relation,
+     *                                   to be used as main alias in the secondary query
+     * @param string $joinType Accepted values are null, 'left join', 'right join', 'inner join'
+     *
+     * @return \Model\OrderQuery A secondary query class using the current class as primary query
+     */
+    public function useOrderQuery($relationAlias = null, $joinType = Criteria::LEFT_JOIN)
+    {
+        return $this
+            ->joinOrder($relationAlias, $joinType)
+            ->useQuery($relationAlias ? $relationAlias : 'Order', '\Model\OrderQuery');
+    }
+
+    /**
+     * Use the Order relation Order object
+     *
+     * @param callable(\Model\OrderQuery):\Model\OrderQuery $callable A function working on the related query
+     *
+     * @param string|null $relationAlias optional alias for the relation
+     *
+     * @param string|null $joinType Accepted values are null, 'left join', 'right join', 'inner join'
+     *
+     * @return $this
+     */
+    public function withOrderQuery(
+        callable $callable,
+        string $relationAlias = null,
+        ?string $joinType = Criteria::LEFT_JOIN
+    ) {
+        $relatedQuery = $this->useOrderQuery(
+            $relationAlias,
+            $joinType
+        );
+        $callable($relatedQuery);
+        $relatedQuery->endUse();
+
+        return $this;
+    }
+
+    /**
+     * Use the relation to Order table for an EXISTS query.
+     *
+     * @see \Propel\Runtime\ActiveQuery\ModelCriteria::useExistsQuery()
+     *
+     * @param string|null $modelAlias sets an alias for the nested query
+     * @param string|null $queryClass Allows to use a custom query class for the exists query, like ExtendedBookQuery::class
+     * @param string $typeOfExists Either ExistsQueryCriterion::TYPE_EXISTS or ExistsQueryCriterion::TYPE_NOT_EXISTS
+     *
+     * @return \Model\OrderQuery The inner query object of the EXISTS statement
+     */
+    public function useOrderExistsQuery($modelAlias = null, $queryClass = null, $typeOfExists = 'EXISTS')
+    {
+        /** @var $q \Model\OrderQuery */
+        $q = $this->useExistsQuery('Order', $modelAlias, $queryClass, $typeOfExists);
+        return $q;
+    }
+
+    /**
+     * Use the relation to Order table for a NOT EXISTS query.
+     *
+     * @see useOrderExistsQuery()
+     *
+     * @param string|null $modelAlias sets an alias for the nested query
+     * @param string|null $queryClass Allows to use a custom query class for the exists query, like ExtendedBookQuery::class
+     *
+     * @return \Model\OrderQuery The inner query object of the NOT EXISTS statement
+     */
+    public function useOrderNotExistsQuery($modelAlias = null, $queryClass = null)
+    {
+        /** @var $q \Model\OrderQuery */
+        $q = $this->useExistsQuery('Order', $modelAlias, $queryClass, 'NOT EXISTS');
+        return $q;
+    }
+
+    /**
+     * Use the relation to Order table for an IN query.
+     *
+     * @see \Propel\Runtime\ActiveQuery\ModelCriteria::useInQuery()
+     *
+     * @param string|null $modelAlias sets an alias for the nested query
+     * @param string|null $queryClass Allows to use a custom query class for the IN query, like ExtendedBookQuery::class
+     * @param string $typeOfIn Criteria::IN or Criteria::NOT_IN
+     *
+     * @return \Model\OrderQuery The inner query object of the IN statement
+     */
+    public function useInOrderQuery($modelAlias = null, $queryClass = null, $typeOfIn = 'IN')
+    {
+        /** @var $q \Model\OrderQuery */
+        $q = $this->useInQuery('Order', $modelAlias, $queryClass, $typeOfIn);
+        return $q;
+    }
+
+    /**
+     * Use the relation to Order table for a NOT IN query.
+     *
+     * @see useOrderInQuery()
+     *
+     * @param string|null $modelAlias sets an alias for the nested query
+     * @param string|null $queryClass Allows to use a custom query class for the NOT IN query, like ExtendedBookQuery::class
+     *
+     * @return \Model\OrderQuery The inner query object of the NOT IN statement
+     */
+    public function useNotInOrderQuery($modelAlias = null, $queryClass = null)
+    {
+        /** @var $q \Model\OrderQuery */
+        $q = $this->useInQuery('Order', $modelAlias, $queryClass, 'NOT IN');
         return $q;
     }
 

--- a/src/Model/Base/OrderQuery.php
+++ b/src/Model/Base/OrderQuery.php
@@ -137,6 +137,16 @@ use Propel\Runtime\Exception\PropelException;
  * @method     ChildOrderQuery rightJoinWithUser() Adds a RIGHT JOIN clause and with to the query using the User relation
  * @method     ChildOrderQuery innerJoinWithUser() Adds a INNER JOIN clause and with to the query using the User relation
  *
+ * @method     ChildOrderQuery leftJoinCustomer($relationAlias = null) Adds a LEFT JOIN clause to the query using the Customer relation
+ * @method     ChildOrderQuery rightJoinCustomer($relationAlias = null) Adds a RIGHT JOIN clause to the query using the Customer relation
+ * @method     ChildOrderQuery innerJoinCustomer($relationAlias = null) Adds a INNER JOIN clause to the query using the Customer relation
+ *
+ * @method     ChildOrderQuery joinWithCustomer($joinType = Criteria::INNER_JOIN) Adds a join clause and with to the query using the Customer relation
+ *
+ * @method     ChildOrderQuery leftJoinWithCustomer() Adds a LEFT JOIN clause and with to the query using the Customer relation
+ * @method     ChildOrderQuery rightJoinWithCustomer() Adds a RIGHT JOIN clause and with to the query using the Customer relation
+ * @method     ChildOrderQuery innerJoinWithCustomer() Adds a INNER JOIN clause and with to the query using the Customer relation
+ *
  * @method     ChildOrderQuery leftJoinShippingOption($relationAlias = null) Adds a LEFT JOIN clause to the query using the ShippingOption relation
  * @method     ChildOrderQuery rightJoinShippingOption($relationAlias = null) Adds a RIGHT JOIN clause to the query using the ShippingOption relation
  * @method     ChildOrderQuery innerJoinShippingOption($relationAlias = null) Adds a INNER JOIN clause to the query using the ShippingOption relation
@@ -187,7 +197,7 @@ use Propel\Runtime\Exception\PropelException;
  * @method     ChildOrderQuery rightJoinWithStockItem() Adds a RIGHT JOIN clause and with to the query using the StockItem relation
  * @method     ChildOrderQuery innerJoinWithStockItem() Adds a INNER JOIN clause and with to the query using the StockItem relation
  *
- * @method     \Model\UserQuery|\Model\ShippingOptionQuery|\Model\CountryQuery|\Model\SiteQuery|\Model\PaymentQuery|\Model\StockQuery endUse() Finalizes a secondary criteria and merges it with its primary Criteria
+ * @method     \Model\UserQuery|\Model\CustomerQuery|\Model\ShippingOptionQuery|\Model\CountryQuery|\Model\SiteQuery|\Model\PaymentQuery|\Model\StockQuery endUse() Finalizes a secondary criteria and merges it with its primary Criteria
  *
  * @method     ChildOrder|null findOne(?ConnectionInterface $con = null) Return the first ChildOrder matching the query
  * @method     ChildOrder findOneOrCreate(?ConnectionInterface $con = null) Return the first ChildOrder matching the query, or a new ChildOrder object populated from the query conditions when no match is found
@@ -802,6 +812,8 @@ abstract class OrderQuery extends ModelCriteria
      * $query->filterByCustomerId(array(12, 34)); // WHERE customer_id IN (12, 34)
      * $query->filterByCustomerId(array('min' => 12)); // WHERE customer_id > 12
      * </code>
+     *
+     * @see       filterByCustomer()
      *
      * @param mixed $customerId The value to use as filter.
      *              Use scalar values for equality.
@@ -2594,6 +2606,181 @@ abstract class OrderQuery extends ModelCriteria
     {
         /** @var $q \Model\UserQuery */
         $q = $this->useInQuery('User', $modelAlias, $queryClass, 'NOT IN');
+        return $q;
+    }
+
+    /**
+     * Filter the query by a related \Model\Customer object
+     *
+     * @param \Model\Customer|ObjectCollection $customer The related object(s) to use as filter
+     * @param string|null $comparison Operator to use for the column comparison, defaults to Criteria::EQUAL
+     *
+     * @throws \Propel\Runtime\Exception\PropelException
+     *
+     * @return $this The current query, for fluid interface
+     */
+    public function filterByCustomer($customer, ?string $comparison = null)
+    {
+        if ($customer instanceof \Model\Customer) {
+            return $this
+                ->addUsingAlias(OrderTableMap::COL_CUSTOMER_ID, $customer->getId(), $comparison);
+        } elseif ($customer instanceof ObjectCollection) {
+            if (null === $comparison) {
+                $comparison = Criteria::IN;
+            }
+
+            $this
+                ->addUsingAlias(OrderTableMap::COL_CUSTOMER_ID, $customer->toKeyValue('PrimaryKey', 'Id'), $comparison);
+
+            return $this;
+        } else {
+            throw new PropelException('filterByCustomer() only accepts arguments of type \Model\Customer or Collection');
+        }
+    }
+
+    /**
+     * Adds a JOIN clause to the query using the Customer relation
+     *
+     * @param string|null $relationAlias Optional alias for the relation
+     * @param string|null $joinType Accepted values are null, 'left join', 'right join', 'inner join'
+     *
+     * @return $this The current query, for fluid interface
+     */
+    public function joinCustomer(?string $relationAlias = null, ?string $joinType = Criteria::LEFT_JOIN)
+    {
+        $tableMap = $this->getTableMap();
+        $relationMap = $tableMap->getRelation('Customer');
+
+        // create a ModelJoin object for this join
+        $join = new ModelJoin();
+        $join->setJoinType($joinType);
+        $join->setRelationMap($relationMap, $this->useAliasInSQL ? $this->getModelAlias() : null, $relationAlias);
+        if ($previousJoin = $this->getPreviousJoin()) {
+            $join->setPreviousJoin($previousJoin);
+        }
+
+        // add the ModelJoin to the current object
+        if ($relationAlias) {
+            $this->addAlias($relationAlias, $relationMap->getRightTable()->getName());
+            $this->addJoinObject($join, $relationAlias);
+        } else {
+            $this->addJoinObject($join, 'Customer');
+        }
+
+        return $this;
+    }
+
+    /**
+     * Use the Customer relation Customer object
+     *
+     * @see useQuery()
+     *
+     * @param string $relationAlias optional alias for the relation,
+     *                                   to be used as main alias in the secondary query
+     * @param string $joinType Accepted values are null, 'left join', 'right join', 'inner join'
+     *
+     * @return \Model\CustomerQuery A secondary query class using the current class as primary query
+     */
+    public function useCustomerQuery($relationAlias = null, $joinType = Criteria::LEFT_JOIN)
+    {
+        return $this
+            ->joinCustomer($relationAlias, $joinType)
+            ->useQuery($relationAlias ? $relationAlias : 'Customer', '\Model\CustomerQuery');
+    }
+
+    /**
+     * Use the Customer relation Customer object
+     *
+     * @param callable(\Model\CustomerQuery):\Model\CustomerQuery $callable A function working on the related query
+     *
+     * @param string|null $relationAlias optional alias for the relation
+     *
+     * @param string|null $joinType Accepted values are null, 'left join', 'right join', 'inner join'
+     *
+     * @return $this
+     */
+    public function withCustomerQuery(
+        callable $callable,
+        string $relationAlias = null,
+        ?string $joinType = Criteria::LEFT_JOIN
+    ) {
+        $relatedQuery = $this->useCustomerQuery(
+            $relationAlias,
+            $joinType
+        );
+        $callable($relatedQuery);
+        $relatedQuery->endUse();
+
+        return $this;
+    }
+
+    /**
+     * Use the relation to Customer table for an EXISTS query.
+     *
+     * @see \Propel\Runtime\ActiveQuery\ModelCriteria::useExistsQuery()
+     *
+     * @param string|null $modelAlias sets an alias for the nested query
+     * @param string|null $queryClass Allows to use a custom query class for the exists query, like ExtendedBookQuery::class
+     * @param string $typeOfExists Either ExistsQueryCriterion::TYPE_EXISTS or ExistsQueryCriterion::TYPE_NOT_EXISTS
+     *
+     * @return \Model\CustomerQuery The inner query object of the EXISTS statement
+     */
+    public function useCustomerExistsQuery($modelAlias = null, $queryClass = null, $typeOfExists = 'EXISTS')
+    {
+        /** @var $q \Model\CustomerQuery */
+        $q = $this->useExistsQuery('Customer', $modelAlias, $queryClass, $typeOfExists);
+        return $q;
+    }
+
+    /**
+     * Use the relation to Customer table for a NOT EXISTS query.
+     *
+     * @see useCustomerExistsQuery()
+     *
+     * @param string|null $modelAlias sets an alias for the nested query
+     * @param string|null $queryClass Allows to use a custom query class for the exists query, like ExtendedBookQuery::class
+     *
+     * @return \Model\CustomerQuery The inner query object of the NOT EXISTS statement
+     */
+    public function useCustomerNotExistsQuery($modelAlias = null, $queryClass = null)
+    {
+        /** @var $q \Model\CustomerQuery */
+        $q = $this->useExistsQuery('Customer', $modelAlias, $queryClass, 'NOT EXISTS');
+        return $q;
+    }
+
+    /**
+     * Use the relation to Customer table for an IN query.
+     *
+     * @see \Propel\Runtime\ActiveQuery\ModelCriteria::useInQuery()
+     *
+     * @param string|null $modelAlias sets an alias for the nested query
+     * @param string|null $queryClass Allows to use a custom query class for the IN query, like ExtendedBookQuery::class
+     * @param string $typeOfIn Criteria::IN or Criteria::NOT_IN
+     *
+     * @return \Model\CustomerQuery The inner query object of the IN statement
+     */
+    public function useInCustomerQuery($modelAlias = null, $queryClass = null, $typeOfIn = 'IN')
+    {
+        /** @var $q \Model\CustomerQuery */
+        $q = $this->useInQuery('Customer', $modelAlias, $queryClass, $typeOfIn);
+        return $q;
+    }
+
+    /**
+     * Use the relation to Customer table for a NOT IN query.
+     *
+     * @see useCustomerInQuery()
+     *
+     * @param string|null $modelAlias sets an alias for the nested query
+     * @param string|null $queryClass Allows to use a custom query class for the NOT IN query, like ExtendedBookQuery::class
+     *
+     * @return \Model\CustomerQuery The inner query object of the NOT IN statement
+     */
+    public function useNotInCustomerQuery($modelAlias = null, $queryClass = null)
+    {
+        /** @var $q \Model\CustomerQuery */
+        $q = $this->useInQuery('Customer', $modelAlias, $queryClass, 'NOT IN');
         return $q;
     }
 

--- a/src/Model/Base/ShippingOption.php
+++ b/src/Model/Base/ShippingOption.php
@@ -2284,6 +2284,32 @@ abstract class ShippingOption implements ActiveRecordInterface
      * @return ObjectCollection|ChildOrder[] List of ChildOrder objects
      * @phpstan-return ObjectCollection&\Traversable<ChildOrder}> List of ChildOrder objects
      */
+    public function getOrdersJoinCustomer(?Criteria $criteria = null, ?ConnectionInterface $con = null, $joinBehavior = Criteria::LEFT_JOIN)
+    {
+        $query = ChildOrderQuery::create(null, $criteria);
+        $query->joinWith('Customer', $joinBehavior);
+
+        return $this->getOrders($query, $con);
+    }
+
+
+    /**
+     * If this collection has already been initialized with
+     * an identical criteria, it returns the collection.
+     * Otherwise if this ShippingOption is new, it will return
+     * an empty collection; or if this ShippingOption has previously
+     * been saved, it will retrieve related Orders from storage.
+     *
+     * This method is protected by default in order to keep the public
+     * api reasonable.  You can provide public methods for those you
+     * actually need in ShippingOption.
+     *
+     * @param Criteria $criteria optional Criteria object to narrow the query
+     * @param ConnectionInterface $con optional connection object
+     * @param string $joinBehavior optional join type to use (defaults to Criteria::LEFT_JOIN)
+     * @return ObjectCollection|ChildOrder[] List of ChildOrder objects
+     * @phpstan-return ObjectCollection&\Traversable<ChildOrder}> List of ChildOrder objects
+     */
     public function getOrdersJoinCountry(?Criteria $criteria = null, ?ConnectionInterface $con = null, $joinBehavior = Criteria::LEFT_JOIN)
     {
         $query = ChildOrderQuery::create(null, $criteria);

--- a/src/Model/Base/Site.php
+++ b/src/Model/Base/Site.php
@@ -8327,6 +8327,32 @@ abstract class Site implements ActiveRecordInterface
      * @return ObjectCollection|ChildOrder[] List of ChildOrder objects
      * @phpstan-return ObjectCollection&\Traversable<ChildOrder}> List of ChildOrder objects
      */
+    public function getOrdersJoinCustomer(?Criteria $criteria = null, ?ConnectionInterface $con = null, $joinBehavior = Criteria::LEFT_JOIN)
+    {
+        $query = ChildOrderQuery::create(null, $criteria);
+        $query->joinWith('Customer', $joinBehavior);
+
+        return $this->getOrders($query, $con);
+    }
+
+
+    /**
+     * If this collection has already been initialized with
+     * an identical criteria, it returns the collection.
+     * Otherwise if this Site is new, it will return
+     * an empty collection; or if this Site has previously
+     * been saved, it will retrieve related Orders from storage.
+     *
+     * This method is protected by default in order to keep the public
+     * api reasonable.  You can provide public methods for those you
+     * actually need in Site.
+     *
+     * @param Criteria $criteria optional Criteria object to narrow the query
+     * @param ConnectionInterface $con optional connection object
+     * @param string $joinBehavior optional join type to use (defaults to Criteria::LEFT_JOIN)
+     * @return ObjectCollection|ChildOrder[] List of ChildOrder objects
+     * @phpstan-return ObjectCollection&\Traversable<ChildOrder}> List of ChildOrder objects
+     */
     public function getOrdersJoinShippingOption(?Criteria $criteria = null, ?ConnectionInterface $con = null, $joinBehavior = Criteria::LEFT_JOIN)
     {
         $query = ChildOrderQuery::create(null, $criteria);

--- a/src/Model/Base/User.php
+++ b/src/Model/Base/User.php
@@ -5821,6 +5821,32 @@ abstract class User implements ActiveRecordInterface
      * @return ObjectCollection|ChildOrder[] List of ChildOrder objects
      * @phpstan-return ObjectCollection&\Traversable<ChildOrder}> List of ChildOrder objects
      */
+    public function getOrdersJoinCustomer(?Criteria $criteria = null, ?ConnectionInterface $con = null, $joinBehavior = Criteria::LEFT_JOIN)
+    {
+        $query = ChildOrderQuery::create(null, $criteria);
+        $query->joinWith('Customer', $joinBehavior);
+
+        return $this->getOrders($query, $con);
+    }
+
+
+    /**
+     * If this collection has already been initialized with
+     * an identical criteria, it returns the collection.
+     * Otherwise if this User is new, it will return
+     * an empty collection; or if this User has previously
+     * been saved, it will retrieve related Orders from storage.
+     *
+     * This method is protected by default in order to keep the public
+     * api reasonable.  You can provide public methods for those you
+     * actually need in User.
+     *
+     * @param Criteria $criteria optional Criteria object to narrow the query
+     * @param ConnectionInterface $con optional connection object
+     * @param string $joinBehavior optional join type to use (defaults to Criteria::LEFT_JOIN)
+     * @return ObjectCollection|ChildOrder[] List of ChildOrder objects
+     * @phpstan-return ObjectCollection&\Traversable<ChildOrder}> List of ChildOrder objects
+     */
     public function getOrdersJoinShippingOption(?Criteria $criteria = null, ?ConnectionInterface $con = null, $joinBehavior = Criteria::LEFT_JOIN)
     {
         $query = ChildOrderQuery::create(null, $criteria);

--- a/src/Model/Customer.php
+++ b/src/Model/Customer.php
@@ -31,5 +31,8 @@ use Model\Base\Customer as BaseCustomer;
  */
 class Customer extends BaseCustomer
 {
-
+    public function getFullName(): string
+    {
+        return trim("{$this->getFirstName()} {$this->getLastName()}");
+    }
 }

--- a/src/Model/Map/CustomerTableMap.php
+++ b/src/Model/Map/CustomerTableMap.php
@@ -370,6 +370,13 @@ class CustomerTableMap extends TableMap
     1 => ':id',
   ),
 ), null, null, null, false);
+        $this->addRelation('Order', '\\Model\\Order', RelationMap::ONE_TO_MANY, array (
+  0 =>
+  array (
+    0 => ':customer_id',
+    1 => ':customer_id',
+  ),
+), null, null, 'Orders', false);
     }
 
     /**

--- a/src/Model/Map/OrderTableMap.php
+++ b/src/Model/Map/OrderTableMap.php
@@ -779,7 +779,7 @@ class OrderTableMap extends TableMap
         $this->addForeignKey('site_id', 'SiteId', 'INTEGER', 'sites', 'site_id', false, null, null);
         $this->addColumn('axys_account_id', 'AxysAccountId', 'INTEGER', false, null, null);
         $this->addForeignKey('user_id', 'UserId', 'INTEGER', 'users', 'id', false, null, null);
-        $this->addColumn('customer_id', 'CustomerId', 'INTEGER', false, null, null);
+        $this->addForeignKey('customer_id', 'CustomerId', 'INTEGER', 'customers', 'customer_id', false, null, null);
         $this->addColumn('seller_id', 'SellerId', 'INTEGER', false, null, null);
         $this->addColumn('order_type', 'Type', 'VARCHAR', false, 8, '');
         $this->addColumn('order_as_a_gift', 'AsAGift', 'VARCHAR', false, 16, null);
@@ -837,6 +837,13 @@ class OrderTableMap extends TableMap
   array (
     0 => ':user_id',
     1 => ':id',
+  ),
+), null, null, null, false);
+        $this->addRelation('Customer', '\\Model\\Customer', RelationMap::MANY_TO_ONE, array (
+  0 =>
+  array (
+    0 => ':customer_id',
+    1 => ':customer_id',
   ),
 ), null, null, null, false);
         $this->addRelation('ShippingOption', '\\Model\\ShippingOption', RelationMap::MANY_TO_ONE, array (

--- a/tests/ApiBundle/Controller/OrderControllerTest.php
+++ b/tests/ApiBundle/Controller/OrderControllerTest.php
@@ -46,10 +46,10 @@ class OrderControllerTest extends TestCase
         $controller = new OrderController();
 
         $site = ModelFactory::createSite();
-        $shippingFee = ModelFactory::createShippingFee(site: $site, type: "mondial-relay");
+        $shippingFee = ModelFactory::createShippingOption(site: $site, type: "mondial-relay");
         $order = ModelFactory::createOrder(
             site: $site,
-            shippingFee: $shippingFee,
+            shippingOption: $shippingFee,
             firstName: "Éléonore",
             lastName: "Champollion",
             postalCode: "02330",

--- a/tests/ApiBundle/Controller/PaymentControllerTest.php
+++ b/tests/ApiBundle/Controller/PaymentControllerTest.php
@@ -38,13 +38,20 @@ class PaymentControllerTest extends TestCase
 
         $paymentService = Mockery::mock(PaymentService::class);
         $paymentService->expects("getPayableOrderBySlug")->andReturn($order);
-        $paymentService->expects("createStripePaymentForOrder")->with($order)->andReturn("pi_1234_secret_abcd");
+        $paymentService->expects("createStripePaymentForOrder")->with($order)
+            ->andReturn([
+                "payment_intent_client_secret" => "pi_1234_secret_abcd",
+                "customer_session_client_secret" => "cuss_secret_abcd",
+            ]);
 
         // when
         $response = $controller->createStripePaymentAction($paymentService, $order->getSlug());
 
         // then
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals('{"client_secret":"pi_1234_secret_abcd"}', $response->getContent());
+        $this->assertEquals(
+            '{"payment_intent_client_secret":"pi_1234_secret_abcd","customer_session_client_secret":"cuss_secret_abcd"}',
+            $response->getContent()
+        );
     }
 }

--- a/tests/ApiBundle/Controller/PaymentControllerTest.php
+++ b/tests/ApiBundle/Controller/PaymentControllerTest.php
@@ -35,17 +35,16 @@ class PaymentControllerTest extends TestCase
         // given
         $controller = new PaymentController();
         $order = ModelFactory::createOrder();
-        $payment = ModelFactory::createPayment(providerId: "1234");
 
         $paymentService = Mockery::mock(PaymentService::class);
         $paymentService->expects("getPayableOrderBySlug")->andReturn($order);
-        $paymentService->expects("createStripePaymentForOrder")->with($order)->andReturn($payment);
+        $paymentService->expects("createStripePaymentForOrder")->with($order)->andReturn("pi_1234_secret_abcd");
 
         // when
         $response = $controller->createStripePaymentAction($paymentService, $order->getSlug());
 
         // then
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals('{"session_id":"1234"}', $response->getContent());
+        $this->assertEquals('{"client_secret":"pi_1234_secret_abcd"}', $response->getContent());
     }
 }

--- a/tests/ApiBundle/Controller/ShippingControllerTest.php
+++ b/tests/ApiBundle/Controller/ShippingControllerTest.php
@@ -167,7 +167,7 @@ class ShippingControllerTest extends TestCase
         $controller = new ShippingController();
         $content = '{"id":"","mode":"Colissimo","type":"suivi","zone":"OM2","max_weight":"21","min_amount":"71","max_amount":"76","max_articles":"90","fee":"57","info":"Expedition sous 72h"}';
         $request = RequestFactory::createAuthRequestForAdminUser($content);
-        $shippingFee = ModelFactory::createShippingFee();
+        $shippingFee = ModelFactory::createShippingOption();
         $config = new Config();
         $currentUser = Mockery::mock(CurrentUser::class);
         $currentUser->shouldReceive("authAdmin")->once()->andReturn(true);
@@ -208,7 +208,7 @@ class ShippingControllerTest extends TestCase
         $controller = new ShippingController();
         $content = '{"id":"","mode":"Colissimo","type":"suivi","zone":"OM2","max_weight":"21","min_amount":"71","max_amount":"76","max_articles":"90","fee":"57","info":"Expedition sous 72h"}';
         $request = RequestFactory::createAuthRequestForAdminUser($content);
-        $shippingFee = ModelFactory::createShippingFee();
+        $shippingFee = ModelFactory::createShippingOption();
         $shippingFee->setSiteId(2);
         $shippingFee->save();
         $config = new Config();
@@ -233,7 +233,7 @@ class ShippingControllerTest extends TestCase
     {
         // given
         $controller = new ShippingController();
-        $shippingFee = ModelFactory::createShippingFee();
+        $shippingFee = ModelFactory::createShippingOption();
         $currentUser = Mockery::mock(CurrentUser::class);
         $currentUser->shouldReceive("authAdmin")->once()->andReturn(true);
 
@@ -259,7 +259,7 @@ class ShippingControllerTest extends TestCase
     {
         // given
         $controller = new ShippingController();
-        $shippingFee = ModelFactory::createShippingFee();
+        $shippingFee = ModelFactory::createShippingOption();
         $config = new Config();
         $currentUser = Mockery::mock(CurrentUser::class);
         $currentUser->shouldReceive("authAdmin")->once()->andReturn(true);
@@ -282,7 +282,7 @@ class ShippingControllerTest extends TestCase
     {
         // given
         $controller = new ShippingController();
-        $shippingFee = ModelFactory::createShippingFee();
+        $shippingFee = ModelFactory::createShippingOption();
         $shippingFee->setSiteId(2);
         $shippingFee->save();
         $config = new Config();
@@ -308,7 +308,7 @@ class ShippingControllerTest extends TestCase
     {
         // given
         $site = ModelFactory::createSite();
-        $shippingFee = ModelFactory::createShippingFee(
+        $shippingFee = ModelFactory::createShippingOption(
             site: $site,
             type: "suivi",
             mode: "Colissimo",
@@ -405,7 +405,7 @@ class ShippingControllerTest extends TestCase
         // given
         $config = new Config();
         $country = ModelFactory::createCountry(zone: "Z2");
-        $shippingFee = ModelFactory::createShippingFee(
+        $shippingFee = ModelFactory::createShippingOption(
             type: "Type C",
             country: $country,
             mode: "Colissimo",

--- a/tests/AppBundle/Controller/Legacy/OrderDeliveryTest.php
+++ b/tests/AppBundle/Controller/Legacy/OrderDeliveryTest.php
@@ -58,7 +58,7 @@ class OrderDeliveryTest extends TestCase
         $cart = ModelFactory::createCart(site: $site);
         $article = ModelFactory::createArticle();
         ModelFactory::createStockItem(site: $site, article: $article, cart: $cart);
-        $shipping = ModelFactory::createShippingFee(type: "suivi");
+        $shipping = ModelFactory::createShippingOption(type: "suivi");
         $_POST["order_email"] = "customer@biblys.fr";
         $_POST["order_firstname"] = "Barnabé";
         $_POST["order_lastname"] = "Famagouste";
@@ -372,7 +372,7 @@ class OrderDeliveryTest extends TestCase
         ModelFactory::createStockItem(site: $site, article: $article, cart: $cart);
         $country = ModelFactory::createCountry();
 
-        $shipping = ModelFactory::createShippingFee(type: "suivi");
+        $shipping = ModelFactory::createShippingOption(type: "suivi");
         $_POST = [
             "order_email" => "customer@biblys.fr",
             "order_firstname" => "Barnabé",
@@ -457,7 +457,7 @@ class OrderDeliveryTest extends TestCase
         ModelFactory::createStockItem(site: $site, article: $article, cart: $cart);
         $country = ModelFactory::createCountry();
 
-        $shipping = ModelFactory::createShippingFee(type: "suivi");
+        $shipping = ModelFactory::createShippingOption(type: "suivi");
         $_POST = [
             "order_email" => "customer@biblys.fr",
             "order_firstname" => "Barnabé",

--- a/tests/AppBundle/Controller/PaymentControllerTest.php
+++ b/tests/AppBundle/Controller/PaymentControllerTest.php
@@ -231,7 +231,7 @@ class PaymentControllerTest extends TestCase
 
         // then
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertStringContainsString("Stripe", $response->getContent());
+        $this->assertStringContainsString("stripe-payment-form", $response->getContent());
     }
 
     /**

--- a/tests/Model/CustomerTest.php
+++ b/tests/Model/CustomerTest.php
@@ -1,0 +1,53 @@
+<?php
+/*
+ * Copyright (C) 2025 Clément Latzarus
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+
+namespace Model;
+
+use PHPUnit\Framework\TestCase;
+
+class CustomerTest extends TestCase
+{
+
+    public function testGetFullName()
+    {
+        // given
+        $customer = new Customer();
+        $customer->setFirstName("Maude");
+        $customer->setLastName("Zarella");
+
+        // when
+        $fullName = $customer->getFullName();
+
+        // then
+        $this->assertEquals("Maude Zarella", $fullName);
+    }
+
+    public function testGetFullNameWithEmptyFirstName()
+    {
+        // given
+        $customer = new Customer();
+        $customer->setFirstName("");
+        $customer->setLastName("Voltaire");
+
+        // when
+        $fullName = $customer->getFullName();
+
+        // then
+        $this->assertEquals("Voltaire", $fullName);
+    }
+}

--- a/tests/Model/OrderTest.php
+++ b/tests/Model/OrderTest.php
@@ -201,8 +201,8 @@ class OrderTest extends TestCase
     public function testGetTotalAmountWithShipping(): void
     {
         // given
-        $shippingFee = ModelFactory::createShippingFee(fee: 789);
-        $order = ModelFactory::createOrder(shippingFee: $shippingFee);
+        $shippingFee = ModelFactory::createShippingOption(fee: 789);
+        $order = ModelFactory::createOrder(shippingOption: $shippingFee);
         ModelFactory::createStockItem(order: $order, sellingPrice: 123);
         ModelFactory::createStockItem(order: $order, sellingPrice: 456);
 

--- a/tests/Model/ShippingFeeQueryTest.php
+++ b/tests/Model/ShippingFeeQueryTest.php
@@ -37,7 +37,7 @@ class ShippingFeeQueryTest extends TestCase
         // given
         $site = ModelFactory::createSite();
         $country = ModelFactory::createCountry();
-        $fee = ModelFactory::createShippingFee(
+        $fee = ModelFactory::createShippingOption(
             site: $site,
             country: $country,
         );
@@ -70,12 +70,12 @@ class ShippingFeeQueryTest extends TestCase
         // given
         $site = ModelFactory::createSite();
         $country = ModelFactory::createCountry();
-        ModelFactory::createShippingFee(
+        ModelFactory::createShippingOption(
             site: $site,
             country: $country,
             maxArticles: 1
         );
-        $feeForTwoArticles = ModelFactory::createShippingFee(
+        $feeForTwoArticles = ModelFactory::createShippingOption(
             site: $site,
             country: $country,
             maxArticles: 2
@@ -109,8 +109,8 @@ class ShippingFeeQueryTest extends TestCase
         // given
         $site = ModelFactory::createSite();
         $country = ModelFactory::createCountry();
-        $archivedFee = ModelFactory::createShippingFee(site: $site, country: $country, isArchived: true);
-        $activeFee = ModelFactory::createShippingFee(site: $site, country: $country);
+        $archivedFee = ModelFactory::createShippingOption(site: $site, country: $country, isArchived: true);
+        $activeFee = ModelFactory::createShippingOption(site: $site, country: $country);
         $orderWeight = 500;
         $orderAmount = 1500;
         $currentSite = new CurrentSite($site);

--- a/tests/Model/ShippingFeeTest.php
+++ b/tests/Model/ShippingFeeTest.php
@@ -155,7 +155,7 @@ class ShippingFeeTest extends TestCase
     public function testDeleteWithoutRelatedOrders(): void
     {
         // given
-        $shippingFee = ModelFactory::createShippingFee();
+        $shippingFee = ModelFactory::createShippingOption();
 
         // when
         $shippingFee->delete();
@@ -171,8 +171,8 @@ class ShippingFeeTest extends TestCase
     public function testDeleteWithRelatedOrders(): void
     {
         // given
-        $shippingFee = ModelFactory::createShippingFee();
-        ModelFactory::createOrder(shippingFee: $shippingFee);
+        $shippingFee = ModelFactory::createShippingOption();
+        ModelFactory::createOrder(shippingOption: $shippingFee);
 
         // when
         $exception = Helpers::runAndCatchException(fn() => $shippingFee->delete());

--- a/tests/Usecase/MarkOrderAsShippedUsecaseTest.php
+++ b/tests/Usecase/MarkOrderAsShippedUsecaseTest.php
@@ -45,8 +45,8 @@ class MarkOrderAsShippedUsecaseTest extends TestCase
     public function testExecute()
     {
         // given
-        $shipping = ModelFactory::createShippingFee();
-        $order = ModelFactory::createOrder(shippingFee: $shipping, email: "customer@paronymie.fr");
+        $shipping = ModelFactory::createShippingOption();
+        $order = ModelFactory::createOrder(shippingOption: $shipping, email: "customer@paronymie.fr");
         $site = ModelFactory::createSite(domain: "paronymie-expeditions.fr");
 
         $currentSite = Mockery::mock(CurrentSite::class);
@@ -84,8 +84,8 @@ class MarkOrderAsShippedUsecaseTest extends TestCase
     public function testExecuteWithCustomShippingMessage()
     {
         // given
-        $shipping = ModelFactory::createShippingFee();
-        $order = ModelFactory::createOrder(shippingFee: $shipping, email: "customer@paronymie.fr");
+        $shipping = ModelFactory::createShippingOption();
+        $order = ModelFactory::createOrder(shippingOption: $shipping, email: "customer@paronymie.fr");
         $site = ModelFactory::createSite();
 
         $currentSite = Mockery::mock(CurrentSite::class);
@@ -121,8 +121,8 @@ class MarkOrderAsShippedUsecaseTest extends TestCase
     public function testExecuteWithTrackedShipping()
     {
         // given
-        $shipping = ModelFactory::createShippingFee(type: "suivi");
-        $order = ModelFactory::createOrder(shippingFee: $shipping, email: "customer@paronymie.fr");
+        $shipping = ModelFactory::createShippingOption(type: "suivi");
+        $order = ModelFactory::createOrder(shippingOption: $shipping, email: "customer@paronymie.fr");
         $site = ModelFactory::createSite();
 
         $currentSite = Mockery::mock(CurrentSite::class);
@@ -160,8 +160,8 @@ class MarkOrderAsShippedUsecaseTest extends TestCase
     public function testExecuteWithPickupShipping()
     {
         // given
-        $shipping = ModelFactory::createShippingFee(type: "magasin");
-        $order = ModelFactory::createOrder(shippingFee: $shipping, email: "customer@paronymie.fr");
+        $shipping = ModelFactory::createShippingOption(type: "magasin");
+        $order = ModelFactory::createOrder(shippingOption: $shipping, email: "customer@paronymie.fr");
         $site = ModelFactory::createSite();
 
         $currentSite = Mockery::mock(CurrentSite::class);


### PR DESCRIPTION
## TODO

https://docs.stripe.com/payments/quickstart

### Must have

- [x] Ajouter une méthode `PaymentService->_getOrCreateStripeCustomerForOrder`
- [x] Ajouter une méthode `PaymentService->_createStripePaymentIntentForOrder`
- [x] Appeler les nouvelles méthodes dans `PaymentController->createStripePaymentForOrder`
- [x] Sur la page de paiement, récupérer le `client_secret` et instantier le formulaire de paiement
- [x] Mettre à jour le webhook
- [x] Sauvegarder/mettre à jour le nom et l'email dans le customer stripe
- [x] Proposer la sauvegarde des cartes
- [x] Supprimer le code Stripe plus utilisé

### Nice to have

- [ ] Dans la méthode `PaymentService->getPayableOrder`, vérifier que `CurrentUser` est autorisé à gérer la commande.