### PR TITLE
Correctif 3.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Historique des modifications
 
+## 3.5.2 (DEV)
+
+### Corrections
+
+- La présence d'un paramètre fbclid ajouté par Facebook dans l'URL de certaines 
+  pages pouvait provoquer une erreur. C'est corrigé.
+
 ## 3.5.1 (9 avril 2025)
 
 ### Corrections

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Historique des modifications
 
-## 3.5.2 (DEV)
+## 3.5.2 (16 avril 2025)
 
 ### Corrections
 

--- a/inc/constants.php
+++ b/inc/constants.php
@@ -15,4 +15,4 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-const BIBLYS_VERSION = "3.5.1";
+const BIBLYS_VERSION = "3.5.2-dev.1";

--- a/inc/constants.php
+++ b/inc/constants.php
@@ -15,4 +15,4 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-const BIBLYS_VERSION = "3.5.2-dev.1";
+const BIBLYS_VERSION = "3.5.2";

--- a/src/Biblys/Service/QueryParamsService.php
+++ b/src/Biblys/Service/QueryParamsService.php
@@ -25,6 +25,15 @@ class QueryParamsService extends ParamsService
     public function __construct(private readonly Request $request)
     {
         $rawParams = $this->request->query->all();
+
+        $parametersToIgnore = ["fbclid", "ttclid", "utm_source", "utm_medium", "utm_campaign", "utm_term", "utm_content"];
+
+        foreach ($parametersToIgnore as $param) {
+            if (isset($rawParams[$param])) {
+                unset($rawParams[$param]);
+            }
+        }
+
         parent::__construct($rawParams);
     }
 }

--- a/tests/Biblys/Service/ParamsServiceTest.php
+++ b/tests/Biblys/Service/ParamsServiceTest.php
@@ -437,8 +437,6 @@ class ParamsServiceTest extends TestCase
         $this->assertEquals(123, $page);
     }
 
-
-
     public function testGetIntThrowsForNonNumericValue(): void
     {
         // given

--- a/tests/Biblys/Service/QueryParamsServiceTest.php
+++ b/tests/Biblys/Service/QueryParamsServiceTest.php
@@ -1,0 +1,70 @@
+<?php
+/*
+ * Copyright (C) 2025 Clément Latzarus
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+
+namespace Biblys\Service;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+class QueryParamsServiceTest extends TestCase
+{
+    /** fbclid */
+
+    public function testFbclidIsIgnored(): void
+    {
+        // given
+        $request = new Request();
+        $request->query->set("id", "123");
+        $request->query->set("fbclid", "456");
+
+        $queryParamsService = new QueryParamsService($request);
+
+        // when
+        $queryParamsService->parse([
+            "id" => [
+                "type" => "numeric",
+            ],
+        ]);
+
+        // then
+        $this->assertEquals("123", $queryParamsService->get("id"));
+    }
+
+
+    /** ttclid */
+
+    public function testTtclidIsIgnored(): void
+    {
+        // given
+        $request = new Request();
+        $request->query->set("id", "123");
+        $request->query->set("ttclid", "456");
+
+        $queryParamsService = new QueryParamsService($request);
+
+        // when
+        $queryParamsService->parse([
+            "id" => [
+                "type" => "numeric",
+            ],
+        ]);
+
+        // then
+        $this->assertEquals("123", $queryParamsService->get("id"));
+    }
+}


### PR DESCRIPTION
## Corrections

- La présence d'un paramètre fbclid ajouté par Facebook dans l'URL de certaines 
  pages pouvait provoquer une erreur. C'est corrigé.
