### PR TITLE
Ajouter un use case pour marquer une commande comme payée

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Historique des modifications
 
+## 3.13.0 (DEV)
+
+### Améliorations
+
+- Le courriel de confirmation de paiement a été modernisé.
+
 ## 3.12.1 (9 avril 2026)
 
 ### Corrections

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,479 @@
+# Refactoring : Extraction de la logique de paiement en Use Cases
+
+## Contexte
+
+La logique de paiement vit dans `OrderManager` (`inc/Order.class.php`), une
+classe legacy qui mélange persistance et logique métier. Deux méthodes sont
+concernées :
+
+- **`addPayment()`** (l.507-558) : enregistre un paiement, met à jour les
+  montants, et si tout est payé, crée le container DI inline pour appeler
+  `markAsPayed()`
+- **`markAsPayed()`** (l.564-669) : date de paiement, transfert ebooks,
+  auto-expédition si pas de physique, email de confirmation en HTML dur
+
+**Objectif** : migrer vers des usecases Propel, chaque étape mergeable
+indépendamment.
+
+---
+
+## Phase 0 — Test de non-régression au niveau contrôleur
+
+Il n'existe aucun test contrôleur pour les flux de paiement. Seul le marquage admin est testable facilement en l'état (les webhooks Stripe/PayPlug/PayPal instancient `OrderManager`/`PaymentManager` avec `new` et appellent des API statiques externes, ce qui les rend impossibles à tester sans refacto préalable).
+
+### 0.1 — Ajouter `testUpdateActionToMarkOrderAsPayed`
+
+**Fichier** : `tests/AppBundle/Controller/OrderControllerTest.php`
+
+Suivre le pattern exact de `testUpdateActionToMarkOrderAsShipped` (l.128) :
+
+```php
+public function testUpdateActionToMarkOrderAsPayed()
+{
+    // given
+    $controller = new OrderController();
+    $order = ModelFactory::createOrder();
+    $payload = json_encode(["payment_mode" => "cash", "tracking_number" => null]);
+    $request = new Request(content: $payload);
+    $currentSite = Mockery::mock(CurrentSite::class);
+    $currentUser = Mockery::mock(CurrentUser::class);
+    $currentUser->shouldReceive("authAdmin")->once();
+    $templateService = Mockery::mock(TemplateService::class);
+    $mailer = Mockery::mock(Mailer::class);
+    $mailer->shouldReceive("send")->once();
+
+    // when
+    $response = $controller->updateAction(
+        $request, $currentSite, $currentUser,
+        $templateService, $mailer,
+        $order->getId(), "payed"
+    );
+
+    // then
+    $this->assertEquals(200, $response->getStatusCode());
+    $updatedOrder = OrderQuery::create()->findPk($order->getId());
+    $this->assertNotNull($updatedOrder->getPaymentDate());
+}
+```
+
+**Attention** : `updateAction` utilise `new OrderManager()` en interne. Il faut s'assurer que l'entité legacy correspondante existe aussi (vérifier si `ModelFactory::createOrder()` crée à la fois le Propel Order et l'entité legacy, ou s'il faut aussi utiliser `EntityFactory`).
+
+### Filet de sécurité pendant la transition
+
+1. **Test 0.1** pour le flux admin
+2. **Tests unitaires des usecases** (phases B et D) pour la logique métier
+3. **Tests legacy existants** (`OrderTest`, `OrderManagerTest`) qui continuent de passer
+4. Les webhooks deviendront testables après le refacto (contrôleur mince + usecase injecté)
+
+---
+
+## Phase A — Préparation (nouveaux fichiers uniquement, zéro changement existant)
+
+### A.1 — Ajouter `containsPhysicalArticles()` et
+`containsDownloadableArticles()` sur `\Model\Order`
+
+`Cart` a déjà `containsDownloadableArticles()` et `containsPhysicalArticles()` (
+`src/Model/Cart.php:75-86`). Order a besoin des mêmes méthodes pour le usecase.
+
+**Fichier** : `src/Model/Order.php`
+
+- Ajouter `containsDownloadableArticles(): bool` — itérer `getStockItems()`,
+  vérifier `$item->getArticle()->getType()->isDownloadable()`
+- Ajouter `containsPhysicalArticles(): bool` — itérer `getStockItems()`,
+  vérifier `$item->getArticle()->getType()->isPhysical()`
+- Ajouter les tests correspondants
+
+**Fichiers modifiés** : `src/Model/Order.php`  
+**Fichiers créés** : aucun (tests dans un fichier existant ou nouveau
+`tests/Model/OrderTest.php`)
+
+---
+
+### A.2 — Créer le template Twig `order-paid-email.html.twig`
+
+S'inspirer de
+`src/AppBundle/Resources/views/Order/order-shipped-email.html.twig` qui étend
+`layout:email-layout.html.twig`.
+
+**Fichier** : `src/AppBundle/Resources/views/Order/order-paid-email.html.twig`
+
+Variables du template :
+
+- `subject` — sujet de l'email
+- `order_id` — numéro de commande
+- `order_total` — montant formaté
+- `payment_mode` — mode de paiement
+- `order_url` — lien vers le suivi
+- `has_downloadable` — boolean, affiche le lien bibliothèque numérique
+- `library_url` — URL de la bibliothèque numérique
+
+---
+
+## Phase B — Créer `MarkOrderAsPayedUsecase`
+
+### B.1 — Créer le usecase
+
+**Fichier** : `src/Usecase/MarkOrderAsPayedUsecase.php`
+
+```php
+class MarkOrderAsPayedUsecase
+{
+    public function __construct(
+        private readonly CurrentSite $currentSite,
+        private readonly UrlGenerator $urlGenerator,
+        private readonly TemplateService $templateService,
+        private readonly Mailer $mailer,
+    ) {}
+
+    public function execute(\Model\Order $order): void
+    {
+        // 1. Enregistrer la date de paiement
+        $order->setPaymentDate(new DateTime());
+
+        // 2. Boucler sur les stock items
+        //    - Séparer ebooks / physiques (via ArticleType::isDownloadable / isPhysical)
+        //    - Assigner les physiques au user : $item->setUser($order->getUser()); $item->save()
+
+        // 3. Transférer les ebooks dans la bibliothèque
+        //    - Filtrer les items dont getArticle()->getType()->isDownloadable()
+        //    - Appeler AddArticleToUserLibraryUsecase (déjà existant, src/Usecase/AddArticleToUserLibraryUsecase.php)
+        //    - Passer sendEmail: true
+
+        // 4. Si pas de produits physiques → $order->setShippingDate(new DateTime())
+
+        // 5. $order->save()
+
+        // 6. Envoyer l'email de confirmation via TemplateService + Mailer
+        //    - Rendre le template order-paid-email.html.twig
+        //    - Envoyer via $this->mailer->send()
+    }
+}
+```
+
+**Points d'attention** :
+
+- Le usecase utilise `\Model\Order` (Propel), pas l'entité legacy
+- `AddArticleToUserLibraryUsecase` est instancié avec `$this->mailer` et appelé
+  avec `$this->currentSite`, `$this->urlGenerator`
+- Le code legacy assigne `$stock->set('user_id', $order->get('user_id'))` pour
+  les items physiques → en Propel : `$item->setUser($order->getUser())`
+- L'email legacy catch les exceptions silencieusement → garder ce comportement
+
+### B.2 — Créer les tests
+
+**Fichier** : `tests/Usecase/MarkOrderAsPayedUsecaseTest.php`
+
+Cas de test :
+
+1. **Commande simple** (pas d'ebooks, pas de physique) — vérifie `paymentDate`
+   définie, `shippingDate` définie (auto-expédié), email envoyé
+2. **Commande avec ebooks** — vérifie que `AddArticleToUserLibraryUsecase` est
+   appelé (mock ou vérifier que les items sont dans la bibliothèque)
+3. **Commande avec physique** — vérifie que `shippingDate` n'est PAS définie,
+   que les items physiques sont assignés au user
+4. **Commande mixte** (ebooks + physique) — vérifie les deux comportements
+
+Utiliser les patterns de `tests/OrderManagerTest.php` (Mockery pour CurrentSite,
+UrlGenerator) et `tests/Usecase/` pour la structure.
+
+---
+
+## Phase C — Brancher `MarkOrderAsPayedUsecase` dans `OrderManager`
+
+### C.1 — Transformer `OrderManager::markAsPayed()` en wrapper
+
+**Fichier** : `inc/Order.class.php` (l.564-669)
+
+Remplacer le corps de `markAsPayed()` par :
+
+```php
+public function markAsPayed(CurrentSite $currentSite, UrlGenerator $urlGenerator, Order $order): void
+{
+    $propelOrder = \Model\OrderQuery::create()->findPk($order->get('id'));
+    $container = include __DIR__."/../src/container.php";
+    $templateService = $container->get("template_service");
+    $mailer = $this->getMailer();
+
+    $usecase = new MarkOrderAsPayedUsecase($currentSite, $urlGenerator, $templateService, $mailer);
+    $usecase->execute($propelOrder);
+
+    // Recharger l'entité legacy depuis la DB pour synchroniser les champs
+    $order->set('order_payment_date', $propelOrder->getPaymentDate()->format('Y-m-d H:i:s'));
+    if ($propelOrder->getShippingDate()) {
+        $order->set('order_shipping_date', $propelOrder->getShippingDate()->format('Y-m-d H:i:s'));
+    }
+}
+```
+
+**Note** : le `$container` est déjà utilisé dans `addPayment()` (l.553), donc ce
+n'est pas un nouveau couplage.
+
+### C.2 — Mettre à jour les tests de `OrderManagerTest`
+
+**Fichier** : `tests/OrderManagerTest.php`
+
+Les tests existants appellent `markAsPayed()` directement. Ils doivent continuer
+de passer car le wrapper délègue au usecase. Potentiellement, il faudra mocker
+`TemplateService` en plus (vérifier si le container le fournit dans le contexte
+de test).
+
+### C.3 — Vérification
+
+```bash
+composer test:path tests/OrderManagerTest.php
+composer test:path tests/Usecase/MarkOrderAsPayedUsecaseTest.php
+composer test
+```
+
+---
+
+## Phase D — Créer `AddPaymentToOrderUsecase`
+
+### D.1 — Créer le usecase
+
+**Fichier** : `src/Usecase/AddPaymentToOrderUsecase.php`
+
+```php
+class AddPaymentToOrderUsecase
+{
+    public function __construct(
+        private readonly MarkOrderAsPayedUsecase $markOrderAsPayedUsecase,
+    ) {}
+
+    public function execute(\Model\Order $order, string $mode, int $amount): void
+    {
+        // 1. Créer le Payment Propel
+        $payment = new \Model\Payment();
+        $payment->setOrder($order);
+        $payment->setSite($order->getSite());
+        $payment->setMode($mode);
+        $payment->setAmount($amount);
+        $payment->setExecuted(new DateTime());
+        $payment->save();
+
+        // 2. Mettre à jour le montant pour ce mode sur la commande
+        //    Mapping mode → setter Propel :
+        //    "cash" → setPaymentCash(), "cheque" → setPaymentCheque(),
+        //    "transfer" → setPaymentTransfer(), "card" → setPaymentCard(),
+        //    "paypal" → setPaymentPaypal(), "payplug" → setPaymentPayplug(),
+        //    "stripe" → setPaymentCard() (pas de colonne stripe, utiliser card)
+        //    Note: vérifier le mapping exact utilisé par le code legacy
+        $currentAmount = $this->getPaymentAmountForMode($order, $mode);
+        $this->setPaymentAmountForMode($order, $mode, $currentAmount + $amount);
+
+        // 3. Calculer le restant dû
+        $remaining = max(0, $order->getAmountTobepaid() - $amount);
+        $order->setAmountTobepaid($remaining);
+
+        // 4. Sauvegarder le mode de paiement
+        $order->setPaymentMode($mode);
+        $order->save();
+
+        // 5. Si entièrement payé → marquer comme payé
+        if ($remaining === 0) {
+            $this->markOrderAsPayedUsecase->execute($order);
+        }
+    }
+
+    // Méthodes privées pour le mapping mode → getter/setter Propel
+    // (match expression sur $mode)
+}
+```
+
+**Points d'attention** :
+
+- Le mapping `mode → colonne` est déduit du schema : `order_payment_cash`,
+  `order_payment_cheque`, `order_payment_transfer`, `order_payment_card`,
+  `order_payment_paypal`, `order_payment_payplug`
+- Le code legacy utilise `$order->get('order_payment_'.$mode)` dynamiquement →
+  en Propel, faire un `match ($mode)` vers les getters/setters typés
+- Le mode `"stripe"` n'a pas de colonne dédiée → vérifier quel mode utilise le
+  code Stripe actuel (probablement `"card"` ou une autre convention)
+- `\Model\Payment` a déjà `setExecuted()` (via Propel Base, l.695 de
+  `Base/Payment.php`)
+
+### D.2 — Créer les tests
+
+**Fichier** : `tests/Usecase/AddPaymentToOrderUsecaseTest.php`
+
+Cas de test :
+
+1. **Paiement partiel** — montant restant > 0, `markAsPayed` PAS appelé
+2. **Paiement complet** — montant restant = 0, `markAsPayed` appelé
+3. **Paiement qui dépasse** — remaining ne descend pas en dessous de 0
+4. **Différents modes** — vérifier le mapping pour cash, cheque, card, paypal,
+   payplug
+
+### D.3 — Vérification
+
+```bash
+composer test:path tests/Usecase/AddPaymentToOrderUsecaseTest.php
+```
+
+---
+
+## Phase E — Migrer les contrôleurs (un par un, chaque étape mergeable)
+
+### E.1 — Migrer le contrôleur Admin (le plus simple)
+
+**Fichier** : `src/AppBundle/Controller/OrderController.php` (l.189-193)
+
+Avant :
+
+```php
+$om = new OrderManager();
+$orderEntity = $om->getById($id);
+$amount = $orderEntity->get('amount_tobepaid');
+$om->addPayment($orderEntity, $requestBody->payment_mode, $amount);
+```
+
+Après :
+
+```php
+$order = OrderQuery::create()->findPk($id);
+$usecase = new AddPaymentToOrderUsecase($markOrderAsPayedUsecase);
+$usecase->execute($order, $requestBody->payment_mode, $order->getAmountTobepaid());
+```
+
+**Note** : il faut que le contrôleur ait accès à `MarkOrderAsPayedUsecase` pour
+construire `AddPaymentToOrderUsecase`. Options :
+
+- Injecter les dépendances dans l'action du contrôleur (via les
+  ArgumentValueResolvers existants)
+- Ou instancier le usecase inline avec les services disponibles
+
+Vérifier que `TemplateService`, `Mailer`, `CurrentSite`, `UrlGenerator` sont
+déjà injectables dans ce contrôleur (le contrôleur a déjà `$currentSite`,
+`$templateService`, `$mailer` dans la signature de `updateAction`).
+
+### E.2 — Migrer le contrôleur Stripe
+
+**Fichier** : `src/AppBundle/Controller/PaymentController.php` (l.181-199)
+
+Avant :
+
+```php
+$om = new OrderManager();
+$order = $om->getById($payment->get('order_id'));
+$om->addPayment($order, $payment);
+```
+
+Ici, `addPayment` reçoit un objet `Payment` legacy. Avec le nouveau usecase, il
+faut extraire le mode et le montant :
+
+Après :
+
+```php
+$propelOrder = \Model\OrderQuery::create()->findPk($payment->get('order_id'));
+$usecase = new AddPaymentToOrderUsecase($markOrderAsPayedUsecase);
+$usecase->execute($propelOrder, $payment->get('mode'), $payment->get('amount'));
+```
+
+**Note** : le `Payment` legacy est déjà créé avant (l.182 via
+`PaymentManager::get()`). Avec le nouveau usecase, le Payment Propel est créé
+par le usecase. Il y a donc un doublon : le payment legacy existe déjà en base.
+Deux options :
+
+1. **Option A** : ne pas créer un nouveau Payment dans le usecase, mais plutôt
+   recevoir un `\Model\Payment` optionnel déjà existant et le mettre à jour
+2. **Option B** : le contrôleur récupère le Payment legacy, extrait mode +
+   amount, et le usecase crée un nouveau Payment Propel → il faut s'assurer de
+   ne pas dupliquer l'enregistrement
+
+**Recommandation** : Option A — ajouter un paramètre optionnel
+`?\Model\Payment $existingPayment = null` au usecase. Si fourni, on le met à
+jour au lieu d'en créer un nouveau. Cela correspond au cas Stripe/PayPlug où le
+Payment est créé en amont.
+
+**Signature ajustée** :
+
+```php
+public function execute(
+    \Model\Order $order,
+    string $mode,
+    int $amount,
+    ?\Model\Payment $existingPayment = null,
+): void
+```
+
+### E.3 — Migrer le contrôleur PayPlug
+
+**Fichier** : `src/AppBundle/Controller/OrderController.php` (l.298-301)
+
+Même pattern que Stripe (Payment legacy déjà créé).
+
+Après :
+
+```php
+$propelPayment = \Model\PaymentQuery::create()->findPk($payment->get('id'));
+$propelOrder = \Model\OrderQuery::create()->findPk($order->get('id'));
+$usecase = new AddPaymentToOrderUsecase($markOrderAsPayedUsecase);
+$usecase->execute($propelOrder, $propelPayment->getMode(), $propelPayment->getAmount(), $propelPayment);
+```
+
+### E.4 — Migrer le contrôleur PayPal
+
+**Fichier** : `src/ApiBundle/Controller/PaymentController.php` (l.146-152)
+
+Avant :
+
+```php
+$orderManager = new OrderManager();
+$orderEntity = $orderManager->getById($order->getId());
+$orderManager->addPayment($orderEntity, "paypal", $paidAmount * 100);
+```
+
+Après :
+
+```php
+$propelOrder = \Model\OrderQuery::create()->findPk($order->getId());
+$usecase = new AddPaymentToOrderUsecase($markOrderAsPayedUsecase);
+$usecase->execute($propelOrder, "paypal", (int)($paidAmount * 100));
+```
+
+**Note** : ce contrôleur est dans `ApiBundle`, vérifier que les services sont
+injectables via les ArgumentResolvers.
+
+---
+
+## Phase F — Nettoyage
+
+### F.1 — Supprimer `OrderManager::addPayment()` et
+`OrderManager::markAsPayed()`
+
+**Fichier** : `inc/Order.class.php`
+
+- Supprimer `addPayment()` (l.507-558)
+- Supprimer `markAsPayed()` (l.564-669)
+
+### F.2 — Supprimer/migrer les tests legacy
+
+- `tests/OrderTest.php` : les tests `testAddPayment`, `testAddPaymentObject`,
+  `testAddPaymentWhenPayed` (l.203-256) testent la méthode supprimée → les
+  supprimer ou les migrer en tests du usecase
+- `tests/OrderManagerTest.php` : les tests `testMarkAsPayed`,
+  `testMarkAsPayedWithEbooks` → supprimer (couverts par les tests du usecase)
+
+### F.3 — Vérification finale
+
+```bash
+composer test
+```
+
+---
+
+## Résumé de l'ordre (chaque ligne = 1 PR mergeable)
+
+| #  | Étape                                          | Risque                                         | Fichiers principaux                                                                          |
+|----|------------------------------------------------|------------------------------------------------|----------------------------------------------------------------------------------------------|
+| 0  | 0.1 — Test contrôleur marquage admin payé      | Nul (ajout test)                               | `tests/AppBundle/Controller/OrderControllerTest.php`                                         |
+| 1  | A.1 — Méthodes helper sur `\Model\Order`       | Nul (ajout)                                    | `src/Model/Order.php`                                                                        |
+| 2  | A.2 — Template Twig email                      | Nul (ajout)                                    | `src/AppBundle/Resources/views/Order/order-paid-email.html.twig`                             |
+| 3  | B — `MarkOrderAsPayedUsecase` + tests          | Nul (ajout)                                    | `src/Usecase/MarkOrderAsPayedUsecase.php`, `tests/Usecase/MarkOrderAsPayedUsecaseTest.php`   |
+| 4  | C — Wrapper dans `OrderManager::markAsPayed()` | Faible (changement interne, même comportement) | `inc/Order.class.php`, `tests/OrderManagerTest.php`                                          |
+| 5  | D — `AddPaymentToOrderUsecase` + tests         | Nul (ajout)                                    | `src/Usecase/AddPaymentToOrderUsecase.php`, `tests/Usecase/AddPaymentToOrderUsecaseTest.php` |
+| 6  | E.1 — Migrer Admin                             | Faible                                         | `src/AppBundle/Controller/OrderController.php`                                               |
+| 7  | E.2 — Migrer Stripe                            | Faible                                         | `src/AppBundle/Controller/PaymentController.php`                                             |
+| 8  | E.3 — Migrer PayPlug                           | Faible                                         | `src/AppBundle/Controller/OrderController.php`                                               |
+| 9  | E.4 — Migrer PayPal                            | Faible                                         | `src/ApiBundle/Controller/PaymentController.php`                                             |
+| 10 | F — Nettoyage legacy                           | Moyen (suppression)                            | `inc/Order.class.php`, `tests/OrderTest.php`, `tests/OrderManagerTest.php`                   |

