### PR TITLE
Correctif 3.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Historique des modifications
 
+## 3.8.1 (DEV)
+
+### Corrections
+
+- Les fichiers téléchargeables associés à un article ne s'affichaient pas
+  correctement. C'est corrigé.
+
 ## 3.8.0 (6 août 2025)
 
 ### Améliorations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Historique des modifications
 
-## 3.8.1 (DEV)
+## 3.8.1 (28 août 2025)
 
 ### Corrections
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Les fichiers téléchargeables associés à un article ne s'affichaient pas
   correctement. C'est corrigé.
+- La section "Contenu du lot" n'apparaissait sur la page d'édition d'un article
+  lorsque le type "Lot" était sélectionné. C'est corrigé.
 
 ## 3.8.0 (6 août 2025)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   correctement. C'est corrigé.
 - La section "Contenu du lot" n'apparaissait sur la page d'édition d'un article
   lorsque le type "Lot" était sélectionné. C'est corrigé.
+- La recherche de contributeur·ices pouvaient ne renvoyer aucun résultat si le
+  nom ou le prénom contenait certains caractères accentués. C'est corrigé.
 
 ## 3.8.0 (6 août 2025)
 

--- a/controllers/common/php/adm_article_people.php
+++ b/controllers/common/php/adm_article_people.php
@@ -17,6 +17,7 @@
 
 
 use Biblys\Service\QueryParamsService;
+use Biblys\Service\Slug\SlugService;
 use Model\PeopleQuery;
 use Propel\Runtime\ActiveQuery\Criteria;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -30,10 +31,11 @@ return function (Request $request, QueryParamsService $params): JsonResponse {
     $params->parse(["term" => ["type" => "string", "default" => ""]]);
     $term = $params->get("term");
 
+    $slugService = new SlugService();
+    $slugTerm = $slugService->slugify($term);
+
     $people = PeopleQuery::create()
-        ->filterByLastName("%$term%", Criteria::LIKE)
-        ->_or()
-        ->filterByFirstName("%$term%", Criteria::LIKE)
+        ->filterByUrl("%$slugTerm%", Criteria::LIKE)
         ->limit(25)
         ->find();
 

--- a/inc/constants.php
+++ b/inc/constants.php
@@ -15,4 +15,4 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-const BIBLYS_VERSION = "3.8.1-dev.1";
+const BIBLYS_VERSION = "3.8.1-dev.2";

--- a/inc/constants.php
+++ b/inc/constants.php
@@ -15,4 +15,4 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-const BIBLYS_VERSION = "3.8.1-dev.3";
+const BIBLYS_VERSION = "3.8.1";

--- a/inc/constants.php
+++ b/inc/constants.php
@@ -15,4 +15,4 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-const BIBLYS_VERSION = "3.8.1-dev.2";
+const BIBLYS_VERSION = "3.8.1-dev.3";

--- a/inc/constants.php
+++ b/inc/constants.php
@@ -15,4 +15,4 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-const BIBLYS_VERSION = "3.8.1-dev";
+const BIBLYS_VERSION = "3.8.1-dev.1";

--- a/inc/constants.php
+++ b/inc/constants.php
@@ -15,4 +15,4 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-const BIBLYS_VERSION = "3.8.0";
+const BIBLYS_VERSION = "3.8.1-dev";

--- a/public/common/js/article_edit.js
+++ b/public/common/js/article_edit.js
@@ -153,6 +153,48 @@ document.addEventListener('DOMContentLoaded', function() {
   });
 });
 
+/** Add to bundle autocomplete */
+document.addEventListener('DOMContentLoaded', function() {
+  const field = document.getElementById('add-to-bundle-search-field');
+  new EntitySearchField(field, {
+    onResultSelected: (field, { value }) => {
+      const articleId = document.getElementById('article_id').value;
+      $.post(`/api/admin/articles/${value}/add-to-bundle`, {
+          bundle_id: articleId,
+        },
+        /**
+         * @param res {object}
+         * @param res.error {string} Error message if any
+         * @param res.link_id {number} ID of the newly created link
+         * @param res.article_title {string} Title of the article
+         * @param res.article_authors {string} Authors of the article
+         * @param res.article_collection {string} Collection of the article
+         * @param res.article_url {string} URL of the article
+         */
+        function (res) {
+          if (res.error) {
+            window._alert(res.error);
+          } else {
+            const row = `<tr id="link_${res.link_id}" class="new">
+                    <td>${res.article_title}</td>
+                    <td>${res.article_authors}</td>
+                    <td>${res.article_collection}</td>
+                    <td>
+                        <button type="button" class="btn btn-danger btn-sm deleteLink pointer" data-link_id="${res.link_id}">
+                            <i aria-label="Supprimer" class="fa-solid fa-chain-broken"></i>
+                        </button> 
+                    </td>
+                </tr>`;
+            $('#bundle_articles').append(row);
+            $('.new').slideDown().removeClass('new');
+            $('#addToBundle').val('');
+            reloadArticleAdminEvents();
+          }
+        });
+      field.reset();
+    },
+  });
+});
 
 /* eslint-env jquery */
 
