### PR TITLE
Correctif 3.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Historique des modifications
 
+## 3.7.1 (DEV)
+
+### Corrections
+
+* La page des ventes numériques pouvaient mettre du temps à s'afficher si
+  le nombre de ventes était important. Elle affiche désormais par défaut
+  uniquement les ventes du mois courant.
+
 ## 3.7.0 (11 juillet 2025)
 
 ### Améliorations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,19 @@
 # Historique des modifications
 
-## 3.7.1 (DEV)
+## 3.7.1 (23 juillet 2025)
 
 ### Corrections
 
 * La page des ventes numériques pouvaient mettre du temps à s'afficher si
   le nombre de ventes était important. Elle affiche désormais par défaut
   uniquement les ventes du mois courant.
+* La sélection d'un article depuis la page "Ajouter un exemplaire" ne 
+  déclenchait plus aucune action. Désormais, la sélection de l'article permettra
+  d'aller à la page d'ajout d'exemplaire pour cet article.
+* Le pré-remplissage des champs Titre et EAN sur la page d'édition d'article
+  ne fonctionnait plus. C'est corrigé.
+* La recherche automatique dans les bases externes n'était plus lancée lors de
+  la création d'un nouvel article avec des champs pré-remplis. C'est corrigé.
 
 ## 3.7.0 (11 juillet 2025)
 

--- a/controllers/common/php/adm_ebooks.php
+++ b/controllers/common/php/adm_ebooks.php
@@ -61,11 +61,15 @@ return function(Request $request): Response
     $reqParams = [];
     $reqPeopleParams = [];
 