--- a/inc/Order.class.php
+++ b/inc/Order.class.php
@@ -24,6 +24,8 @@ use Biblys\Service\CurrentSite;
 use Biblys\Service\CurrentUser;
 use Biblys\Service\Log;
 use Biblys\Service\Mailer;
+use Biblys\Test\Helpers;
+use Model\OrderQuery;
 use Model\StockQuery;
 use Model\UserQuery;
 use PayPal\Api\Amount;
@@ -47,6 +49,7 @@ use Symfony\Component\Mailer\Exception\TransportExceptionInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Generator\UrlGenerator;
 use Usecase\AddArticleToUserLibraryUsecase;
+use Usecase\MarkOrderAsPaidUsecase;
 
 class Order extends Entity
 {
@@ -565,107 +568,25 @@ class OrderManager extends EntityManager
     {
         $mailer = $this->getMailer();
 
-        // Save payment date
-        $order->set('order_payment_date', date('Y-m-d H:i:s'));
+        $templateService = Helpers::getTemplateService();
 
-        $order_downloadable = null;
-        if ($order->containsDownloadable()) {
-            $order_downloadable = '
-                <p>
-                    Vous pouvez télécharger les articles numériques de votre commande depuis
-                    <a href="http://'.$this->site->get('domain').'/pages/log_myebooks">
-                        votre bibliothèque numérique
-                    </a>.
-                </p>
-            ';
-        }
+        $addArticleToUserLibraryUsecase = new AddArticleToUserLibraryUsecase($mailer);
 
-        // Physical types
-        $types = ArticleType::getAllPhysicalTypes();
-        $physical_types = array_map(function ($type) {
-            return $type->getId();
-        }, $types);
+        $usecase = new MarkOrderAsPaidUsecase(
+            urlGenerator: $urlGenerator,
+            templateService: $templateService,
+            mailer: $mailer,
+            currentSite: $currentSite,
+            addArticleToUserLibraryUsecase: $addArticleToUserLibraryUsecase,
+        );
 
-        // Loop through each copy
-        $sm = new StockManager();
-        $stocks = $sm->getAll(array('order_id' => $order->get('id')));
-        $books = [];
-        $ebooks = [];
-        $physical = [];
+        $orderModel = OrderQuery::create()->findPk($order->get('id'));
 
-        foreach ($stocks as $stock) {
-            $type_id = $stock->get('article')->get('type_id');
-
-            if ($type_id == 2) {
-                $ebooks[] = $stock;
-            } else {
-                $books[] = $stock;
-                $stock->set('user_id', $order->get('user_id'));
-                $sm->update($stock);
-            }
-
-            // If article is physical
-            if (in_array($type_id, $physical_types)) {
-                $physical[] = $stock;
-            }
-        }
-
-        // Books & e-books
-        if ($order->has('user_id') && !empty($ebooks)) {
-            $items = array_map(function (Stock $ebook) {
-                return StockQuery::create()->findPk($ebook->get('id'));
-            }, $ebooks);
-
-            $user = UserQuery::create()->findPk($order->get('user_id'));
-            $usecase = new AddArticleToUserLibraryUsecase($mailer);
-            $usecase->execute(
-                currentSite: $currentSite,
-                urlGenerator: $urlGenerator,
-                user: $user,
-                items: $items,
-                sendEmail: true,
-            );
-        }
-
-        // If no physical products, mark order as shipped without warning the user
-        if (!count($physical)) {
-            $order->set('order_shipping_date', date('Y-m-d H:i:s'));
-        }
-
-        // Persist
-        $this->update($order);
-
-        // Send mail
-        $subject = 'Commande n° '.$order->get('id').' payée';
-        $message = '
-            <p>Bonjour '.$order->get('firstname').' !</p>
-
-            <p>Votre paiement pour la commande n° '.$order->get('id').' a bien été reçu.</p>
-
-            <p>
-                Commande n° '.$order->get('id').'<br>
-                Montant : '.currency($order->getTotal() / 100).'<br>
-                Mode de règlement : '.$order->get('payment_mode'). '<br>
-            </p>
-
-            <p>
-                <a href="https://' .$this->site->get('domain').'/order/'.$order->get('url').'">Suivi de la commande</a></a>
-            </p>
-
-            '.$order_downloadable.'
-
-            <p>
-                Merci pour votre confiance.
-            </p>
-
-            <p><a href="http://'.$this->site->get('domain').'/">http://'.$this->site["site_domain"].'/</a></p>
-        ';
-
-        try {
-            $mailer->send($order->get('email'), $subject, $message);
-        } catch (Exception $e) {
-            // Do nothing
-        }
+        $usecase->execute(
+            order: $orderModel,
+            payedAmountInCents: $order->get('order_amount'),
+            paymentMode: $order->get('payment_mode'),
+        );
     }
 
     public function followUp(Order $order)

--- a/inc/constants.php
+++ b/inc/constants.php
@@ -15,4 +15,4 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-const BIBLYS_VERSION = "3.12.1";
+const BIBLYS_VERSION = "3.13.0-dev";

--- a/src/AppBundle/Resources/views/Order/order-payed-email.html.twig
+++ b/src/AppBundle/Resources/views/Order/order-payed-email.html.twig
@@ -1,0 +1,62 @@
+{#
+Copyright (C) 2024 Clément Latzarus
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, version 3.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#}
+
+{% extends "layout:email-layout.html.twig" %}
+
+{% block subject %}
+  {{ subject }}
+{% endblock %}
+
+{% block preview %}
+{% endblock %}
+
+{% block content %}
+  <h1>Merci !</h1>
+
+  <p>Votre paiement pour la commande n° {{ order_id }} a bien été reçu.</p>
+
+  <p>
+    Montant : {{ payed_amount }}<br>
+    Mode de règlement : {{ payment_mode }}<br>
+  </p>
+
+  {% if has_downloadable %}
+    <p>
+      Vous pouvez télécharger les articles numériques de votre commande depuis
+      <a href="{{ library_url }}">votre bibliothèque numérique</a>.
+    </p>
+  {% endif %}
+
+  <p>
+    Merci pour votre confiance.
+  </p>
+
+  <table role="presentation" border="0" cellpadding="0" cellspacing="0" class="btn btn-primary">
+    <tbody>
+    <tr>
+      <td align="center">
+        <table role="presentation" border="0" cellpadding="0" cellspacing="0">
+          <tbody>
+          <tr>
+            <td><a href="{{ order_url }}" target="_blank">Voir ma commande</a></td>
+          </tr>
+          </tbody>
+        </table>
+      </td>
+    </tr>
+    </tbody>
+  </table>
+{% endblock %}

--- a/src/Biblys/Test/EntityFactory.php
+++ b/src/Biblys/Test/EntityFactory.php
@@ -126,7 +126,7 @@ class EntityFactory
         ?User     $user = null,
         string    $firstName = "Marie",
         string    $lastName = "Golade",
-        string    $orderEmail = "customer@example.net",
+        string    $orderEmail = "customer@paronymie.fr",
         int       $shippingId = 0,
         ?string   $mondialRelayPickupPointCode = null,
         ?DateTime $paymentDate = null,
@@ -148,6 +148,7 @@ class EntityFactory
         $order->set("mondial_relay_pickup_point_code", $mondialRelayPickupPointCode);
         $order->set("order_payment_date", $paymentDate?->format("Y-m-d H:i:s"));
         $order->set("order_payment_mode", $paymentMethod);
+        $order->set("order_email", $orderEmail);
 
         $order->set("user_id", $user?->getId() ?? null);
         $om->update($order);

--- a/src/Biblys/Test/EntityFactory.php
+++ b/src/Biblys/Test/EntityFactory.php
@@ -130,6 +130,7 @@ class EntityFactory
         int       $shippingId = 0,
         ?string   $mondialRelayPickupPointCode = null,
         ?DateTime $paymentDate = null,
+        string    $paymentMethod = null,
     ): Order
     {
         $om = new OrderManager();
@@ -146,6 +147,7 @@ class EntityFactory
         $order->set("shipping_id", $shippingId);
         $order->set("mondial_relay_pickup_point_code", $mondialRelayPickupPointCode);
         $order->set("order_payment_date", $paymentDate?->format("Y-m-d H:i:s"));
+        $order->set("order_payment_mode", $paymentMethod);
 
         $order->set("user_id", $user?->getId() ?? null);
         $om->update($order);

--- a/src/Biblys/Test/Helpers.php
+++ b/src/Biblys/Test/Helpers.php
@@ -25,6 +25,8 @@ use Biblys\Service\MetaTagsService;
 use Biblys\Service\TemplateService;
 use Exception;
 use Mockery;
+use PHPUnit\Framework\Constraint\Callback;
+use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use ReflectionException;
 use Symfony\Component\HttpFoundation\Request;
@@ -86,5 +88,18 @@ class Helpers
             metaTagsService: $metaTags,
             request: $request
         );
+    }
+
+    public static function stringContainsString(array $needles, TestCase $instance): Callback
+    {
+        return $instance->callback(function ($arg) use ($needles) {
+            foreach ($needles as $needle) {
+                if (!str_contains($arg, $needle)) {
+                    throw new \Exception("String not found: $needle in \n\n $arg");
+                }
+            }
+
+            return true;
+        });
     }
 }