@@ -575,48 +617,6 @@ $(document).ready(function () {
       }
     }
   }).keypress(function () { $(this).autocomplete('search'); });
-
-  // Ajouter au lot
-  $('#addToBundle').autocomplete({
-    source: '/pages/adm_article_search',
-    minLength: 3,
-    delay: 250,
-    select: function (event, ui) {
-      const articleId = $('#article_id').val();
-      $.post(`/api/admin/articles/${ui.item.article_id}/add-to-bundle`, {
-        bundle_id: articleId,
-      },
-      /**
-       * @param res {object}
-       * @param res.error {string} Error message if any
-       * @param res.link_id {number} ID of the newly created link
-       * @param res.article_title {string} Title of the article
-       * @param res.article_authors {string} Authors of the article
-       * @param res.article_collection {string} Collection of the article
-       * @param res.article_url {string} URL of the article
-       */
-      function (res) {
-        if (res.error) {
-          window._alert(res.error);
-        } else {
-          const row = `<tr id="link_${res.link_id}" class="new">
-                    <td>${res.article_title}</td>
-                    <td>${res.article_authors}</td>
-                    <td>${res.article_collection}</td>
-                    <td>
-                        <button type="button" class="btn btn-danger btn-sm deleteLink pointer" data-link_id="${res.link_id}">
-                            <i aria-label="Supprimer" class="fa-solid fa-chain-broken"></i>
-                        </button> 
-                    </td>
-                </tr>`;
-          $('#bundle_articles').append(row);
-          $('.new').slideDown().removeClass('new');
-          $('#addToBundle').val('');
-          reloadArticleAdminEvents();
-        }
-      });
-    }
-  }).keypress(function (event) { if (event.keyCode === 13) { event.preventDefault(); } });
 });
 
 document.addEventListener('DOMContentLoaded', function () {

--- a/public/common/js/article_edit.js
+++ b/public/common/js/article_edit.js
@@ -258,13 +258,20 @@ function reloadArticleAdminEvents(scope) {
 
   // Changer le type d'article
   $('#type_id', scope).change(function () {
-    const type_id = $(this).val();
+    const type_id = Number(this.value);
+
+    const ebooksFieldset = document.getElementById('ebooks_fieldset');
+    const bundleFieldset = document.getElementById('bundle_fieldset');
+
+    ebooksFieldset && (ebooksFieldset.style.display = 'none');
+    bundleFieldset && (bundleFieldset.style.display = 'none');
+
     if (type_id === 2) {
-      $('#ebooks_fieldset').slideDown();
-    } else if (type_id === 8) {
-      $('#bundle_fieldset').slideDown();
-    } else {
-      $('#ebooks_fieldset').slideUp();
+      ebooksFieldset && (ebooksFieldset.style.display = 'block');
+    }
+
+    if (type_id === 8) {
+      bundleFieldset && (bundleFieldset.style.display = 'block');
     }
   });
 

--- a/src/AppBundle/Resources/views/Legacy/article-edit.html.twig
+++ b/src/AppBundle/Resources/views/Legacy/article-edit.html.twig
@@ -402,7 +402,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
       </tr>
       </thead>
       <tbody>
-      {{ files_table }}
+      {{ files_table|raw }}
       </tbody>
       <tfoot>
       <tr>

--- a/src/AppBundle/Resources/views/Legacy/article-edit.html.twig
+++ b/src/AppBundle/Resources/views/Legacy/article-edit.html.twig
@@ -232,15 +232,12 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
       <tbody>
       {{ bundle_articles|raw }}
       </tbody>
-      </tfoot>
-      <tr>
-        <td colspan="4">
-          <input type="text" id="addToBundle" class="form-control" placeholder="Titre de l’article à ajouter..." />
-        </td>
-      </tr>
-      </tfoot>
     </table>
-    </ul>
+    {% include "AppBundle:Utils:_entity-search-field.html.twig" with {
+      query_url: "/pages/adm_article_search",
+      label: "Ajouter un article au lot…",
+      field_id: "add-to-bundle-search-field",
+    } %}
   </fieldset>
 
   <fieldset id="Contributeurs">

--- a/src/AppBundle/Resources/views/Legacy/article-edit.html.twig
+++ b/src/AppBundle/Resources/views/Legacy/article-edit.html.twig
@@ -139,6 +139,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
           field_id: "collection-search-field",
           selected_result_value: article.bookCollection ? article.bookCollection.id : '',
           selected_result_label: article.bookCollection ? article.bookCollection.name : '',
+          required: true,
         } %}
       </div>
       <span class="col-auto col-form-label text-md-right">n°</span>


### PR DESCRIPTION
## Corrections

- Les fichiers téléchargeables associés à un article ne s'affichaient pas correctement. C'est corrigé.
- La section "Contenu du lot" n'apparaissait sur la page d'édition d'un article lorsque le type "Lot" était sélectionné. C'est corrigé.
- La recherche de contributeur·ices pouvaient ne renvoyer aucun résultat si le nom ou le prénom contenait certains caractères accentués. C'est corrigé.
