### PR TITLE
Correctif 3.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Historique des modifications
 
+## 3.6.1 (DEV)
+
+### Corrections
+
+- La création d'un contributeur, d'une collection, d'un éditeur ou d'un cycle
+  depuis la page d'édition d'un article pouvait échouer. C'est corrigé.
+
 ## 3.6.0 (6 juin 2025)
 
 ### Améliorations

--- a/inc/constants.php
+++ b/inc/constants.php
@@ -15,4 +15,4 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-const BIBLYS_VERSION = "3.6.0";
+const BIBLYS_VERSION = "3.6.1-dev";

--- a/public/common/js/article_edit.js
+++ b/public/common/js/article_edit.js
@@ -431,7 +431,7 @@ $(document).ready(function () {
     minLength: 3,
     delay: 250,
     select: function (event, ui) {
-      if (ui.item.create === '1') { // Créer une nouvelle collection
+      if (ui.item.create === 1) { // Créer une nouvelle collection
         $('#collection_name').val(ui.item.value);
         $('#createCollection').dialog({
           title: 'Créer une nouvelle collection',
@@ -465,7 +465,7 @@ $(document).ready(function () {
       minLength: 3,
       delay: 250,
       select: function (event, ui) {
-        if (ui.item.create === '1') { // Créer un nouvel editeur
+        if (ui.item.create === 1) { // Créer un nouvel editeur
           $('#collection_publisher').addClass('loading');
           $.post({
             url: '/x/adm_article_publisher',
@@ -495,7 +495,7 @@ $(document).ready(function () {
     minLength: 3,
     delay: 250,
     select: function (event, ui) {
-      if (ui.item.create === '1') { // Créer un nouveau cycle
+      if (ui.item.create === 1) { // Créer un nouveau cycle
         $('#article_cycle').addClass('loading');
         $.ajax({
           url: '/x/adm_article_cycle',
@@ -533,7 +533,7 @@ $(document).ready(function () {
     select: function (event, ui) {
       const field = $(this);
       field.attr('readonly', 'readonly').addClass('loading');
-      if (ui.item.create === '1') { // Créer un nouveau contributeur
+      if (ui.item.create === 1) { // Créer un nouveau contributeur
         $('#create_people').dialog({
           title: 'Créer un nouveau contributeur',
           modal: true,


### PR DESCRIPTION
- La création d'un contributeur, d'une collection, d'un éditeur ou d'un cycle depuis la page d'édition d'un article pouvait échouer. C'est corrigé.