--- a/src/Biblys/Test/ModelFactory.php
+++ b/src/Biblys/Test/ModelFactory.php
@@ -317,7 +317,7 @@ class ModelFactory
         string          $city = "Bordeaux",
         ?Country        $country = null,
         string          $phone = "0601020304",
-        string          $email = "silas.coade@example.net",
+        string          $email = "silas.coade@paronymie.fr",
         ?string         $mondialRelayPickupPointCode = null,
         DateTime        $paymentDate = null,
         DateTime        $cancelDate = null,
@@ -724,7 +724,7 @@ class ModelFactory
         ?string $axysAccountId = null,
         string  $firstName = "Silas",
         string  $lastName = "Coade",
-        string  $email = "silas.coade@example.net",
+        string  $email = "silas.coade@paronymie.fr",
     ): Customer
     {
         $customer = new Customer();

--- a/src/Model/Order.php
+++ b/src/Model/Order.php
@@ -105,6 +105,22 @@ class Order extends BaseOrder
     /**
      * @throws PropelException
      */
+    public function containsPhysicalArticles(): bool
+    {
+        $stockItems = $this->getStockItems()->getArrayCopy();
+
+        foreach ($stockItems as $stockItem) {
+            if ($stockItem->getArticle()->getType()->isPhysical()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @throws PropelException
+     */
     public function containsDownloadableArticles(): bool
     {
         $stockItems = $this->getStockItems()->getArrayCopy();

--- a/src/Model/Order.php
+++ b/src/Model/Order.php
@@ -101,4 +101,20 @@ class Order extends BaseOrder
             return $totalWeight + $stockItem->getWeight();
         }, 0);
     }
+
+    /**
+     * @throws PropelException
+     */
+    public function containsDownloadableArticles(): bool
+    {
+        $stockItems = $this->getStockItems()->getArrayCopy();
+
+        foreach ($stockItems as $stockItem) {
+            if ($stockItem->getArticle()->getType()->isDownloadable()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
 }

--- a/src/Model/Order.php
+++ b/src/Model/Order.php
@@ -39,6 +39,15 @@ class Order extends BaseOrder
     {
         return $this->getPaymentDate() !== null;
     }
+
+    /**
+     * @throws PropelException
+     */
+    public function isShipped(): bool
+    {
+        return $this->getShippingDate() !== null;
+    }
+
     /**
      * @throws PropelException
      */

--- a/src/Usecase/AddArticleToUserLibraryUsecase.php
+++ b/src/Usecase/AddArticleToUserLibraryUsecase.php
@@ -45,13 +45,13 @@ class AddArticleToUserLibraryUsecase
      * @throws TransportExceptionInterface
      */
     public function execute(
-        CurrentSite  $currentSite,
-        UrlGenerator $urlGenerator,
-        User         $user,
-        ?Article     $article = null,
-        array        $items = [],
-        bool         $allowsPreDownload = false,
-        bool         $sendEmail = false,
+        CurrentSite           $currentSite,
+        UrlGeneratorInterface $urlGenerator,
+        User                  $user,
+        ?Article              $article = null,
+        array                 $items = [],
+        bool                  $allowsPreDownload = false,
+        bool                  $sendEmail = false,
     ): void
     {
         if ($article) {

--- a/src/Usecase/MarkOrderAsPaidUsecase.php
+++ b/src/Usecase/MarkOrderAsPaidUsecase.php
@@ -1,0 +1,97 @@
+<?php
+/*
+ * Copyright (C) 2026 Clément Latzarus
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+
+namespace Usecase;
+
+use Biblys\Exception\InvalidEmailAddressException;
+use Biblys\Service\InvalidSiteIdException;
+use Biblys\Service\Mailer;
+use Biblys\Service\TemplateService;
+use DateTime;
+use Exception;
+use Model\Map\UserTableMap;
+use Model\Order;
+use Propel\Runtime\Exception\PropelException;
+use Propel\Runtime\Propel;
+use Symfony\Component\Mailer\Exception\TransportExceptionInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Twig\Error\LoaderError;
+use Twig\Error\RuntimeError;
+use Twig\Error\SyntaxError;
+
+readonly class MarkOrderAsPaidUsecase
+{
+
+    public function __construct(
+        private UrlGeneratorInterface $urlGenerator,
+        private TemplateService $templateService,
+        private Mailer $mailer
+    )
+    {
+    }
+
+    /**
+     * @throws InvalidEmailAddressException
+     * @throws PropelException
+     * @throws TransportExceptionInterface
+     * @throws InvalidSiteIdException
+     * @throws LoaderError
+     * @throws RuntimeError
+     * @throws SyntaxError
+     */
+    public function execute(Order $order, int $payedAmountInCents, string $paymentMode): void
+    {
+        $con = Propel::getWriteConnection(UserTableMap::DATABASE_NAME);
+        $con->beginTransaction();
+
+        try {
+            $order->setPaymentDate(new DateTime());
+            $order->save();
+
+            $orderUrl = $this->urlGenerator->generate("legacy_order", ["url" => $order->getSlug()]);
+
+            $formatter = new \NumberFormatter('fr_FR', \NumberFormatter::CURRENCY);
+            $formattedPayedAmount = $formatter->formatCurrency($payedAmountInCents / 100, 'EUR');
+
+            $mailSubject = "Paiement pour votre commande bien reçu";
+            $mailBody = $this->templateService->render(
+                "AppBundle:Order:order-payed-email.html.twig",
+                [
+                    "subject" => $mailSubject,
+                    "order_id" => $order->getId(),
+                    "payed_amount" => $formattedPayedAmount, true,
+                    "payment_mode" => $paymentMode,
+                    "has_downloadable" => false, // $order->containsDownloadableArticles(),
+                    "library_url" => "",
+                    "order_url" => $orderUrl,
+                ]
+            );
+
+            $this->mailer->send(
+                $order->getEmail(),
+                $mailSubject,
+                $mailBody,
+            );
+
+            $con->commit();
+        } catch (Exception $exception) {
+            $con->rollBack();
+            throw $exception;
+        }
+     }
+}

--- a/src/Usecase/MarkOrderAsPaidUsecase.php
+++ b/src/Usecase/MarkOrderAsPaidUsecase.php
@@ -110,6 +110,11 @@ readonly class MarkOrderAsPaidUsecase
                     items: $downloadableItems,
                     sendEmail: true,
                 );
+
+                if (!$order->containsPhysicalArticles()) {
+                    $order->setShippingDate(new DateTime());
+                    $order->save();
+                }
             }
 
             $con->commit();

--- a/src/Usecase/MarkOrderAsPaidUsecase.php
+++ b/src/Usecase/MarkOrderAsPaidUsecase.php
@@ -19,6 +19,7 @@
 namespace Usecase;
 
 use Biblys\Exception\InvalidEmailAddressException;
+use Biblys\Service\CurrentSite;
 use Biblys\Service\InvalidSiteIdException;
 use Biblys\Service\Mailer;
 use Biblys\Service\TemplateService;
@@ -38,21 +39,23 @@ readonly class MarkOrderAsPaidUsecase
 {
 
     public function __construct(
-        private UrlGeneratorInterface $urlGenerator,
-        private TemplateService $templateService,
-        private Mailer $mailer
+        private UrlGeneratorInterface          $urlGenerator,
+        private TemplateService                $templateService,
+        private Mailer                         $mailer,
+        private CurrentSite                    $currentSite,
+        private AddArticleToUserLibraryUsecase $addArticleToUserLibraryUsecase,
     )
     {
     }
 
     /**
+     * @throws BusinessRuleException
      * @throws InvalidEmailAddressException
-     * @throws PropelException
-     * @throws TransportExceptionInterface
-     * @throws InvalidSiteIdException
      * @throws LoaderError
+     * @throws PropelException
      * @throws RuntimeError
      * @throws SyntaxError
+     * @throws TransportExceptionInterface
      */
     public function execute(Order $order, int $payedAmountInCents, string $paymentMode): void
     {
@@ -68,6 +71,11 @@ readonly class MarkOrderAsPaidUsecase
             $formatter = new \NumberFormatter('fr_FR', \NumberFormatter::CURRENCY);
             $formattedPayedAmount = $formatter->formatCurrency($payedAmountInCents / 100, 'EUR');
 
+            $libraryUrl = "";
+            if ($order->containsDownloadableArticles()) {
+                $libraryUrl = $this->urlGenerator->generate("user_library");
+            }
+
             $mailSubject = "Paiement pour votre commande bien reçu";
             $mailBody = $this->templateService->render(
                 "AppBundle:Order:order-payed-email.html.twig",
@@ -76,8 +84,8 @@ readonly class MarkOrderAsPaidUsecase
                     "order_id" => $order->getId(),
                     "payed_amount" => $formattedPayedAmount, true,
                     "payment_mode" => $paymentMode,
-                    "has_downloadable" => false, // $order->containsDownloadableArticles(),
-                    "library_url" => "",
+                    "has_downloadable" => $order->containsDownloadableArticles(),
+                    "library_url" => $libraryUrl,
                     "order_url" => $orderUrl,
                 ]
             );
@@ -88,10 +96,26 @@ readonly class MarkOrderAsPaidUsecase
                 $mailBody,
             );
 
+            if ($order->containsDownloadableArticles()) {
+
+                $downloadableItems = array_values(array_filter(
+                    $order->getStockItems()->getArrayCopy(),
+                    fn($stockItem) => $stockItem->getArticle()->getType()->isDownloadable()
+                ));
+
+                $this->addArticleToUserLibraryUsecase->execute(
+                    currentSite: $this->currentSite,
+                    urlGenerator: $this->urlGenerator,
+                    user: $order->getUser(),
+                    items: $downloadableItems,
+                    sendEmail: true,
+                );
+            }
+
             $con->commit();
         } catch (Exception $exception) {
             $con->rollBack();
             throw $exception;
         }
-     }
+    }
 }