-    if (!empty($_GET["date1"])) {
-        $req .= " AND `stock_selling_date` >= :date1 AND `stock_selling_date` <= :date2";
-        $reqParams['date1'] = $request->query->get('date1') . ' 00:00:00';
-        $reqParams['date2'] = $request->query->get('date2') . ' 23:59:59';
-    }
+    $firstDayOfCurrentMonth = date("Y-m-01");
+    $lastDayOfCurrentMonth = date("Y-m-t");
+
+    $startDate = $request->query->get("date1", $firstDayOfCurrentMonth);
+    $endDate = $request->query->get("date2", $lastDayOfCurrentMonth);
+
+    $req .= " AND `stock_selling_date` >= :date1 AND `stock_selling_date` <= :date2";
+    $reqParams["date1"] = "$startDate 00:00:00";
+    $reqParams["date2"] = "$endDate 23:59:59";
 
     $articleId = $request->query->get('article_id');
     if ($articleId) {
@@ -169,14 +173,14 @@ return function(Request $request): Response
                 <div class="form-group row">
                     <label for="date1" class="col-sm-3 col-form-label text-right">Du :</label>
                     <div class="col-sm-9">
-                        <input type="date" class="form-control" id="date1" name="date1" value="' . ($_GET["date1"] ?? null) . '">
+                        <input type="date" class="form-control" id="date1" name="date1" value="' . ($startDate ?? null) . '">
                     </div>
                 </div>
 
                 <div class="form-group row">
                     <label for="date2" class="col-sm-3 col-form-label text-right">Au :</label>
                     <div class="col-sm-9">
-                        <input type="date" class="form-control" id="date2" name="date2" value="' . ($_GET["date2"] ?? null) . '">
+                        <input type="date" class="form-control" id="date2" name="date2" value="' . ($endDate ?? null) . '">
                     </div>
                 </div>
                 

--- a/controllers/common/php/article_edit.php
+++ b/controllers/common/php/article_edit.php
@@ -288,6 +288,9 @@ return function (
     if (!isset($_GET['id'])) {
         $_GET['id'] = null;
     }
+
+    $autoImport = false;
+
     $articles = EntityManager::prepareAndExecute(
         'SELECT * FROM `articles`
     WHERE (`article_id` = :article_id OR `article_editing_user` = :user_id)
@@ -363,6 +366,7 @@ return function (
 
             $importQuery = $request->query->get("import");
             if (isset($importQuery)) {
+                $autoImport = true;
                 if (Isbn::isParsable($importQuery)) {
                     $article->setEan(Isbn::convertToEan13($importQuery));
                 } else {
@@ -716,6 +720,9 @@ return function (
           data-mode="{{ form_mode }}"
           data-uploading=0 
           data-submitted=0
+          {% if auto_import %}
+            data-autoimport="true"
+          {% endif %}
         >
     
             <fieldset>
@@ -1190,6 +1197,7 @@ return function (
     ', [
         "article" => $article,
         "form_mode" => $formMode,
+        "auto_import" => $autoImport,
     ]);
 
     return new Response($content);

--- a/controllers/common/php/article_edit.php
+++ b/controllers/common/php/article_edit.php
@@ -360,11 +360,13 @@ return function (
         } else {
             $request->attributes->set("page_title", "Créer un nouvel article");
             $formMode = 'insert';
-            if (isset($_GET['import'])) {
-                if (Isbn::isParsable($_GET['import'])) {
-                    $a['article_ean'] = Isbn::convertToEan13($_GET['import']);
+
+            $importQuery = $request->query->get("import");
+            if (isset($importQuery)) {
+                if (Isbn::isParsable($importQuery)) {
+                    $article->setEan(Isbn::convertToEan13($importQuery));
                 } else {
-                    $a['article_title'] = $_GET['import'];
+                    $article->setTitle($importQuery);
                 }
             }
             $content .= '<h1><span class="fa fa-book"></span> Créer un nouvel article</h1>';

--- a/inc/constants.php
+++ b/inc/constants.php
@@ -15,4 +15,4 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-const BIBLYS_VERSION = "3.7.0";
+const BIBLYS_VERSION = "3.7.1-dev";

--- a/inc/constants.php
+++ b/inc/constants.php
@@ -15,4 +15,4 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-const BIBLYS_VERSION = "3.7.1-dev";
+const BIBLYS_VERSION = "3.7.1";

--- a/public/common/js/article_edit.js
+++ b/public/common/js/article_edit.js
@@ -652,6 +652,11 @@ $(document).ready(function () {
 
 document.addEventListener('DOMContentLoaded', function () {
 
+  const autoImport = document.querySelector('#article_form')?.dataset.autoimport;
+  if (autoImport) {
+    article_search();
+  }
+
   const article = {
     id: document.querySelector('#article_id')?.value
   };

--- a/src/AppBundle/Resources/views/StockItem/new.html.twig
+++ b/src/AppBundle/Resources/views/StockItem/new.html.twig
@@ -42,6 +42,9 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
     document.addEventListener('DOMContentLoaded', function() {
       const field = document.getElementById('entity-search-field');
       new EntitySearchField(field, {
+        onResultSelected: (result) => {
+          window.location.href = `/pages/adm_stock?add=${result.value}`;
+        },
         action: {
           label: 'Créer un article pour « %query% »',
           onSelect: (query) => {

--- a/src/AppBundle/Resources/views/Utils/_entity-search-field.html.twig
+++ b/src/AppBundle/Resources/views/Utils/_entity-search-field.html.twig
@@ -49,10 +49,10 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
       Commencer à écrire pour lancer la recherche.<br />
     </p>
     <p class="text-muted">
-      Utilisez la touche <kbd>Tab</kbd> ou les touches
+      Utilisez les touches
       <kbd><i class="fa-solid fa-arrow-down"></i></kbd> et
       <kbd><i class="fa-solid fa-arrow-up"></i></kbd>
-      pour sélectionner un résultat.
+      pour sélectionner un résultat ou une action.
     </p>
     <p class="text-muted mb-0">
       Appuyez sur <kbd>Entrée</kbd> pour valider la sélection.


### PR DESCRIPTION
## Corrections

* La page des ventes numériques pouvaient mettre du temps à s'afficher si
  le nombre de ventes était important. Elle affiche désormais pas défaut
  uniquement les ventes du mois courant.
* La sélection d'un article depuis la page "Ajouter un exemplaire" ne 
  déclenchait plus aucune action. Désormais, la sélection de l'article permettra
  d'aller à la page d'ajout d'exemplaire pour cet article.
* Le pré-remplissage des champs Titre et EAN sur la page d'édition d'article
  ne fonctionnait plus. C'est corrigé.
* La recherche automatique dans les bases externes n'était plus lancée lors de
  la création d'un nouvel article avec des champs pré-remplis. C'est corrigé.