### PR TITLE
Correctif 3.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Historique des modifications
 
-## 3.5.1 (DEV)
+## 3.5.1 (9 avril 2025)
 
 ### Corrections
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Historique des modifications
 
+## 3.5.1 (DEV)
+
+### Corrections
+
+- Les commandes payées avec PayPal et PayPlug pouvaient ne pas être marquées
+  comme payées. C'est corrigé.
+- Le marquage d'une commande numérique comme expédiée pouvait échouer sans 
+  erreur. Ça n'arrivera plus.
+
 ## 3.5.0 (4 avril 2025)
 
 ### Expérience de paiement

--- a/controllers/common/php/list_xhr.php
+++ b/controllers/common/php/list_xhr.php
@@ -198,8 +198,9 @@ return function (Request $request, CurrentUser $currentUser, ImagesService $imag
 
     } elseif ($del) {
         $link = $lm->getById($del);
-        $lm->delete($link);
-
+        if ($link) {
+            $lm->delete($link);
+        }
     }
 
     return new JsonResponse(["content" => $content]);

--- a/inc/constants.php
+++ b/inc/constants.php
@@ -15,4 +15,4 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-const BIBLYS_VERSION = "3.5.1-dev";
+const BIBLYS_VERSION = "3.5.1-dev.1";

--- a/inc/constants.php
+++ b/inc/constants.php
@@ -15,4 +15,4 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-const BIBLYS_VERSION = "3.5.1-dev.1";
+const BIBLYS_VERSION = "3.5.1";

--- a/inc/constants.php
+++ b/inc/constants.php
@@ -15,4 +15,4 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-const BIBLYS_VERSION = "3.5.0";
+const BIBLYS_VERSION = "3.5.1-dev";

--- a/src/ApiBundle/Controller/PaymentController.php
+++ b/src/ApiBundle/Controller/PaymentController.php
@@ -98,7 +98,7 @@ class PaymentController extends Controller
                 ->build(),
         ];
 