--- a/src/Usecase/MarkOrderAsShippedUsecase.php
+++ b/src/Usecase/MarkOrderAsShippedUsecase.php
@@ -30,12 +30,12 @@ use Twig\Error\LoaderError;
 use Twig\Error\RuntimeError;
 use Twig\Error\SyntaxError;
 
-class MarkOrderAsShippedUsecase
+readonly class MarkOrderAsShippedUsecase
 {
     public function __construct(
-        private readonly CurrentSite $currentSite,
-        private readonly TemplateService $templateService,
-        private readonly Mailer $mailer,
+        private CurrentSite     $currentSite,
+        private TemplateService $templateService,
+        private Mailer          $mailer,
     )
     {
 

--- a/tests/ApiBundle/Controller/OrderControllerTest.php
+++ b/tests/ApiBundle/Controller/OrderControllerTest.php
@@ -101,7 +101,7 @@ class OrderControllerTest extends TestCase
             "FR",                      # I - Pays du destinataire (O)
             "+33601020304",            # J - Téléphone fixe du destinataire (F)
             "",                        # K - Téléphone cellulaire (F)
-            "SILAS.COADE@EXAMPLE.NET", # L - Adresse e-mail du destinataire (F)
+            "SILAS.COADE@PARONYMIE.FR", # L - Adresse e-mail du destinataire (F)
             "R",                       # M - Type Collect (R = Relais)
             "654321",                  # N - Id Relais Collecte
             "FR",                      # O - Code Pays Collecte

--- a/tests/AppBundle/Controller/OrderControllerTest.php
+++ b/tests/AppBundle/Controller/OrderControllerTest.php
@@ -130,7 +130,7 @@ class OrderControllerTest extends TestCase
         $controller = new OrderController();
         $order = ModelFactory::createOrder();
 
-        $payload = json_encode(["payment_mode" => null, "tracking_number" => null]);
+        $payload = json_encode(["payment_mode" => "card", "tracking_number" => null]);
         $request = new Request(content: $payload);
         $currentSite = Mockery::mock(CurrentSite::class);
         $currentUser = Mockery::mock(CurrentUser::class);

--- a/tests/AppBundle/Controller/OrderControllerTest.php
+++ b/tests/AppBundle/Controller/OrderControllerTest.php
@@ -118,7 +118,42 @@ class OrderControllerTest extends TestCase
         $this->assertEquals("/order/order-slug", $response->getTargetUrl());
     }
 
-    /** updateAction */
+    /** updateAction
+     * @throws InvalidEmailAddressException
+     * @throws PropelException
+     * @throws TransportExceptionInterface
+     */
+
+    public function testUpdateActionToMarkOrderAsPaid(): void
+    {
+        // given
+        $controller = new OrderController();
+        $order = ModelFactory::createOrder();
+
+        $payload = json_encode(["payment_mode" => null, "tracking_number" => null]);
+        $request = new Request(content: $payload);
+        $currentSite = Mockery::mock(CurrentSite::class);
+        $currentUser = Mockery::mock(CurrentUser::class);
+        $currentUser->shouldReceive("authAdmin")->once()->andReturn();
+        $templateService = Mockery::mock(TemplateService::class);
+        $mailer = Mockery::mock(Mailer::class);
+
+        // when
+        $response = $controller->updateAction(
+            $request,
+            $currentSite,
+            $currentUser,
+            $templateService,
+            $mailer,
+            $order->getId(),
+            "payed",
+        );
+
+        // then
+        $this->assertEquals(200, $response->getStatusCode());
+        $order->reload();
+        $this->assertTrue($order->isPaid());
+    }
 
     /**
      * @throws InvalidEmailAddressException

--- a/tests/Biblys/Legacy/OrderDeliveryHelpersTest.php
+++ b/tests/Biblys/Legacy/OrderDeliveryHelpersTest.php
@@ -325,7 +325,7 @@ class OrderDeliveryHelpersTest extends TestCase
         $mailer = Mockery::mock(Mailer::class);
         $mailer->shouldReceive("send")
             ->with(
-                "customer@example.net",
+                "customer@paronymie.fr",
                 "Commande n° {$order->get("id")}",
                 $mailBody
             )
@@ -336,7 +336,7 @@ class OrderDeliveryHelpersTest extends TestCase
                 "Commande n° {$order->get("id")}",
                 $mailBody,
                 ['contact@paronymie.fr' => 'Marie Golade'],
-                ['reply-to' => 'customer@example.net'],
+                ['reply-to' => 'customer@paronymie.fr'],
             )
             ->andReturn(true);
 
@@ -451,7 +451,7 @@ class OrderDeliveryHelpersTest extends TestCase
         $mailer = Mockery::mock(Mailer::class);
         $mailer->shouldReceive("send")
             ->with(
-                "customer@example.net",
+                "customer@paronymie.fr",
                 "Commande n° {$order->get("id")}",
                 $mailBody
             )
@@ -462,7 +462,7 @@ class OrderDeliveryHelpersTest extends TestCase
                 "Commande n° {$order->get("id")}",
                 $mailBody,
                 ['contact@paronymie.fr' => 'Rondial Melay'],
-                ['reply-to' => 'customer@example.net'],
+                ['reply-to' => 'customer@paronymie.fr'],
             )
             ->andReturn(true);
 
@@ -509,7 +509,7 @@ class OrderDeliveryHelpersTest extends TestCase
         $mailer = Mockery::mock(Mailer::class);
         $mailer->shouldReceive("send")
             ->with(
-                "customer@example.net",
+                "customer@paronymie.fr",
                 "Commande n° {$order->get("id")}",
                 Mockery::any()
             )
@@ -520,7 +520,7 @@ class OrderDeliveryHelpersTest extends TestCase
                 "PARONYMIE · Commande n° {$order->get("id")}",
                 Mockery::any(),
                 ['contact@paronymie.fr' => 'Marie Golade'],
-                ['reply-to' => 'customer@example.net'],
+                ['reply-to' => 'customer@paronymie.fr'],
             )
             ->andReturn(true);
 
@@ -636,7 +636,7 @@ class OrderDeliveryHelpersTest extends TestCase
         $mailer = Mockery::mock(Mailer::class);
         $mailer->shouldReceive("send")
             ->with(
-                "customer@example.net",
+                "customer@paronymie.fr",
                 "Commande n° {$order->get("id")} (mise à jour)",
                 $mailBody,
             )
@@ -647,7 +647,7 @@ class OrderDeliveryHelpersTest extends TestCase
                 "Commande n° {$order->get("id")} (mise à jour)",
                 $mailBody,
                 ['contact@paronymie.fr' => 'Marie Golade'],
-                ['reply-to' => 'customer@example.net'],
+                ['reply-to' => 'customer@paronymie.fr'],
             )
             ->andReturn(true);
 

--- a/tests/Model/OrderTest.php
+++ b/tests/Model/OrderTest.php
@@ -230,9 +230,51 @@ class OrderTest extends TestCase
         $this->assertEquals(579, $result);
     }
 
-    /** containsDownloadableArticle /*
+    /** containsPhysicalArticles */
 
-    /*
+    /**
+     * @return void
+     * @throws PropelException
+     */
+    public function testContainsPhysicalArticlesWhenFalse(): void
+    {
+        // given
+        $order = new Order();
+        $downloadableArticle = ModelFactory::createArticle(typeId: ArticleType::EBOOK);
+        $stockItem = ModelFactory::createStockItem($downloadableArticle);
+        $order->addStockItem($stockItem);
+
+        // when
+        $result = $order->containsPhysicalArticles();
+
+        // then
+        $this->assertFalse($result);
+    }
+
+    /**
+     * @return void
+     * @throws PropelException
+     */
+    public function testContainsPhysicalArticlesWhenTrue(): void
+    {
+        // given
+        $order = new Order();
+        $physicalArticle = ModelFactory::createArticle();
+        $stockItem = ModelFactory::createStockItem($physicalArticle);
+        $order->addStockItem($stockItem);
+
+        // when
+        $result = $order->containsPhysicalArticles();
+
+        // then
+        $this->assertTrue($result);
+    }
+
+    /**
+     * containsDownloadableArticles
+     */
+
+    /**
      * @throws PropelException
      */
     public function testContainsDownloadableArticlesWhenFalse(): void

--- a/tests/Model/OrderTest.php
+++ b/tests/Model/OrderTest.php
@@ -62,6 +62,34 @@ class OrderTest extends TestCase
         $this->assertTrue($result);
     }
 
+    /** isShipped */
+
+    public function testIsShippedReturnsFalseForUnshippedOrder(): void
+    {
+        // given
+        $order = new Order();
+        $order->setShippingDate(null);
+
+        // when
+        $result = $order->isShipped();
+
+        // then
+        $this->assertFalse($result);
+    }
+
+    public function testIsShippedReturnsTrueForShippedOrder(): void
+    {
+        // given
+        $order = new Order();
+        $order->setShippingDate(new DateTime());
+
+        // when
+        $result = $order->isShipped();
+
+        // then
+        $this->assertTrue($result);
+    }
+
     /** isCancelled */
 
     /**

--- a/tests/Model/OrderTest.php
+++ b/tests/Model/OrderTest.php
@@ -18,6 +18,7 @@
 
 namespace Model;
 
+use Biblys\Data\ArticleType;
 use Biblys\Test\ModelFactory;
 use DateTime;
 use PHPUnit\Framework\TestCase;
@@ -93,7 +94,6 @@ class OrderTest extends TestCase
         // then
         $this->assertTrue($result);
     }
-
 
     /** getTrackingLink */
 
@@ -228,5 +228,43 @@ class OrderTest extends TestCase
 
         // then
         $this->assertEquals(579, $result);
+    }
+
+    /** containsDownloadableArticle /*
+
+    /*
+     * @throws PropelException
+     */
+    public function testContainsDownloadableArticlesWhenFalse(): void
+    {
+        // given
+        $order = new Order();
+        $physicalArticle = ModelFactory::createArticle();
+        $stockItem = ModelFactory::createStockItem($physicalArticle);
+        $order->addStockItem($stockItem);
+
+        // when
+        $result = $order->containsDownloadableArticles();
+
+        // then
+        $this->assertFalse($result);
+    }
+
+    /**
+     * @throws PropelException
+     */
+    public function testContainsDownloadableArticlesWhenTrue(): void
+    {
+        // given
+        $order = new Order();
+        $downloadableArticle = ModelFactory::createArticle(typeId: ArticleType::EBOOK);
+        $stockItem = ModelFactory::createStockItem($downloadableArticle);
+        $order->addStockItem($stockItem);
+
+        // when
+        $result = $order->containsDownloadableArticles();
+
+        // then
+        $this->assertTrue($result);
     }
 }