-        $apiResponse = $client->getOrdersController()->ordersCreate($orderBody);
+        $apiResponse = $client->getOrdersController()->createOrder($orderBody);
         $jsonResponse = json_decode($apiResponse->getBody(), true);
 
         $logger->log(
@@ -133,7 +133,7 @@ class PaymentController extends Controller
             $data = json_decode($request->getContent());
 
             $client = $this->_createPayPalClient($config);
-            $apiResponse = $client->getOrdersController()->ordersCapture(["id" => $data->paypalOrderId]);
+            $apiResponse = $client->getOrdersController()->captureOrder(["id" => $data->paypalOrderId]);
             $jsonResponse = json_decode($apiResponse->getBody(), true);
 
             $logger->log(

--- a/src/AppBundle/Resources/views/Article/_cartButton.html.twig
+++ b/src/AppBundle/Resources/views/Article/_cartButton.html.twig
@@ -14,23 +14,50 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #}
 
-<button
-  class="btn btn-primary cart-button add_to_cart event"
-  data-type="article"
-  data-id="{{ article.id }}"
-  {% if hideLabel is defined %}
-    aria-label="{{ article.model.cartButtonLabel }}"
-    title="{{ article.model.cartButtonLabel }}"
-  {% endif %}
->
-  <span class="fa-solid fa-shopping-basket"></span>
-  {% if hideLabel is not defined %}
-    <span class="cart-button-text">
-      {% if label is defined %}
-        {{ label }}
-      {% else %}
-        {{ article.model.cartButtonLabel }}
-      {% endif %}
-    </span>
-  {% endif %}
-</button>
+{% if article.model.price == 0 and article.type.isDownloadable %}
+
+  <a
+    class="btn btn-success cart-button"
+    href="{{ path('article_free_download', { id: article.id }) }}"
+    {% if hideLabel is defined %}
+      aria-label="{{ article.model.cartButtonLabel }}"
+      title="{{ article.model.cartButtonLabel }}"
+    {% endif %}
+  >
+    <i class="fa-solid fa-file-arrow-down"></i>
+
+    {% if hideLabel is not defined %}
+      <span class="cart-button-text">
+        {% if label is defined %}
+          {{ label }}
+        {% else %}
+          Télécharger gratuitement
+        {% endif %}
+      </span>
+    {% endif %}
+  </a>
+
+{% else %}
+
+  <button
+    class="btn btn-primary cart-button add_to_cart event"
+    data-type="article"
+    data-id="{{ article.id }}"
+    {% if hideLabel is defined %}
+      aria-label="{{ article.model.cartButtonLabel }}"
+      title="{{ article.model.cartButtonLabel }}"
+    {% endif %}
+  >
+    <span class="fa-solid fa-shopping-basket"></span>
+    {% if hideLabel is not defined %}
+      <span class="cart-button-text">
+        {% if label is defined %}
+          {{ label }}
+        {% else %}
+          {{ article.model.cartButtonLabel }}
+        {% endif %}
+      </span>
+    {% endif %}
+  </button>
+
+{% endif %}

--- a/src/AppBundle/Resources/views/Payment/select-method.html.twig
+++ b/src/AppBundle/Resources/views/Payment/select-method.html.twig
@@ -48,34 +48,35 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
              data-parent="#payment-methods-accordion">
           <div class="card-body">
             {% if order.amountTobepaid < 50 %}
-              <p class="alert alert-warning">
+              <p class="alert alert-warning mb-0">
                 <span class="fa-solid fa-triangle-exclamation"></span>&nbsp;
-                Les commandes dont le montant total est inférieur à 0,50 €<br>
+                Les commandes dont le montant total est inférieur à 0,50 €
                 ne peuvent être réglés par carte bancaire.
               </p>
-            {% endif %}
-
-            <form id="stripe-payment-form"
-              data-public-key="{{ stripePublicKey }}"
-              data-payment-url="{{ path('api_stripe_create_payment', { slug: order.slug }) }}"
-              data-order-url="{{ url('legacy_order', { url: order.slug }) }}"
-            >
-              <div id="payment-element">
-                <span class="spinner-border spinner-border-sm ml-1" role="status" id="spinner"></span>
-                Chargement du formulaire de paiement sécurisé…
-              </div>
-
-              <button id="stripe-payment-button" class="btn btn-primary mt-4 d-none" id="submit"
-                  {% if order.amountTobepaid < 50 %}disabled{% endif %}
-                >
-                <div class="spinner-border spinner-border-sm ml-1 d-none" role="status" id="stripe-payment-button-loader">
-                  <span class="sr-only">Paiement en cours…</span>
+            {% else %}
+              <form id="stripe-payment-form"
+                    data-public-key="{{ stripePublicKey }}"
+                    data-payment-url="{{ path('api_stripe_create_payment', { slug: order.slug }) }}"
+                    data-order-url="{{ url('legacy_order', { url: order.slug }) }}"
+              >
+                <div id="payment-element">
+                  <span class="spinner-border spinner-border-sm ml-1" role="status" id="spinner"></span>
+                  Chargement du formulaire de paiement sécurisé…
                 </div>
-                <span id="button-text">Payer</span>
-              </button>
 
-              <div id="payment-message" class="hidden"></div>
-            </form>
+                <button id="stripe-payment-button" class="btn btn-primary mt-4 d-none" id="submit"
+                        {% if order.amountTobepaid < 50 %}disabled{% endif %}
+                >
+                  <div class="spinner-border spinner-border-sm ml-1 d-none" role="status"
+                       id="stripe-payment-button-loader">
+                    <span class="sr-only">Paiement en cours…</span>
+                  </div>
+                  <span id="button-text">Payer</span>
+                </button>
+
+                <div id="payment-message" class="hidden"></div>
+              </form>
+            {% endif %}
           </div>
         </div>
       </div>
@@ -96,25 +97,25 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
              data-parent="#payment-methods-accordion">
           <div class="card-body">
 
+            <p>Payez par carte bancaire via le serveur sécurisé de notre partenaire PayPlug.</p>
+
             {% if order.amountTobepaid < 50 %}
               <p class="alert alert-warning">
                 <span class="fa-solid fa-triangle-exclamation"></span>&nbsp;
                 Les commandes dont le montant total est inférieur à 0,50 €<br>
                 ne peuvent être réglés par carte bancaire.
               </p>
+
+            {% else %}
+
+              <form method="post" action="{{ path("payment_payplug", { slug: order.slug }) }}">
+                <input type="hidden" name="payment" value="payplug">
+                <button type="submit" class="btn btn-primary"
+                        {% if order.amountTobepaid < 50 %}disabled{% endif %}
+                >Payer par carte bancaire
+                </button>
+              </form>
             {% endif %}
-
-            <p>
-              Payez par carte bancaire via le serveur sécurisé de notre partenaire PayPlug.
-            </p>
-
-            <form method="post" action="{{ path("payment_payplug", { slug: order.slug }) }}">
-              <input type="hidden" name="payment" value="payplug">
-              <button type="submit" class="btn btn-primary"
-                      {% if order.amountTobepaid < 50 %}disabled{% endif %}
-              >Payer par carte bancaire
-              </button>
-            </form>
           </div>
         </div>
       </div>
@@ -135,6 +136,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
         <div id="collapse-paypal" class="collapse" aria-labelledby="headingTwo"
              data-parent="#payment-methods-accordion">
           <div class="card-body">
+            <p>Payez avec votre compte PayPal.</p>
 
             {% if order.amountTobepaid < 100 %}
               <p class="alert alert-warning">
@@ -142,15 +144,15 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
                 Les commandes dont le montant total est inférieur à 1,00 €<br>
                 ne peuvent être réglés par carte bancaire ou Paypal.
               </p>
+
+            {% else %}
+
+              <div id="pay-with-paypal"
+                   data-create-order-url="{{ path('payment_paypal_create_order', { slug: order.slug }) }}"
+                   data-capture-payment-url="{{ path('payment_paypal_capture', { slug: order.slug }) }}"
+                   data-order-url="{{ path('legacy_order', { url: order.slug }) }}"
+              ></div>
             {% endif %}
-
-            <p>Payez avec votre compte PayPal.</p>
-
-            <div id="pay-with-paypal"
-                 data-create-order-url="{{ path('payment_paypal_create_order', { slug: order.slug }) }}"
-                 data-capture-payment-url="{{ path('payment_paypal_capture', { slug: order.slug }) }}"
-                 data-order-url="{{ path('legacy_order', { url: order.slug }) }}"
-            ></div>
           </div>
         </div>
       </div>

--- a/src/Biblys/Service/PaymentService.php
+++ b/src/Biblys/Service/PaymentService.php
@@ -242,6 +242,7 @@ class PaymentService
             $payment->setAmount($total_amount);
             $payment->setProviderId($response->id);
             $payment->setUrl($response->hosted_payment->payment_url);
+            $payment->save();
 
             return $payment;
         } catch (HttpException $exception) {

--- a/src/Usecase/MarkOrderAsShippedUsecase.php
+++ b/src/Usecase/MarkOrderAsShippedUsecase.php
@@ -55,9 +55,14 @@ class MarkOrderAsShippedUsecase
         $order->setTrackNumber($trackingNumber);
         $order->save();
 
+        if (!$order->getShippingOption()) {
+            return;
+        }
+
         $mailSubjectSuffix = $this->currentSite->getOption("shipped_mail_subject") ?? "a été expédiée !";
         $mailSubject = "Votre commande $mailSubjectSuffix";
         $mailMessage = $this->currentSite->getOption("shipped_mail_message") ?? "Votre commande n°{$order->getId()} a été expédiée.";
+
         $isPickup = $order->getShippingOption()->getType() === "magasin";
         if ($isPickup) {
             $mailSubject = "Votre commande est disponible en magasin !";

--- a/tests/AppBundle/Controller/PaymentControllerTest.php
+++ b/tests/AppBundle/Controller/PaymentControllerTest.php
@@ -216,7 +216,7 @@ class PaymentControllerTest extends TestCase
     {
         // given
         $controller = new PaymentController();
-        $order = ModelFactory::createOrder();
+        $order = ModelFactory::createOrder(amountToBePaid: 1000);
         $config = new Config(["stripe" => ["public_key" => "abcd"]]);
         $currentSite = Mockery::mock(CurrentSite::class);
         $currentSite->expects("getOption")->with("payment_iban")->andReturn(null);

--- a/tests/Usecase/MarkOrderAsShippedUsecaseTest.php
+++ b/tests/Usecase/MarkOrderAsShippedUsecaseTest.php
@@ -34,6 +34,34 @@ require_once __DIR__ . "/../setUp.php";
 
 class MarkOrderAsShippedUsecaseTest extends TestCase
 {
+    /**
+     * @throws Exception
+     * @throws PropelException
+     * @throws InvalidEmailAddressException
+     * @throws TransportExceptionInterface
+     * @throws \Exception
+     */
+    public function testExecuteForOrderWithoutShippingOption()
+    {
+        // given
+        $order = ModelFactory::createOrder(email: "customer@paronymie.fr");
+        $site = ModelFactory::createSite();
+
+        $currentSite = Mockery::mock(CurrentSite::class);
+        $currentSite->expects("getOption")->andReturn(null);
+        $currentSite->expects("getSite")->andReturn($site);
+        $mailer = $this->createMock(Mailer::class);
+        $templateService = Helpers::getTemplateService();
+
+        $usecase = new MarkOrderAsShippedUsecase($currentSite, $templateService, $mailer);
+
+        // when
+        $usecase->execute($order, trackingNumber: null);
+
+        // then
+        $order->reload();
+        $this->assertNotNull($order->getShippingDate());
+    }
 
     /**
      * @throws Exception


### PR DESCRIPTION
## Corrections

- Les commandes payées avec PayPal et PayPlug pouvaient ne pas être marquées
  comme payées. C'est corrigé.
- Le marquage d'une commande numérique comme expédiée pouvait échouer sans 
  erreur. Ça n'arrivera plus.