--- a/tests/OrderManagerTest.php
+++ b/tests/OrderManagerTest.php
@@ -20,7 +20,7 @@ use Biblys\Data\ArticleType;
 use Biblys\Service\CurrentSite;
 use Biblys\Test\EntityFactory;
 use Biblys\Test\ModelFactory;
-use Model\OptionQuery;
+use Model\OrderQuery;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Mailer\Exception\TransportExceptionInterface;
 use Symfony\Component\Routing\Generator\UrlGenerator;
@@ -37,15 +37,19 @@ class OrderManagerTest extends TestCase
     {
         // given
         $orderManager = new OrderManager();
-        $order = EntityFactory::createOrder(orderEmail: "customer@paronymie.fr");
+        $order = EntityFactory::createOrder(orderEmail: "customer@paronymie.fr", paymentMethod: "stripe");
         $currentSite = Mockery::mock(CurrentSite::class);
         $urlGenerator = Mockery::mock(UrlGenerator::class);
+        $urlGenerator->shouldReceive("generate")->with("legacy_order", [
+            "url" => $order->get("url"),
+        ]);
 
         // when
         $orderManager->markAsPayed($currentSite, $urlGenerator, $order);
 
         // then
-        $this->assertTrue($order->isPayed());
+        $updatedOrder = OrderQuery::create()->findPk($order->get("id"));
+        $this->assertTrue($updatedOrder->isPaid());
     }
 
     /**
@@ -58,7 +62,7 @@ class OrderManagerTest extends TestCase
         $site = ModelFactory::createSite();
         $user = ModelFactory::createUser();
         $orderManager = new OrderManager();
-        $orderEntity = EntityFactory::createOrder(user: $user, orderEmail: "customer@paronymie.fr");
+        $orderEntity = EntityFactory::createOrder(user: $user, orderEmail: "customer@paronymie.fr", paymentMethod: "card");
         $ebook = ModelFactory::createArticle(typeId: ArticleType::EBOOK);
         $item = EntityFactory::createStock(["article_id" => $ebook->getId()]);
         $orderManager->addStock($orderEntity, $item);
@@ -73,6 +77,7 @@ class OrderManagerTest extends TestCase
         $orderManager->markAsPayed($currentSite, $urlGenerator, $orderEntity);
 
         // then
-        $this->assertTrue($orderEntity->isPayed());
+        $updatedOrder = OrderQuery::create()->findPk($orderEntity->get("id"));
+        $this->assertTrue($updatedOrder->isPaid());
     }
 }

--- a/tests/OrderTest.php
+++ b/tests/OrderTest.php
@@ -150,16 +150,7 @@ class OrderTest extends PHPUnit\Framework\TestCase
 
     /**
      * Test adding stock
-     * @throws Exception
-     * @throws Exception
-     * @throws Exception
-     * @throws Exception
-     * @throws PropelException
-     * @throws Exception
-     * @throws Exception
-     * @throws Exception
-     * @throws Exception
-     * @throws PropelException
+     * @depends testUpdate
      * @throws Exception
      */
     public function testAddStock()
@@ -305,6 +296,7 @@ class OrderTest extends PHPUnit\Framework\TestCase
         $customer = $cm->create();
 
         // Set order customer
+        /** @var Customer $customer */
         $order = $om->create();
         /** @var Customer $customer */
         $om->setCustomer($order, $customer);
@@ -589,6 +581,7 @@ class OrderTest extends PHPUnit\Framework\TestCase
 
     /**
      * Test deleting an order
+     * @depends testGet
      * @throws Exception
      */
     public function testDelete()

--- a/tests/OrderTest.php
+++ b/tests/OrderTest.php
@@ -223,8 +223,8 @@ class OrderTest extends PHPUnit\Framework\TestCase
 
         // Adding payement
         $om->addPayment($order, "cash", $amount);
-        $om->update($order);
 
+        $order = $om->getById($order->get('id'));
         $this->assertEquals(0, $order->get('amount_tobepaid'));
         $this->assertEquals($order->get('payment_cash'), $amount);
         $this->assertNotNull($order->get('payment_date'));
@@ -256,6 +256,7 @@ class OrderTest extends PHPUnit\Framework\TestCase
         // Adding payement
         $om->addPayment($order, $payment);
 
+        $order = $om->getById($order->get('id'));
         $this->assertEquals(0, $order->get('amount_tobepaid'));
         $this->assertEquals(1234, $order->get('payment_cash'));
         $this->assertNotNull($order->get('payment_date'));
@@ -273,8 +274,8 @@ class OrderTest extends PHPUnit\Framework\TestCase
         $om = new OrderManager();
         $order = EntityFactory::createOrder();
         $om->addPayment($order, "cash", "1000");
-        $om->update($order);
 
+        $order = $om->getById($order->get('id'));
         $this->assertEquals(0, $order->get('amount_tobepaid'));
         $this->assertEquals("1000", $order->get('payment_cash'));
         $this->assertNotNull($order->get('payment_date'));

--- a/tests/Usecase/MarkOrderAsPaidUsecaseTest.php
+++ b/tests/Usecase/MarkOrderAsPaidUsecaseTest.php
@@ -18,7 +18,9 @@
 
 namespace Usecase;
 
+use Biblys\Data\ArticleType;
 use Biblys\Exception\InvalidEmailAddressException;
+use Biblys\Service\CurrentSite;
 use Biblys\Service\Mailer;
 use Biblys\Test\Helpers;
 use Biblys\Test\ModelFactory;
@@ -68,6 +70,74 @@ class MarkOrderAsPaidUsecaseTest extends TestCase
             urlGenerator: $urlGenerator,
             templateService: $templateService,
             mailer: $mailer,
+            currentSite: $this->createMock(CurrentSite::class),
+            addArticleToUserLibraryUsecase: $this->createMock(AddArticleToUserLibraryUsecase::class),
+        );
+
+        // when
+        $usecase->execute($order, payedAmountInCents: 999, paymentMode: "Carte bancaire");
+
+        // then
+        $this->assertTrue($order->isPaid(), "order is marked as paid");
+    }
+
+    /**
+     * @throws PropelException
+     * @throws InvalidEmailAddressException
+     * @throws Exception
+     * @throws TransportExceptionInterface
+     * @throws \Exception
+     */
+    public function testMarkingAsPaidOrderWithDownloadableArticles(): void
+    {
+        // given
+        $downloadableArticle = ModelFactory::createArticle(typeId: ArticleType::EBOOK);
+        $stockItem = ModelFactory::createStockItem(article: $downloadableArticle);
+        $user = ModelFactory::createUser();
+        $order = ModelFactory::createOrder(
+            slug: "order-123",
+            email: "payer@paronymie.fr",
+        );
+        $order->addStockItem($stockItem);
+        $order->setUser($user);
+
+        $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
+        $urlGenerator->method("generate")->willReturnMap([
+            ["legacy_order", ["url" => "order-123"], 1, "https://paronymie.fr/order/order-123"],
+            ["user_library", [], 1, "https://paronymie.fr/user/library"],
+        ]);
+        $templateService = Helpers::getTemplateService();
+        $mailer = $this->createMock(Mailer::class);
+        $mailer->expects($this->once())->method("send")->with(
+            $this->anything(),
+            $this->anything(),
+            Helpers::stringContainsString([
+                "Vous pouvez télécharger les articles numériques de votre commande depuis",
+                "https://paronymie.fr/user/library",
+            ], $this),
+        );
+        $currentSite = $this->createMock(CurrentSite::class);
+
+        $addArticleToUserLibraryUsecase = $this->getMockBuilder(AddArticleToUserLibraryUsecase::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(["execute"])
+            ->getMock();
+        $addArticleToUserLibraryUsecase->expects($this->once())->method("execute")->with(
+            $currentSite,
+            $urlGenerator,
+            $user,
+            null,          // article
+            [$stockItem],  // items
+            false,         // allowsPreDownload
+            true,          // sendEmail
+        );
+
+        $usecase = new MarkOrderAsPaidUsecase(
+            urlGenerator: $urlGenerator,
+            templateService: $templateService,
+            mailer: $mailer,
+            currentSite: $currentSite,
+            addArticleToUserLibraryUsecase: $addArticleToUserLibraryUsecase,
         );
 
         // when

--- a/tests/Usecase/MarkOrderAsPaidUsecaseTest.php
+++ b/tests/Usecase/MarkOrderAsPaidUsecaseTest.php
@@ -1,0 +1,80 @@
+<?php
+/*
+ * Copyright (C) 2026 Clément Latzarus
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+
+namespace Usecase;
+
+use Biblys\Exception\InvalidEmailAddressException;
+use Biblys\Service\Mailer;
+use Biblys\Test\Helpers;
+use Biblys\Test\ModelFactory;
+use PHPUnit\Framework\MockObject\Exception;
+use PHPUnit\Framework\TestCase;
+use Propel\Runtime\Exception\PropelException;
+use Symfony\Component\Mailer\Exception\TransportExceptionInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+class MarkOrderAsPaidUsecaseTest extends TestCase
+{
+    /**
+     * @throws PropelException
+     * @throws InvalidEmailAddressException
+     * @throws Exception
+     * @throws TransportExceptionInterface
+     * @throws \Exception
+     */
+    public function testMarkingAsPaidOrderWithPhysicalArticles(): void
+    {
+        // given
+        $order = ModelFactory::createOrder(
+            slug: "order-123",
+            email: "payer@paronymie.fr",
+        );
+
+        $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
+        $urlGenerator->expects($this->once())->method("generate")->with(
+            "legacy_order",
+            ["url" => "order-123"],
+        )->willReturn("https://paronymie.fr/order/order-123");
+        $templateService = Helpers::getTemplateService();
+        $mailer = $this->createMock(Mailer::class);
+        $mailer->expects($this->once())->method("send")->with(
+            "payer@paronymie.fr",
+            "Paiement pour votre commande bien reçu",
+            Helpers::stringContainsString([
+                "Merci !",
+                "Votre paiement pour la commande n° {$order->getId()} a bien été reçu.",
+                "Montant : 9,99 €",
+                "Mode de règlement : Carte bancaire",
+                "https://paronymie.fr/order/order-123",
+            ], $this),
+        );
+
+        $usecase = new MarkOrderAsPaidUsecase(
+            urlGenerator: $urlGenerator,
+            templateService: $templateService,
+            mailer: $mailer,
+        );
+
+        // when
+        $usecase->execute($order, payedAmountInCents: 999, paymentMode: "Carte bancaire");
+
+        // then
+        $order->reload();
+        $this->assertTrue($order->isPaid(), "order is marked as paid");
+    }
+}

--- a/tests/Usecase/MarkOrderAsPaidUsecaseTest.php
+++ b/tests/Usecase/MarkOrderAsPaidUsecaseTest.php
@@ -42,10 +42,13 @@ class MarkOrderAsPaidUsecaseTest extends TestCase
     public function testMarkingAsPaidOrderWithPhysicalArticles(): void
     {
         // given
+        $physicalArticle = ModelFactory::createArticle();
+        $stockItem = ModelFactory::createStockItem(article: $physicalArticle);
         $order = ModelFactory::createOrder(
             slug: "order-123",
             email: "payer@paronymie.fr",
         );
+        $order->addStockItem($stockItem);
 
         $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
         $urlGenerator->expects($this->once())->method("generate")->with(
@@ -79,6 +82,7 @@ class MarkOrderAsPaidUsecaseTest extends TestCase
 
         // then
         $this->assertTrue($order->isPaid(), "order is marked as paid");
+        $this->assertFalse($order->isShipped(), "order is not marked as shipped");
     }
 
     /**
@@ -146,5 +150,76 @@ class MarkOrderAsPaidUsecaseTest extends TestCase
         // then
         $order->reload();
         $this->assertTrue($order->isPaid(), "order is marked as paid");
+        $this->assertTrue($order->isShipped(), "order marked as shipped");
+    }
+
+    /**
+     * @throws PropelException
+     * @throws InvalidEmailAddressException
+     * @throws Exception
+     * @throws TransportExceptionInterface
+     * @throws \Exception
+     */
+    public function testMarkingAsPaidOrderWithBothArticleTypes(): void
+    {
+        // given
+        $user = ModelFactory::createUser();
+        $order = ModelFactory::createOrder(
+            slug: "order-123",
+            email: "payer@paronymie.fr",
+        );
+        $physicalArticle = ModelFactory::createArticle();
+        $physicalStockItem = ModelFactory::createStockItem(article: $physicalArticle);
+        $downloadableArticle = ModelFactory::createArticle(typeId: ArticleType::EBOOK);
+        $downloadableStockItem = ModelFactory::createStockItem(article: $downloadableArticle);
+        $order->addStockItem($physicalStockItem);
+        $order->addStockItem($downloadableStockItem);
+        $order->setUser($user);
+
+        $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
+        $urlGenerator->method("generate")->willReturnMap([
+            ["legacy_order", ["url" => "order-123"], 1, "https://paronymie.fr/order/order-123"],
+            ["user_library", [], 1, "https://paronymie.fr/user/library"],
+        ]);
+        $templateService = Helpers::getTemplateService();
+        $mailer = $this->createMock(Mailer::class);
+        $mailer->expects($this->once())->method("send")->with(
+            $this->anything(),
+            $this->anything(),
+            Helpers::stringContainsString([
+                "Vous pouvez télécharger les articles numériques de votre commande depuis",
+                "https://paronymie.fr/user/library",
+            ], $this),
+        );
+        $currentSite = $this->createMock(CurrentSite::class);
+
+        $addArticleToUserLibraryUsecase = $this->getMockBuilder(AddArticleToUserLibraryUsecase::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(["execute"])
+            ->getMock();
+        $addArticleToUserLibraryUsecase->expects($this->once())->method("execute")->with(
+            $currentSite,
+            $urlGenerator,
+            $user,
+            null,          // article
+            [$downloadableStockItem],  // items
+            false,         // allowsPreDownload
+            true,          // sendEmail
+        );
+
+        $usecase = new MarkOrderAsPaidUsecase(
+            urlGenerator: $urlGenerator,
+            templateService: $templateService,
+            mailer: $mailer,
+            currentSite: $currentSite,
+            addArticleToUserLibraryUsecase: $addArticleToUserLibraryUsecase,
+        );
+
+        // when
+        $usecase->execute($order, payedAmountInCents: 999, paymentMode: "Carte bancaire");
+
+        // then
+        $this->assertTrue($order->isPaid(), "order is marked as paid");
+        $this->assertFalse($order->isShipped(), "order marked as shipped");
     }
 }


### PR DESCRIPTION
## Problème

Contexte : #409 

Le code pour marquer une commande comme payée est assez complexe et implémente de nombreuses règles métiers. Il est actuellement dans la méthode `markAsPayed` de l'entité legacy `Order` ce qui le rend difficile à tester.

## Solution

Ajouter un usecase `MarkOrderAsPayedUsecase` pour implémenter la logique métier.

## Remarques

Pour l'instant, l'ancienne méthode `markAsPayed` est conservée et utilisée comme un wrapper autour du nouveau use case.

## Tests

- [x] Depuis l'administration
  - [x] Marquer une commande contentant des articles physiques comme payés
  - [x] Marquer une commande contentant des articles téléchargeables comme payés
  - [x] Marquer une commande contenant les deux types d'articles comme payés

- [x] Parcours client : ajouter un livre au panier, valider la commande, payer la commande
