### PR TITLE
S'assurer que tous les paiements sont écrits dans la table payments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 3.13.0 (DEV)
 
+### Conformité NF525
+
+- La fonctionnalité "Vendu en magasin" a été supprimée.
+
 ### Améliorations
 
 - Le courriel de confirmation de paiement a été modernisé.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Conformité NF525
 
 - La fonctionnalité "Vendu en magasin" a été supprimée.
+- La possibilité de modifier le paiement d'une commande depuis la page d'édition
+  de commande a été supprimée.
+- Un formulaire "Ajouter un paiement" a été ajouté sur la page d'édition d'une commande.
 
 ### Améliorations
 

--- a/composer.lock
+++ b/composer.lock
@@ -2745,32 +2745,40 @@
         },
         {
             "name": "mailjet/mailjet-apiv3-php",
-            "version": "v1.6.6",
+            "version": "v1.6.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mailjet/mailjet-apiv3-php.git",
-                "reference": "9d5cea25f347719d7df7909fb4a43a72bd4e5011"
+                "reference": "7d515f7a2a8bdb93c29d202c2ae471acdbc61b83"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mailjet/mailjet-apiv3-php/zipball/9d5cea25f347719d7df7909fb4a43a72bd4e5011",
-                "reference": "9d5cea25f347719d7df7909fb4a43a72bd4e5011",
+                "url": "https://api.github.com/repos/mailjet/mailjet-apiv3-php/zipball/7d515f7a2a8bdb93c29d202c2ae471acdbc61b83",
+                "reference": "7d515f7a2a8bdb93c29d202c2ae471acdbc61b83",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "guzzlehttp/guzzle": "^7.4.4",
                 "php": "^8.1",
+                "php-http/discovery": "^1.19",
                 "psr/http-client": "^1.0",
-                "symfony/validator": "^6.3|^7.0"
+                "psr/http-client-implementation": "^1.0",
+                "psr/http-factory": "^1.0",
+                "psr/http-factory-implementation": "^1.0",
+                "symfony/validator": "^6.3|^7.0|^8.0"
             },
             "require-dev": {
+                "guzzlehttp/guzzle": "^7.4.4",
                 "mockery/mockery": "^1.4",
                 "php-coveralls/php-coveralls": "^2.0",
                 "phpcompatibility/php-compatibility": "*",
                 "phpstan/phpstan": "^2.0",
                 "phpunit/phpunit": "^11.4.0",
                 "squizlabs/php_codesniffer": "*"
+            },
+            "suggest": {
+                "guzzlehttp/guzzle": "PSR-18 compatible HTTP client",
+                "symfony/http-client": "PSR-18 compatible HTTP client (use with nyholm/psr7 for PSR-17 factories)"
             },
             "type": "library",
             "autoload": {
@@ -2800,9 +2808,9 @@
             ],
             "support": {
                 "issues": "https://github.com/mailjet/mailjet-apiv3-php/issues",
-                "source": "https://github.com/mailjet/mailjet-apiv3-php/tree/v1.6.6"
+                "source": "https://github.com/mailjet/mailjet-apiv3-php/tree/v1.6.7"
             },
-            "time": "2025-12-24T15:55:48+00:00"
+            "time": "2026-02-25T21:58:12+00:00"
         },
         {
             "name": "matthiasmullie/scrapbook",
@@ -11926,5 +11934,5 @@
     "platform-overrides": {
         "php": "8.2"
     },
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/controllers/common/php/adm_order.php
+++ b/controllers/common/php/adm_order.php
@@ -360,20 +360,20 @@ return function (Request $request, UrlGenerator $urlGenerator): Response|Redirec
             <div class="form-group row">
                 <label for="order_payment_mode" class="col-sm-3 col-form-label">Mode</label>
                 <div class="col-sm-3">
-                    <input type="text" name="order_payment_mode" id="order_payment_mode" value="' . $o["order_payment_mode"] . '" class="form-control" />
+                    <input type="text" name="order_payment_mode" id="order_payment_mode" value="' . $o["order_payment_mode"] . '" class="form-control" disabled />
                 </div>
             </div>
             <div class="form-group row">
                 <label for="order_payment_date" class="col-sm-3 col-form-label">Date</label>
                 <div class="col-sm-5">
-                    <input type="datetime-local" name="order_payment_date" id="order_payment_date" value="' . $o["order_payment_date"] . '" class="form-control" />
+                    <input type="datetime-local" name="order_payment_date" id="order_payment_date" value="' . $o["order_payment_date"] . '" class="form-control" disabled />
                 </div>
             </div>
             <div class="form-group row">
                 <label for="order_payment_cash" class="col-sm-3 col-form-label">Espèces</label>
                 <div class="col-sm-3">
                     <div class="input-group">
-                        <input type="number" name="order_payment_cash" id="order_payment_cash" value="' . $o["order_payment_cash"] . '" class="form-control" />
+                        <input type="number" name="order_payment_cash" id="order_payment_cash" value="' . $o["order_payment_cash"] . '" class="form-control" disabled />
                         <div class="input-group-append"><span class="input-group-text">centimes</span></div>
                     </div>
                 </div>
@@ -382,7 +382,7 @@ return function (Request $request, UrlGenerator $urlGenerator): Response|Redirec
                 <label for="order_payment_cheque" class="col-sm-3 col-form-label">Chèque</label>
                 <div class="col-sm-3">
                     <div class="input-group">
-                        <input type="number" name="order_payment_cheque" id="order_payment_cheque" value="' . $o["order_payment_cheque"] . '" class="form-control" />
+                        <input type="number" name="order_payment_cheque" id="order_payment_cheque" value="' . $o["order_payment_cheque"] . '" class="form-control" disabled />
                         <div class="input-group-append"><span class="input-group-text">centimes</span></div>
                     </div>
                 </div>
@@ -391,7 +391,7 @@ return function (Request $request, UrlGenerator $urlGenerator): Response|Redirec
                 <label for="order_payment_transfer" class="col-sm-3 col-form-label">Virement</label>
                 <div class="col-sm-3">
                     <div class="input-group">
-                        <input type="number" name="order_payment_transfer" id="order_payment_transfer" value="' . $order->get('payment_transfer') . '" class="form-control" />
+                        <input type="number" name="order_payment_transfer" id="order_payment_transfer" value="' . $order->get('payment_transfer') . '" class="form-control" disabled />
                         <div class="input-group-append"><span class="input-group-text">centimes</span></div>
                     </div>
                 </div>
@@ -400,7 +400,7 @@ return function (Request $request, UrlGenerator $urlGenerator): Response|Redirec
                 <label for="order_payment_card" class="col-sm-3 col-form-label">Carte bancaire</label>
                 <div class="col-sm-3">
                     <div class="input-group">
-                        <input type="number" name="order_payment_card" id="order_payment_card" value="' . $o["order_payment_card"] . '" class="form-control" />
+                        <input type="number" name="order_payment_card" id="order_payment_card" value="' . $o["order_payment_card"] . '" class="form-control" disabled />
                         <div class="input-group-append"><span class="input-group-text">centimes</span></div>
                     </div>
                 </div>
@@ -409,7 +409,7 @@ return function (Request $request, UrlGenerator $urlGenerator): Response|Redirec
                 <label for="order_payment_paypal" class="col-sm-3 col-form-label">Paypal</label>
                 <div class="col-sm-3">
                     <div class="input-group">
-                        <input type="number" name="order_payment_paypal" id="order_payment_paypal" value="' . $o["order_payment_paypal"] . '" class="form-control" />
+                        <input type="number" name="order_payment_paypal" id="order_payment_paypal" value="' . $o["order_payment_paypal"] . '" class="form-control" disabled />
                         <div class="input-group-append"><span class="input-group-text">centimes</span></div>
                     </div>
                 </div>
@@ -418,7 +418,7 @@ return function (Request $request, UrlGenerator $urlGenerator): Response|Redirec
                 <label for="order_payment_payplug" class="col-sm-3 col-form-label">Payplug</label>
                 <div class="col-sm-3">
                     <div class="input-group">
-                        <input type="number" name="order_payment_payplug" id="order_payment_payplug" value="' . $o["order_payment_payplug"] . '" class="form-control" />
+                        <input type="number" name="order_payment_payplug" id="order_payment_payplug" value="' . $o["order_payment_payplug"] . '" class="form-control" disabled />
                         <div class="input-group-append"><span class="input-group-text">centimes</span></div>
                     </div>
                 </div>
@@ -427,7 +427,7 @@ return function (Request $request, UrlGenerator $urlGenerator): Response|Redirec
                 <label for="order_payment_left" class="col-sm-3 col-form-label">Monnaie rendue</label>
                 <div class="col-sm-3">
                     <div class="input-group">
-                        <input type="number" name="order_payment_left" id="order_payment_left" value="' . $o["order_payment_left"] . '" class="form-control" />
+                        <input type="number" name="order_payment_left" id="order_payment_left" value="' . $o["order_payment_left"] . '" class="form-control" disabled />
                         <div class="input-group-append"><span class="input-group-text">centimes</span></div>
                     </div>
                 </div>

--- a/controllers/common/php/adm_order.php
+++ b/controllers/common/php/adm_order.php
@@ -19,16 +19,18 @@
 use Biblys\Service\CurrentSite;
 use Model\CountryQuery;
 use Model\ShippingOptionQuery;
+use Model\StockQuery;
 use Propel\Runtime\Exception\PropelException;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\Generator\UrlGenerator;
 
 /**
  * @throws PropelException
  */
-return function (Request $request, CurrentSite $currentSite): Response|RedirectResponse
+return function (Request $request, UrlGenerator $urlGenerator): Response|RedirectResponse
 {
     $cm = new CustomerManager();
     $om = new OrderManager();
@@ -194,7 +196,7 @@ return function (Request $request, CurrentSite $currentSite): Response|RedirectR
         return '<option value="' . $country->get('id') . '"' . ($country == $order->get('country') ? ' selected' : null) . '>' . $country->get('name') . '</option>';
     }, $countries);
 
-    $stockItemCount = \Model\StockQuery::create()->filterByOrderId($order->get('id'))->count();
+    $stockItemCount = StockQuery::create()->filterByOrderId($order->get('id'))->count();
 
     $feesList = [];
     $country = $order->get("country");
@@ -213,6 +215,13 @@ return function (Request $request, CurrentSite $currentSite): Response|RedirectR
 
     $pageTitle = $order_type . ' n° <a href="/order/' . $o['order_url'] . '">' . $o["order_id"] . '</a>';
     $request->attributes->set("page_title", "$order_type n° {$o["order_id"]}");
+
+    $paymentModes = \Model\Payment::getModes();
+    $paymentModesHtml = array_map(function ($mode) {
+        return '<option value="' . $mode . '">' . $mode . '</option>';
+    }, $paymentModes);
+    $paymentCreateUrl = $urlGenerator->generate("payment_create");
+
     $content .= '
     <h2>' . $pageTitle . '</h2>
 
@@ -507,6 +516,25 @@ return function (Request $request, CurrentSite $currentSite): Response|RedirectR
                         </div>
                     </div>
                 </div>
+            </div>
+        </fieldset>
+    </form>
+    
+    <form id="add_payment" class="fieldset" action="'.$paymentCreateUrl.'" method="post">
+        <fieldset>
+            <legend>Ajouter un paiement</legend>
+            <input type="hidden" name="order_id" value="'.$order->get('id').'">
+            <div class="form-inline">
+                <label for="payment_amount" class="col-sm-3 col-form-label">Nouveau paiement</label>
+                <select name="payment_mode" id="payment_mode" class="form-control mr-2" required>
+                    <option></option>
+                    '.join('', $paymentModesHtml).'
+                </select>
+                <div class="input-group mr-2">
+                    <input type="number" min="0" name="payment_amount" id="payment_amount" class="form-control" placeholder="Montant" required>
+                    <div class="input-group-append"><span class="input-group-text">centimes</span></div>
+                </div>
+                <button type="submit" class="btn btn-primary">Ajouter</button>
             </div>
         </fieldset>
     </form>

--- a/controllers/common/php/adm_order.php
+++ b/controllers/common/php/adm_order.php
@@ -160,20 +160,26 @@ return function (Request $request, CurrentSite $currentSite): Response|RedirectR
     $customer = '
     <fieldset>
         <legend>Client</legend>
-        <p>
-            <label for="customer_id">Client n°</label>
-            <input type="text" id="customer_id" name="customer_id" readonly> (<a href="#customer">Associer un client</a>)
-        <p>
+        <div class="form-group row">
+            <label for="customer_id" class="col-sm-3 col-form-label">Client n°</label>
+            <div class="col-sm-3">
+                <input type="text" id="customer_id" name="customer_id" class="form-control" readonly>
+                <small class="form-text text-muted"><a href="#customer">Associer un client</a></small>
+            </div>
+        </div>
     </fieldset>
 ';
     if ($c = $cm->get(array('customer_id' => $o['customer_id']))) {
         $customer = '
         <fieldset>
             <legend>Client</legend>
-            <p>
-                <label for="customer_id">Client n°</label>
-                <input type="text" id="customer_id" name="customer_id" value="' . $c->get('id') . '"> (<a href="/pages/adm_customer?id=' . $c->get('id') . '">' . trim($c->get('first_name') . ' ' . $c->get('last_name')) . '</a>)
-            <p>
+            <div class="form-group row">
+                <label for="customer_id" class="col-sm-3 col-form-label">Client n°</label>
+                <div class="col-sm-3">
+                    <input type="text" id="customer_id" name="customer_id" class="form-control" value="' . $c->get('id') . '">
+                    <small class="form-text text-muted"><a href="/pages/adm_customer?id=' . $c->get('id') . '">' . trim($c->get('first_name') . ' ' . $c->get('last_name')) . '</a></small>
+                </div>
+            </div>
         </fieldset>
     ';
     }
@@ -223,139 +229,261 @@ return function (Request $request, CurrentSite $currentSite): Response|RedirectR
 
     <form method="post" id="order" class="fieldset">
         <fieldset>
-
             <input type="hidden" name="order_url" value="' . $o["order_url"] . '" />
 
             <legend>Général</legend>
-            <label for="order" class="disabled">' . $order_type . ' n°</label>
-            <input type="number" name="order_id" id="order_id" value= "' . $o["order_id"] . '" class="short" readonly />
-            <br />
-            <label for="order_insert">Date :</label>
-            <input type="text" name="order_insert" id="order_insert" value="' . $o["order_insert"] . '" class="datetime" />
-            <br />
-            <p>
-                <label for="order_type">Type :</label>
-                <select name="order_type" id="order_type">
-                    <option></option>
-                    <option value="web"' . ($o->get('type') == 'web' ? ' selected' : null) . '>Commande VPC</option>
-                    <option value="shop"' . ($o->get('type') == 'shop' ? ' selected' : null) . '>Vente magasin</option>
-                </select>
-            </p>
-            <br />
-            <label for="order_amount">Montant :</label>
-            <input type="number" name="order_amount" id="order_amount" value="' . $o["order_amount"] . '" class="mini" /> centimes
-            <br />
-            <label for="order_amount_tobepaid">Montant à payer :</label>
-            <input type="number" name="order_amount_tobepaid" id="order_amount_tobepaid" value="' . $o["order_amount_tobepaid"] . '" class="mini" /> centimes
-            <br />
-            <label for="order_discount">Remise :</label>
-            <input type="number" name="order_discount" id="order_discount" value="' . $o["order_discount"] . '" class="mini" /> centimes
+            <div class="form-group row">
+                <label for="order_id" class="col-sm-3 col-form-label">' . $order_type . ' n°</label>
+                <div class="col-sm-3">
+                    <input type="number" name="order_id" id="order_id" value="' . $o["order_id"] . '" class="form-control" readonly />
+                </div>
+            </div>
+            <div class="form-group row">
+                <label for="order_insert" class="col-sm-3 col-form-label">Date</label>
+                <div class="col-sm-4">
+                    <input type="datetime-local" name="order_insert" id="order_insert" value="' . $o["order_insert"] . '" class="form-control" />
+                </div>
+            </div>
+            <div class="form-group row">
+                <label for="order_type" class="col-sm-3 col-form-label">Type</label>
+                <div class="col-sm-3">
+                    <select name="order_type" id="order_type" class="form-control">
+                        <option></option>
+                        <option value="web"' . ($o->get('type') == 'web' ? ' selected' : null) . '>Commande VPC</option>
+                        <option value="shop"' . ($o->get('type') == 'shop' ? ' selected' : null) . '>Vente magasin</option>
+                    </select>
+                </div>
+            </div>
+            <div class="form-group row">
+                <label for="order_amount" class="col-sm-3 col-form-label">Montant</label>
+                <div class="col-sm-3">
+                    <div class="input-group">
+                        <input type="number" name="order_amount" id="order_amount" value="' . $o["order_amount"] . '" class="form-control" />
+                        <div class="input-group-append"><span class="input-group-text">centimes</span></div>
+                    </div>
+                </div>
+            </div>
+            <div class="form-group row">
+                <label for="order_amount_tobepaid" class="col-sm-3 col-form-label">Montant à payer</label>
+                <div class="col-sm-3">
+                    <div class="input-group">
+                        <input type="number" name="order_amount_tobepaid" id="order_amount_tobepaid" value="' . $o["order_amount_tobepaid"] . '" class="form-control" />
+                        <div class="input-group-append"><span class="input-group-text">centimes</span></div>
+                    </div>
+                </div>
+            </div>
+            <div class="form-group row">
+                <label for="order_discount" class="col-sm-3 col-form-label">Remise</label>
+                <div class="col-sm-3">
+                    <div class="input-group">
+                        <input type="number" name="order_discount" id="order_discount" value="' . $o["order_discount"] . '" class="form-control" />
+                        <div class="input-group-append"><span class="input-group-text">centimes</span></div>
+                    </div>
+                </div>
+            </div>
         </fieldset>
 
         ' . $customer . '
 
         <fieldset>
             <legend>Coordonnées</legend>
-
-            <label for="order_firstname">Prénom :</label>
-            <input type="text" name="order_firstname" id="order_firstname" value="' . $o["order_firstname"] . '" />
-            <br />
-            <label for="order_lastname">Nom :</label>
-            <input type="text" name="order_lastname" id="order_lastname" value="' . $o["order_lastname"] . '" />
-            <br /><br>
-            <label for="order_address1">Adresse 1 :</label>
-            <input type="text" name="order_address1" id="order_address1" value="' . $o["order_address1"] . '" />
-            <br />
-            <label for="order_address2">Adresse 2 :</label>
-            <input type="text" name="order_address2" id="order_address2" value="' . $o["order_address2"] . '" />
-            <br />
-            <label for="order_postalcode">Code postal :</label>
-            <input type="text" name="order_postalcode" id="order_postalcode" value="' . $o["order_postalcode"] . '" />
-            <br />
-            <label for="order_city">Ville :</label>
-            <input type="text" name="order_city" id="order_city" value="' . $o["order_city"] . '" />
-            <br />
-            <label for="country_id">Pays :</label>
-            <select name="country_id" id="country_id">
-                <option></option>
-                ' . implode($countries) . '
-            </select>
-            <br /><br>
-            <label for="order_phone">Téléphone :</label>
-            <input type="text" name="order_phone" id="order_phone" value="' . $o["order_phone"] . '" />
-            <br />
-            <label for="order_email">E-mail :</label>
-            <input type="text" name="order_email" id="order_email" value="' . $o["order_email"] . '">
-            <br />
-
+            <div class="form-group row">
+                <label for="order_firstname" class="col-sm-3 col-form-label">Prénom</label>
+                <div class="col-sm-4">
+                    <input type="text" name="order_firstname" id="order_firstname" value="' . $o["order_firstname"] . '" class="form-control" />
+                </div>
+            </div>
+            <div class="form-group row">
+                <label for="order_lastname" class="col-sm-3 col-form-label">Nom</label>
+                <div class="col-sm-4">
+                    <input type="text" name="order_lastname" id="order_lastname" value="' . $o["order_lastname"] . '" class="form-control" />
+                </div>
+            </div>
+            <div class="form-group row">
+                <label for="order_address1" class="col-sm-3 col-form-label">Adresse 1</label>
+                <div class="col-sm-5">
+                    <input type="text" name="order_address1" id="order_address1" value="' . $o["order_address1"] . '" class="form-control" />
+                </div>
+            </div>
+            <div class="form-group row">
+                <label for="order_address2" class="col-sm-3 col-form-label">Adresse 2</label>
+                <div class="col-sm-5">
+                    <input type="text" name="order_address2" id="order_address2" value="' . $o["order_address2"] . '" class="form-control" />
+                </div>
+            </div>
+            <div class="form-group row">
+                <label for="order_postalcode" class="col-sm-3 col-form-label">Code postal</label>
+                <div class="col-sm-3">
+                    <input type="text" name="order_postalcode" id="order_postalcode" value="' . $o["order_postalcode"] . '" class="form-control" />
+                </div>
+            </div>
+            <div class="form-group row">
+                <label for="order_city" class="col-sm-3 col-form-label">Ville</label>
+                <div class="col-sm-4">
+                    <input type="text" name="order_city" id="order_city" value="' . $o["order_city"] . '" class="form-control" />
+                </div>
+            </div>
+            <div class="form-group row">
+                <label for="country_id" class="col-sm-3 col-form-label">Pays</label>
+                <div class="col-sm-4">
+                    <select name="country_id" id="country_id" class="form-control">
+                        <option></option>
+                        ' . implode($countries) . '
+                    </select>
+                </div>
+            </div>
+            <div class="form-group row">
+                <label for="order_phone" class="col-sm-3 col-form-label">Téléphone</label>
+                <div class="col-sm-4">
+                    <input type="text" name="order_phone" id="order_phone" value="' . $o["order_phone"] . '" class="form-control" />
+                </div>
+            </div>
+            <div class="form-group row">
+                <label for="order_email" class="col-sm-3 col-form-label">E-mail</label>
+                <div class="col-sm-5">
+                    <input type="text" name="order_email" id="order_email" value="' . $o["order_email"] . '" class="form-control" />
+                </div>
+            </div>
         </fieldset>
 
         <fieldset>
             <legend>Paiement</legend>
-            <label for="order_payment_mode">Mode :</label>
-            <input type="text" name="order_payment_mode" id="order_payment_cash" value="' . $o["order_payment_mode"] . '" class="mini" />
-            <br />
-            <label for="order_payment_date">Date :</label>
-            <input type="text" name="order_payment_date" id="order_payment_date" value="' . $o["order_payment_date"] . '" class="datetime" />
-            <br />
-            <label for="order_payment_cash">Espèces :</label>
-            <input type="number" name="order_payment_cash" id="order_payment_cash" value="' . $o["order_payment_cash"] . '" class="mini" /> centimes
-            <br />
-            <label for="order_payment_cheque">Chèque :</label>
-            <input type="number" name="order_payment_cheque" id="order_payment_cheque" value="' . $o["order_payment_cheque"] . '" class="mini" /> centimes
-            <br />
-            <label for="order_payment_transfer">Virement :</label>
-            <input type="number" name="order_payment_transfer" id="order_payment_transfer" value="' . $order->get('payment_transfer') . '" class="mini" /> centimes
-            <br />
-            <label for="order_payment_card">Carte bancaire :</label>
-            <input type="number" name="order_payment_card" id="order_payment_card" value="' . $o["order_payment_card"] . '" class="mini" /> centimes
-            <br />
-            <label for="order_payment_paypal">Paypal :</label>
-            <input type="number" name="order_payment_paypal" id="order_payment_paypal" value="' . $o["order_payment_paypal"] . '" class="mini" /> centimes
-            <br />
-            <label for="order_payment_payplug">Payplug :</label>
-            <input type="number" name="order_payment_payplug" id="order_payment_payplug" value="' . $o["order_payment_payplug"] . '" class="mini" /> centimes
-            <br />
-            <label for="order_payment_left">Monnaie rendue :</label>
-            <input type="number" name="order_payment_left" id="order_payment_left" value="' . $o["order_payment_left"] . '" class="mini" /> centimes
-            <br />
+            <div class="form-group row">
+                <label for="order_payment_mode" class="col-sm-3 col-form-label">Mode</label>
+                <div class="col-sm-3">
+                    <input type="text" name="order_payment_mode" id="order_payment_mode" value="' . $o["order_payment_mode"] . '" class="form-control" />
+                </div>
+            </div>
+            <div class="form-group row">
+                <label for="order_payment_date" class="col-sm-3 col-form-label">Date</label>
+                <div class="col-sm-5">
+                    <input type="datetime-local" name="order_payment_date" id="order_payment_date" value="' . $o["order_payment_date"] . '" class="form-control" />
+                </div>
+            </div>
+            <div class="form-group row">
+                <label for="order_payment_cash" class="col-sm-3 col-form-label">Espèces</label>
+                <div class="col-sm-3">
+                    <div class="input-group">
+                        <input type="number" name="order_payment_cash" id="order_payment_cash" value="' . $o["order_payment_cash"] . '" class="form-control" />
+                        <div class="input-group-append"><span class="input-group-text">centimes</span></div>
+                    </div>
+                </div>
+            </div>
+            <div class="form-group row">
+                <label for="order_payment_cheque" class="col-sm-3 col-form-label">Chèque</label>
+                <div class="col-sm-3">
+                    <div class="input-group">
+                        <input type="number" name="order_payment_cheque" id="order_payment_cheque" value="' . $o["order_payment_cheque"] . '" class="form-control" />
+                        <div class="input-group-append"><span class="input-group-text">centimes</span></div>
+                    </div>
+                </div>
+            </div>
+            <div class="form-group row">
+                <label for="order_payment_transfer" class="col-sm-3 col-form-label">Virement</label>
+                <div class="col-sm-3">
+                    <div class="input-group">
+                        <input type="number" name="order_payment_transfer" id="order_payment_transfer" value="' . $order->get('payment_transfer') . '" class="form-control" />
+                        <div class="input-group-append"><span class="input-group-text">centimes</span></div>
+                    </div>
+                </div>
+            </div>
+            <div class="form-group row">
+                <label for="order_payment_card" class="col-sm-3 col-form-label">Carte bancaire</label>
+                <div class="col-sm-3">
+                    <div class="input-group">
+                        <input type="number" name="order_payment_card" id="order_payment_card" value="' . $o["order_payment_card"] . '" class="form-control" />
+                        <div class="input-group-append"><span class="input-group-text">centimes</span></div>
+                    </div>
+                </div>
+            </div>
+            <div class="form-group row">
+                <label for="order_payment_paypal" class="col-sm-3 col-form-label">Paypal</label>
+                <div class="col-sm-3">
+                    <div class="input-group">
+                        <input type="number" name="order_payment_paypal" id="order_payment_paypal" value="' . $o["order_payment_paypal"] . '" class="form-control" />
+                        <div class="input-group-append"><span class="input-group-text">centimes</span></div>
+                    </div>
+                </div>
+            </div>
+            <div class="form-group row">
+                <label for="order_payment_payplug" class="col-sm-3 col-form-label">Payplug</label>
+                <div class="col-sm-3">
+                    <div class="input-group">
+                        <input type="number" name="order_payment_payplug" id="order_payment_payplug" value="' . $o["order_payment_payplug"] . '" class="form-control" />
+                        <div class="input-group-append"><span class="input-group-text">centimes</span></div>
+                    </div>
+                </div>
+            </div>
+            <div class="form-group row">
+                <label for="order_payment_left" class="col-sm-3 col-form-label">Monnaie rendue</label>
+                <div class="col-sm-3">
+                    <div class="input-group">
+                        <input type="number" name="order_payment_left" id="order_payment_left" value="' . $o["order_payment_left"] . '" class="form-control" />
+                        <div class="input-group-append"><span class="input-group-text">centimes</span></div>
+                    </div>
+                </div>
+            </div>
         </fieldset>
 
         <fieldset>
             <legend>Relance</legend>
-            <label for="order_followup_date">Date :</label>
-            <input type="text" name="order_followup_date" id="order_followup_date" value="' . $o["order_followup_date"] . '" class="datetime" />
-            <br />
+            <div class="form-group row">
+                <label for="order_followup_date" class="col-sm-3 col-form-label">Date</label>
+                <div class="col-sm-5">
+                    <input type="datetime-local" name="order_followup_date" id="order_followup_date" value="' . $o["order_followup_date"] . '" class="form-control" />
+                </div>
+            </div>
         </fieldset>
 
         <fieldset>
             <legend>Expédition</legend>
-            <label for="order_shipping_mode">Mode :</label>
-            <input type="text" name="order_shipping_mode" id="order_shipping_mode" value="' . $o["order_shipping_mode"] . '" class="medium" />
-            <br />
-            <label for="order_shipping">Port :</label>
-            <input type="number" name="order_shipping" id="order_shipping" value="' . $o["order_shipping"] . '" class="mini" /> centimes
-            <br />
-            <label for="order_shipping_date">Date :</label>
-            <input type="text" name="order_shipping_date" id="order_shipping_date" value="' . $o["order_shipping_date"] . '" class="datetime" />
-            <br />
-            <label for="order_track_number">N° de suivi :</label>
-            <input type="text" name="order_track_number" id="order_track_number" value="' . $o["order_track_number"] . '" class="datetime" />
-            <br />
+            <div class="form-group row">
+                <label for="order_shipping_mode" class="col-sm-3 col-form-label">Mode</label>
+                <div class="col-sm-3">
+                    <input type="text" name="order_shipping_mode" id="order_shipping_mode" value="' . $o["order_shipping_mode"] . '" class="form-control" />
+                </div>
+            </div>
+            <div class="form-group row">
+                <label for="order_shipping" class="col-sm-3 col-form-label">Port</label>
+                <div class="col-sm-3">
+                    <div class="input-group">
+                        <input type="number" name="order_shipping" id="order_shipping" value="' . $o["order_shipping"] . '" class="form-control" />
+                        <div class="input-group-append"><span class="input-group-text">centimes</span></div>
+                    </div>
+                </div>
+            </div>
+            <div class="form-group row">
+                <label for="order_shipping_date" class="col-sm-3 col-form-label">Date</label>
+                <div class="col-sm-5">
+                    <input type="datetime-local" name="order_shipping_date" id="order_shipping_date" value="' . $o["order_shipping_date"] . '" class="form-control" />
+                </div>
+            </div>
+            <div class="form-group row">
+                <label for="order_track_number" class="col-sm-3 col-form-label">N° de suivi</label>
+                <div class="col-sm-5">
+                    <input type="text" name="order_track_number" id="order_track_number" value="' . $o["order_track_number"] . '" class="form-control" />
+                </div>
+            </div>
         </fieldset>
 
         <fieldset>
             <legend>Confirmation</legend>
-            <label for="order_confirmation_date">Date :</label>
-            <input type="text" name="order_confirmation_date" id="order_confirmation_date" value="' . $o["order_confirmation_date"] . '" class="datetime" />
-            <br />
+            <div class="form-group row">
+                <label for="order_confirmation_date" class="col-sm-3 col-form-label">Date</label>
+                <div class="col-sm-4">
+                    <input type="datetime-local" name="order_confirmation_date" id="order_confirmation_date" value="' . $o["order_confirmation_date"] . '" class="form-control" />
+                </div>
+            </div>
         </fieldset>
 
         <fieldset>
             <legend>Annulation</legend>
-            <label for="order_cancel_date">Date :</label>
-            <input type="text" name="order_cancel_date" id="order_cancel_date" value="' . $o["order_cancel_date"] . '" class="datetime" />
-            <br />
+            <div class="form-group row">
+                <label for="order_cancel_date" class="col-sm-3 col-form-label">Date</label>
+                <div class="col-sm-4">
+                    <input type="datetime-local" name="order_cancel_date" id="order_cancel_date" value="' . $o["order_cancel_date"] . '" class="form-control" />
+                </div>
+            </div>
         </fieldset>
 
         <fieldset class="center">
@@ -369,11 +497,17 @@ return function (Request $request, CurrentSite $currentSite): Response|RedirectR
         <fieldset>
             <legend>Associer un client</legend>
             <input type="hidden" name="action" value="customer">
-            <p>
-                <label for="customer_id">Client n°&nbsp;:</label>
-                <input name="customer_id" id="customer_id" value="' . $order->get("customer_id") . '">
-                <button type="submit" class="btn btn-success btn-sm">Associer</button>
-            </p>
+            <div class="form-group row">
+                <label for="customer_id" class="col-sm-3 col-form-label">Client n°</label>
+                <div class="col-sm-3">
+                    <div class="input-group">
+                        <input name="customer_id" id="customer_id" value="' . $order->get("customer_id") . '" class="form-control">
+                        <div class="input-group-append">
+                            <button type="submit" class="btn btn-success">Associer</button>
+                        </div>
+                    </div>
+                </div>
+            </div>
         </fieldset>
     </form>
 
@@ -381,14 +515,20 @@ return function (Request $request, CurrentSite $currentSite): Response|RedirectR
         <fieldset>
             <legend>Modifier le mode d\'expédition</legend>
             <input type="hidden" name="order_id" value="' . $o["order_id"] . '">
-            <p>
-                <label for="shipping_fee">Nouveau mode :</label>
-                <select name="shipping_fee" id="shipping_fee">
-                    <option/>
-                    ' . join($feesList) . '
-                </select>
-                <button type="submit" class="btn btn-primary btn-sm">Valider</button>
-            </p>
+            <div class="form-group row">
+                <label for="shipping_fee" class="col-sm-3 col-form-label">Nouveau mode</label>
+                <div class="col-sm-6">
+                    <div class="input-group">
+                        <select name="shipping_fee" id="shipping_fee" class="form-control">
+                            <option/>
+                            ' . join($feesList) . '
+                        </select>
+                        <div class="input-group-append">
+                            <button type="submit" class="btn btn-primary">Valider</button>
+                        </div>
+                    </div>
+                </div>
+            </div>
         </fieldset>
     </form>
 
@@ -396,11 +536,17 @@ return function (Request $request, CurrentSite $currentSite): Response|RedirectR
         <fieldset>
             <legend>Retirer un article</legend>
             <input type="hidden" name="order_id" value="' . $o["order_id"] . '">
-            <p>
-                <label for="stock_remove">Articles :</label>
-                <select name="stock_remove" id="stock_remove">' . $article_list . '</select>
-                <button type="submit" class="btn btn-warning btn-sm">Retirer</button>
-            </p>
+            <div class="form-group row">
+                <label for="stock_remove" class="col-sm-3 col-form-label">Articles</label>
+                <div class="col-sm-6">
+                    <div class="input-group">
+                        <select name="stock_remove" id="stock_remove" class="form-control">' . $article_list . '</select>
+                        <div class="input-group-append">
+                            <button type="submit" class="btn btn-warning">Retirer</button>
+                        </div>
+                    </div>
+                </div>
+            </div>
         </fieldset>
     </form>
 
@@ -408,11 +554,17 @@ return function (Request $request, CurrentSite $currentSite): Response|RedirectR
         <fieldset>
             <legend>Ajouter un article</legend>
             <input type="hidden" name="order_id" value="' . $o["order_id"] . '">
-            <p>
-                <label for="stock_add">Exemplaire n°&nbsp;:</label>
-                <input name="stock_add" id="stock_add">
-                <button type="submit" class="btn btn-success btn-sm">Ajouter</button>
-            </p>
+            <div class="form-group row">
+                <label for="stock_add" class="col-sm-3 col-form-label">Exemplaire n°</label>
+                <div class="col-sm-3">
+                    <div class="input-group">
+                        <input name="stock_add" id="stock_add" class="form-control">
+                        <div class="input-group-append">
+                            <button type="submit" class="btn btn-success">Ajouter</button>
+                        </div>
+                    </div>
+                </div>
+            </div>
         </fieldset>
     </form>
 

--- a/controllers/common/php/adm_order.php
+++ b/controllers/common/php/adm_order.php
@@ -267,7 +267,7 @@ return function (Request $request, UrlGenerator $urlGenerator): Response|Redirec
                 <label for="order_amount" class="col-sm-3 col-form-label">Montant</label>
                 <div class="col-sm-3">
                     <div class="input-group">
-                        <input type="number" name="order_amount" id="order_amount" value="' . $o["order_amount"] . '" class="form-control" />
+                        <input type="number" name="order_amount" id="order_amount" value="' . $o["order_amount"] . '" class="form-control" readonly />
                         <div class="input-group-append"><span class="input-group-text">centimes</span></div>
                     </div>
                 </div>
@@ -276,7 +276,7 @@ return function (Request $request, UrlGenerator $urlGenerator): Response|Redirec
                 <label for="order_amount_tobepaid" class="col-sm-3 col-form-label">Montant à payer</label>
                 <div class="col-sm-3">
                     <div class="input-group">
-                        <input type="number" name="order_amount_tobepaid" id="order_amount_tobepaid" value="' . $o["order_amount_tobepaid"] . '" class="form-control" />
+                        <input type="number" name="order_amount_tobepaid" id="order_amount_tobepaid" value="' . $o["order_amount_tobepaid"] . '" class="form-control" readonly />
                         <div class="input-group-append"><span class="input-group-text">centimes</span></div>
                     </div>
                 </div>
@@ -285,7 +285,7 @@ return function (Request $request, UrlGenerator $urlGenerator): Response|Redirec
                 <label for="order_discount" class="col-sm-3 col-form-label">Remise</label>
                 <div class="col-sm-3">
                     <div class="input-group">
-                        <input type="number" name="order_discount" id="order_discount" value="' . $o["order_discount"] . '" class="form-control" />
+                        <input type="number" name="order_discount" id="order_discount" value="' . $o["order_discount"] . '" class="form-control" readonly />
                         <div class="input-group-append"><span class="input-group-text">centimes</span></div>
                     </div>
                 </div>

--- a/controllers/common/php/adm_stock.php
+++ b/controllers/common/php/adm_stock.php
@@ -76,53 +76,6 @@ return function (
         return new RedirectResponse('/pages/adm_stock?id=' . $lostCopyId);
     }
 
-    if (isset($_GET['sold'])) {
-        // All copies sold in shop are associated to a fake customer that needs
-        // to be created and specified via the `fake_shop_customer` site option.
-        // This allows to create only one order for shop sales per day.
-        $fakeCustomerId = $currentSite->getOption('fake_shop_customer');
-        if (!$fakeCustomerId) {
-            throw new Exception("L'option de site `fake_shop_customer` doit être définie.");
-        }
-
-        if ($stockEntity = $sm->get(['stock_id' => $_GET['sold']])) {
-            if (!$stockEntity->isAvailable()) {
-                trigger_error('Exemplaire indisponible.');
-            } else {
-                try {
-                    // Get order for current day shop sales if it exists
-                    $orderDate = date('Y-m-d') . ' 00:00:00';
-                    $order = $om->get([
-                        'customer_id' => $fakeCustomerId,
-                        'order_created' => $orderDate,
-                    ]);
-
-                    // Else, create a new one
-                    if (!$order) {
-                        $order = $om->create();
-                        $order->set('order_created', $orderDate)
-                            ->set('customer_id', $fakeCustomerId)
-                            ->set('order_type', 'shop')
-                            ->set('order_payment_date', $orderDate);
-                        $om->update($order);
-                    }
-
-                    // Add the copy to the order
-                    $om->addStock($order, $stockEntity);
-
-                    // Update the order amount from stock
-                    $om->updateFromStock($order);
-                } catch (Exception $e) {
-                    trigger_error($e->getMessage());
-                }
-
-                return new RedirectResponse('/pages/adm_stock?id=' . $stockEntity->get('id') . '&solded=1');
-            }
-        } else {
-            trigger_error('Exemplaire introuvable');
-        }
-    }
-
     $mode = "";
     if ($request->getMethod() === 'POST') {
         // AddSlashes
@@ -319,8 +272,6 @@ return function (
             $content .= '<p class="success">L\'exemplaire a été retourné.</p>';
         } elseif (isset($_GET['losted'])) {
             $content .= '<p class="success">L\'exemplaire a été marqué comme perdu.</p>';
-        } elseif (isset($_GET['solded'])) {
-            $content .= '<p class="success">L\'exemplaire a été marqué comme vendu en magasin.</p>';
         }
 
         if (isset($_GET['alerts'])) {

--- a/controllers/common/php/adm_stocks.php
+++ b/controllers/common/php/adm_stocks.php
@@ -19,14 +19,11 @@
 use Biblys\Data\ArticleType;
 use Biblys\Service\CurrentSite;
 use Biblys\Service\Images\ImagesService;
-use Propel\Runtime\Exception\PropelException;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
- * @throws InvalidDateFormatException
- * @throws PropelException
  */
 return function (
     Request       $request,
@@ -73,7 +70,7 @@ return function (
         WHERE `stock_created` > SUBDATE(NOW(), INTERVAL 1 MONTH)
         GROUP BY `date`
         ORDER BY `date` DESC
-    ", []);
+    ");
     foreach ($stockDates as $stockDate) {
         if ($_GET['stock_created'] == $stockDate['date']) {
             $stockDate['selected'] = 'selected="selected"';
@@ -294,7 +291,7 @@ return function (
         ' . $limit . '
     ';
 
-    $sql = EntityManager::prepareAndExecute($sql_query, []);
+    $sql = EntityManager::prepareAndExecute($sql_query);
     $num = $sql->rowCount();
 
     if (isset($_GET['article_id'])) {
@@ -360,32 +357,18 @@ return function (
                 </a>
             ';
 
-            if ($currentSite->getOption("fake_shop_customer")) {
-                $soldButton = '
-                    <a href="/pages/adm_stock?sold=' . $x['stock_id'] . '">
-                        <span class="fa fa-shopping-bag fa-lg black" title="Vendu en magasin" />
-                    </a>
-                ';
-            }
-
-
             if ($x['stock_return_date']) { // Retourné
                 $x['led'] = 'square_orange';
                 $x['status'] = 'Retourné&nbsp;le<br />' . _date($x['stock_return_date'], 'd/m/Y');
-                unset($returnButton, $soldButton);
+                unset($returnButton);
                 ++$retours;
             } elseif ($x['stock_selling_date']) { // Vendu
                 $x['led'] = 'square_blue';
                 $x['status'] = 'Vendu le<br />' . _date($x['stock_selling_date'], 'd/m/Y');
 
                 // Sold in shop
-                if ($x['customer_id'] === $currentSite->getOption("fake_shop_customer")) {
-                    $x['status'] .= '<span class="fa fa-shopping-bag fa-lg"  title="Vendu en magasin" />';
-                } else {
-                    $x['status'] .= '<span class="fa fa- fa-lg" aria-label="Vendu en ligne" title="Vendu en ligne" />';
-                }
+                $x['status'] .= '<span class="fa fa- fa-lg" aria-label="Vendu en ligne" title="Vendu en ligne" />';
 
-                $soldButton = null;
                 ++$ventes;
             } elseif ($x['stock_cart_date']) { // En panier
                 $x['led'] = 'square_gray';
@@ -411,7 +394,6 @@ return function (
                     <td>
                         <a href="/pages/adm_stock?id=' . $x['stock_id'] . '">' . $x['stock_id'] . '</a><br />
                         ' . $copyButton . '
-                        ' . ($soldButton ?? null) . '
                         ' . ($returnButton ?? null) . '
                         ' . $lostButton . '
                         <span class="fa fa-trash-can fa-lg deleteStock pointer"
@@ -546,7 +528,7 @@ return function (
 
     $tbody = $list;
 
-    $lists = $lm->getAll([]);
+    $lists = $lm->getAll();
     $lists = array_map(function ($list) {
         return '<option value=' . $list->get('id') . '>' . $list->get('title') . '</option>';
     }, $lists);

--- a/src/AppBundle/Controller/PaymentController.php
+++ b/src/AppBundle/Controller/PaymentController.php
@@ -21,10 +21,12 @@ use Biblys\Exception\CannotFindPayableOrderException;
 use Biblys\Exception\InvalidConfigurationException;
 use Biblys\Exception\InvalidEmailAddressException;
 use Biblys\Exception\UnreachableExternalServiceException;
+use Biblys\Service\BodyParamsService;
 use Biblys\Service\Config;
 use Biblys\Service\CurrentSite;
 use Biblys\Service\CurrentUser;
 use Biblys\Service\FlashMessagesService;
+use Biblys\Service\InvalidSiteIdException;
 use Biblys\Service\LoggerService;
 use Biblys\Service\Mailer;
 use Biblys\Service\Pagination;
@@ -131,6 +133,63 @@ class PaymentController extends Controller
             "pages" => $pagination,
             "total" => $total,
         ], isPrivate: true);
+    }
+
+    /**
+     * POST /admin/payments
+     *
+     * @throws BusinessRuleException
+     * @throws InvalidEmailAddressException
+     * @throws LoaderError
+     * @throws PropelException
+     * @throws RuntimeError
+     * @throws SyntaxError
+     * @throws TransportExceptionInterface
+     * @throws UnreachableExternalServiceException
+     * @throws InvalidSiteIdException
+     */
+    public function createAction(
+        BodyParamsService    $bodyParams,
+        CurrentUser          $currentUser,
+        Mailer               $mailer,
+        CurrentSite          $currentSite,
+        UrlGenerator         $urlGenerator,
+        TemplateService      $templateService,
+        FlashMessagesService $flashMessages,
+    ): Response
+    {
+        $currentUser->authAdmin();
+
+        $bodyParams->parse([
+            "order_id" => ["type" => "numeric"],
+            "payment_mode" => ["type" => "string"],
+            "payment_amount" => ["type" => "numeric"],
+        ]);
+
+        $orderId = $bodyParams->getInteger("order_id");
+        $order = OrderQuery::create()->findPk($orderId);
+        $paymentAmount = $bodyParams->getInteger("payment_amount");
+
+        $payment = new Payment();
+        $payment->setOrder($order);
+        $payment->setMode($bodyParams->get("payment_mode"));
+        $payment->setAmount($paymentAmount);
+
+        $usecase = $this->getPaymentUsecase(
+            mailer: $mailer,
+            currentSite: $currentSite,
+            urlGenerator: $urlGenerator,
+            templateService: $templateService,
+        );
+        $usecase->execute($order, $payment);
+
+        $formattedAmount = currency($paymentAmount, true);
+        $flashMessages->add(
+            "success",
+            "Un paiement de $formattedAmount a été ajouté à la commande {$order->getId()}."
+        );
+
+        return new RedirectResponse("/pages/adm_order?order_id=$orderId");
     }
 
     /**

--- a/src/AppBundle/routes.yml
+++ b/src/AppBundle/routes.yml
@@ -451,6 +451,11 @@ payments_index:
   methods: GET
   controller: AppBundle\Controller\PaymentController::index
 
+payment_create:
+  path: /admin/payments/
+  methods: POST
+  controller: AppBundle\Controller\PaymentController::createAction
+
 payment_pay:
   path: /order/{slug}/pay
   methods: GET

--- a/src/Biblys/Service/MailingList/MailjetMailingList.php
+++ b/src/Biblys/Service/MailingList/MailjetMailingList.php
@@ -35,14 +35,10 @@ class MailjetMailingList implements MailingListInterface
     public function __construct(Config $config)
     {
         $this->config = $config;
-        $mailjet = new Mailjet(
+        $this->client = new Mailjet(
             key: $config->get("mailing.client_id"),
             secret: $config->get("mailing.client_secret"),
         );
-        $mailjet->setTimeout(20000);
-        $mailjet->setConnectionTimeout(20000);
-
-        $this->client = $mailjet;
     }
 
     public function getSource(): string

--- a/src/Biblys/Test/Helpers.php
+++ b/src/Biblys/Test/Helpers.php
@@ -70,15 +70,16 @@ class Helpers
     {
         $config = new Config(["environment" => "test"]);
         $currentSite = Mockery::mock(CurrentSite::class);
-        $currentSite->expects("getTitle")->andReturn("Éditions Paronymie");
-        $currentSite->expects("getOption")->andReturn(null);
-        $currentSite->expects("getSite")->andReturn(ModelFactory::createSite());
+        $currentSite->shouldReceive("getTitle")->andReturn("Éditions Paronymie");
+        $currentSite->shouldReceive("getOption")->andReturn(null);
+        $currentSite->shouldReceive("getSite")->andReturn(ModelFactory::createSite());
         $currentUser = Mockery::mock(CurrentUser::class);
-        $currentUser->expects("isAuthenticated")->andReturn(false);
-        $currentUser->expects("isAdmin")->andReturn(false);
-        $currentUser->expects("hasPublisherRight")->andReturn(false);
+        $currentUser->shouldReceive("isAuthenticated")->andReturn(false);
+        $currentUser->shouldReceive("isAdmin")->andReturn(false);
+        $currentUser->shouldReceive("hasPublisherRight")->andReturn(false);
+        $currentUser->shouldReceive("getCart")->andReturn(null);
         $metaTags = Mockery::mock(MetaTagsService::class);
-        $metaTags->expects("dump")->andReturn("");
+        $metaTags->shouldReceive("dump")->andReturn("");
         $request = new Request();
 
         return new TemplateService(

--- a/src/Usecase/AddPaymentToOrderAndExecuteUsecase.php
+++ b/src/Usecase/AddPaymentToOrderAndExecuteUsecase.php
@@ -29,7 +29,7 @@ use Twig\Error\LoaderError;
 use Twig\Error\RuntimeError;
 use Twig\Error\SyntaxError;
 
-readonly class AddPaymentToOrderAndExecuteUsecase
+class AddPaymentToOrderAndExecuteUsecase
 {
     public function __construct(private MarkOrderAsPaidUsecase $markOrderAsPaidUsecase)
     {

--- a/tests/ApiBundle/Controller/CollectionControllerTest.php
+++ b/tests/ApiBundle/Controller/CollectionControllerTest.php
@@ -44,6 +44,11 @@ class CollectionControllerTest extends TestCase
         BookCollectionQuery::create()->deleteAll();
     }
 
+    public function tearDown(): void
+    {
+        Mockery::close();
+    }
+
     /** searchAction */
 
     /**
@@ -130,7 +135,7 @@ class CollectionControllerTest extends TestCase
         ])->andReturn();
         $bodyParams->expects("get")->with("collection_name")
             ->andReturn("Nouvelle collection");
-        $bodyParams->expects("get")->with("collection_publisher")
+        $bodyParams->shouldReceive("get")->with("collection_publisher")
             ->andReturn($publisher->getName());
         $bodyParams->expects("getInteger")->with("collection_publisher_id")
             ->andReturn($publisher->getId());
@@ -165,7 +170,7 @@ class CollectionControllerTest extends TestCase
         ])->andReturn();
         $bodyParams->expects("get")->with("collection_name")
             ->andReturn("Collection existante");
-        $bodyParams->expects("get")->with("collection_publisher")
+        $bodyParams->shouldReceive("get")->with("collection_publisher")
             ->andReturn("");
         $bodyParams->expects("getInteger")->with("collection_publisher_id")
             ->andReturn(0);
@@ -202,7 +207,7 @@ class CollectionControllerTest extends TestCase
         ])->andReturn();
         $bodyParams->expects("get")->with("collection_name")
             ->andReturn("Collection existante");
-        $bodyParams->expects("get")->with("collection_publisher")
+        $bodyParams->shouldReceive("get")->with("collection_publisher")
             ->andReturn($publisher->getName());
         $bodyParams->expects("getInteger")->with("collection_publisher_id")
             ->andReturn($publisher->getId());
@@ -238,7 +243,7 @@ class CollectionControllerTest extends TestCase
         ])->andReturn();
         $bodyParams->expects("get")->with("collection_name")
             ->andReturn("Nouvelle collection");
-        $bodyParams->expects("get")->with("collection_publisher")
+        $bodyParams->shouldReceive("get")->with("collection_publisher")
             ->andReturn($publisher->getName());
         $bodyParams->expects("getInteger")->with("collection_publisher_id")
             ->andReturn($publisher->getId());
@@ -278,9 +283,9 @@ class CollectionControllerTest extends TestCase
             "collection_publisher" => ["type" => "string"],
             "collection_publisher_id" => ["type" => "numeric"],
         ])->andReturn();
-        $bodyParams->expects("get")->with("collection_name")
+        $bodyParams->shouldReceive("get")->with("collection_name")
             ->andReturn("Nouvelle collection");
-        $bodyParams->expects("get")->with("collection_publisher")
+        $bodyParams->shouldReceive("get")->with("collection_publisher")
             ->andReturn($targetPublisher->getName());
         $bodyParams->expects("getInteger")->with("collection_publisher_id")
             ->andReturn($targetPublisher->getId());

--- a/tests/ApiBundle/Controller/PaymentControllerTest.php
+++ b/tests/ApiBundle/Controller/PaymentControllerTest.php
@@ -40,6 +40,10 @@ use Symfony\Component\Routing\Generator\UrlGenerator;
 
 class PaymentControllerTest extends TestCase
 {
+    public function tearDown(): void
+    {
+        Mockery::close();
+    }
 
     /* createStripePaymentAction */
 
@@ -90,9 +94,6 @@ class PaymentControllerTest extends TestCase
         $paymentService->expects("getPayableOrderBySlug")->andReturn($order);
 
         $request = new Request([], [], [], [], [], [], json_encode(["paypalOrderId" => "PAYPAL_ORDER_123"]));
-
-        $logger = Mockery::mock(LoggerService::class);
-        $logger->expects("log")->andReturnNull();
 
         $captureResponseData = [
             "status" => "COMPLETED",

--- a/tests/AppBundle/Controller/ArticleControllerTest.php
+++ b/tests/AppBundle/Controller/ArticleControllerTest.php
@@ -74,6 +74,11 @@ class ArticleControllerTest extends TestCase
         BookCollectionQuery::create()->deleteAll();
     }
 
+    public function tearDown(): void
+    {
+        Mockery::close();
+    }
+
     /** adminCatalogAction  */
 
     /**
@@ -346,7 +351,6 @@ class ArticleControllerTest extends TestCase
             ->andReturn();
         $templateService = Helpers::getTemplateService();
         $imagesService = Mockery::mock(ImagesService::class);
-        $imagesService->expects("deleteImageFor");
 
         // when
         $response = $controller->deleteAction(
@@ -391,7 +395,6 @@ class ArticleControllerTest extends TestCase
             ->andReturn();
         $templateService = Helpers::getTemplateService();
         $imagesService = Mockery::mock(ImagesService::class);
-        $imagesService->expects("deleteImageFor");
 
         // when
         $response = $controller->deleteAction(
@@ -583,7 +586,6 @@ class ArticleControllerTest extends TestCase
             ->shouldReceive("renderResponse")
             ->andReturn(new Response(""));
         $imagesService = Mockery::mock(ImagesService::class);
-        $imagesService->expects("deleteImageFor");
 
         // when
         $exception = Helpers::runAndCatchException(function () use (

--- a/tests/AppBundle/Controller/CollectionControllerTest.php
+++ b/tests/AppBundle/Controller/CollectionControllerTest.php
@@ -41,6 +41,11 @@ class CollectionControllerTest extends TestCase
         BookCollectionQuery::create()->deleteAll();
     }
 
+    public function tearDown(): void
+    {
+        Mockery::close();
+    }
+
     /**
      * @throws SyntaxError
      * @throws RuntimeError

--- a/tests/AppBundle/Controller/InvitationControllerTest.php
+++ b/tests/AppBundle/Controller/InvitationControllerTest.php
@@ -56,6 +56,12 @@ class InvitationControllerTest extends TestCase
     protected function setUp(): void
     {
         InvitationQuery::create()->deleteAll();
+        Mockery::resetContainer();
+    }
+
+    public function tearDown(): void
+    {
+        Mockery::close();
     }
 
     /**
@@ -720,7 +726,7 @@ class InvitationControllerTest extends TestCase
             ->once()
             ->with("warning", "Dans ma bibliothèque était déjà dans votre bibliothèque.");
         $session = Mockery::mock(Session::class);
-        $session->shouldReceive("getFlashBag")->once()->andReturn($flashBag);
+        $session->shouldReceive("getFlashBag")->andReturn($flashBag);
 
         $controller = new InvitationController();
         $request = RequestFactory::createAuthRequest(user: $user);

--- a/tests/AppBundle/Controller/PaymentControllerTest.php
+++ b/tests/AppBundle/Controller/PaymentControllerTest.php
@@ -17,6 +17,7 @@
 
 namespace AppBundle\Controller;
 
+use Biblys\Service\BodyParamsService;
 use Biblys\Service\Config;
 use Biblys\Service\CurrentSite;
 use Biblys\Service\CurrentUser;
@@ -46,6 +47,7 @@ use Symfony\Component\Routing\Generator\UrlGenerator;
 use Twig\Error\LoaderError;
 use Twig\Error\RuntimeError;
 use Twig\Error\SyntaxError;
+use Usecase\AddPaymentToOrderAndExecuteUsecase;
 
 require_once __DIR__ . "/../../setUp.php";
 
@@ -176,6 +178,67 @@ class PaymentControllerTest extends TestCase
         $this->assertStringContainsString("28/04/2019", $response->getContent());
         $this->assertStringNotContainsString("26/04/2019", $response->getContent());
         $this->assertStringNotContainsString("30/04/2019", $response->getContent());
+    }
+
+    /** createAction */
+
+    /**
+     * @throws PropelException
+     * @throws Exception
+     * @throws TransportExceptionInterface
+     */
+    public function testCreateAction(): void
+    {
+        // given
+        $order = ModelFactory::createOrder(amountToBePaid: 1500);
+
+        $controller = new PaymentController();
+
+        $bodyParams = Mockery::mock(BodyParamsService::class);
+        $bodyParams->shouldReceive("parse")->with([
+            "order_id" => ["type" => "numeric"],
+            "payment_mode" => ["type" => "string"],
+            "payment_amount" => ["type" => "numeric"],
+        ])->once();
+        $bodyParams->shouldReceive("getInteger")->with("order_id")->andReturn($order->getId());
+        $bodyParams->shouldReceive("get")->with("payment_mode")->andReturn("cash");
+        $bodyParams->shouldReceive("getInteger")->with("payment_amount")->andReturn(1500);
+
+        $currentUser = Mockery::mock(CurrentUser::class);
+        $currentUser->shouldReceive("authAdmin")->once()->andReturn();
+
+        $mailer = Mockery::mock(Mailer::class);
+        $mailer->expects("send")->once();
+        $currentSite = Mockery::mock(CurrentSite::class);
+        $urlGenerator = Mockery::mock(UrlGenerator::class);
+        $urlGenerator->expects("generate");
+        $templateService = Helpers::getTemplateService();
+
+        $flashMessagesService = Mockery::mock(FlashMessagesService::class);
+        $flashMessagesService->expects("add")
+            ->with("success", "Un paiement de 15,00&nbsp;&euro; a été ajouté à la commande {$order->getId()}.")
+            ->once();
+
+        // when
+        $response = $controller->createAction(
+            bodyParams: $bodyParams,
+            currentUser: $currentUser,
+            mailer: $mailer,
+            currentSite: $currentSite,
+            urlGenerator: $urlGenerator,
+            templateService: $templateService,
+            flashMessages: $flashMessagesService
+        );
+
+        // then
+        $this->assertEquals(302, $response->getStatusCode());
+        $this->assertEquals("/pages/adm_order?order_id={$order->getId()}", $response->getTargetUrl());
+        $order->reload(true);
+        $this->assertTrue($order->isPaid());
+        $payment = PaymentQuery::create()->findOneByOrderId($order->getId());
+        $this->assertNotNull($payment);
+        $this->assertEquals(1500, $payment->getAmount());
+        $this->assertEquals("cash", $payment->getMode());
     }
 
     /** stripeWebhookAction */

--- a/tests/AppBundle/Controller/PaymentControllerTest.php
+++ b/tests/AppBundle/Controller/PaymentControllerTest.php
@@ -30,6 +30,7 @@ use Biblys\Test\ModelFactory;
 use DateTime;
 use Exception;
 use Mockery;
+use Mockery\Mock;
 use Model\OrderQuery;
 use Model\Payment;
 use Model\PaymentQuery;
@@ -57,6 +58,12 @@ class PaymentControllerTest extends TestCase
     {
         OrderQuery::create()->deleteAll();
         PaymentQuery::create()->deleteAll();
+        Mockery::resetContainer();
+    }
+
+    public function tearDown(): void
+    {
+        Mockery::close();
     }
 
     /**
@@ -390,9 +397,9 @@ class PaymentControllerTest extends TestCase
         $order = ModelFactory::createOrder();
         $config = new Config();
         $currentSite = Mockery::mock(CurrentSite::class);
-        $currentSite->expects("getOption")->with("payment_iban")->andReturn(null);
-        $currentSite->expects("getOption")->with("payment_check")->andReturn(null);
-        $currentSite->expects("getOption")->with("name_for_check_payment")->andReturn(null);
+        $currentSite->shouldReceive("getOption")->with("payment_iban")->andReturn(null);
+        $currentSite->shouldReceive("getOption")->with("payment_check")->andReturn(null);
+        $currentSite->shouldReceive("getOption")->with("name_for_check_payment")->andReturn(null);
         $templateService = Helpers::getTemplateService();
         $paymentService = Mockery::mock(PaymentService::class);
         $paymentService->expects("getPayableOrderBySlug")->andReturn($order);
@@ -419,9 +426,9 @@ class PaymentControllerTest extends TestCase
         $order = ModelFactory::createOrder(amountToBePaid: 1000);
         $config = new Config(["stripe" => ["public_key" => "abcd"]]);
         $currentSite = Mockery::mock(CurrentSite::class);
-        $currentSite->expects("getOption")->with("payment_iban")->andReturn(null);
-        $currentSite->expects("getOption")->with("payment_check")->andReturn(null);
-        $currentSite->expects("getOption")->with("name_for_check_payment")->andReturn(null);
+        $currentSite->shouldReceive("getOption")->with("payment_iban")->andReturn(null);
+        $currentSite->shouldReceive("getOption")->with("payment_check")->andReturn(null);
+        $currentSite->shouldReceive("getOption")->with("name_for_check_payment")->andReturn(null);
         $templateService = Helpers::getTemplateService();
         $paymentService = Mockery::mock(PaymentService::class);
         $paymentService->expects("getPayableOrderBySlug")->andReturn($order);
@@ -444,9 +451,9 @@ class PaymentControllerTest extends TestCase
         $order = ModelFactory::createOrder();
         $config = new Config(["payplug" => ["secret" => "abcd"]]);
         $currentSite = Mockery::mock(CurrentSite::class);
-        $currentSite->expects("getOption")->with("payment_iban")->andReturn(null);
-        $currentSite->expects("getOption")->with("payment_check")->andReturn(null);
-        $currentSite->expects("getOption")->with("name_for_check_payment")->andReturn(null);
+        $currentSite->shouldReceive("getOption")->with("payment_iban")->andReturn(null);
+        $currentSite->shouldReceive("getOption")->with("payment_check")->andReturn(null);
+        $currentSite->shouldReceive("getOption")->with("name_for_check_payment")->andReturn(null);
         $templateService = Helpers::getTemplateService();
         $paymentService = Mockery::mock(PaymentService::class);
         $paymentService->expects("getPayableOrderBySlug")->andReturn($order);
@@ -470,9 +477,9 @@ class PaymentControllerTest extends TestCase
         $order = ModelFactory::createOrder();
         $config = new Config(["paypal" => ["client_id" => "PAYPAL_CLIENT_ID", "client_secret" => "1234"]]);
         $currentSite = Mockery::mock(CurrentSite::class);
-        $currentSite->expects("getOption")->with("payment_iban")->andReturn(null);
-        $currentSite->expects("getOption")->with("payment_check")->andReturn(null);
-        $currentSite->expects("getOption")->with("name_for_check_payment")->andReturn(null);
+        $currentSite->shouldReceive("getOption")->with("payment_iban")->andReturn(null);
+        $currentSite->shouldReceive("getOption")->with("payment_check")->andReturn(null);
+        $currentSite->shouldReceive("getOption")->with("name_for_check_payment")->andReturn(null);
         $templateService = Helpers::getTemplateService();
         $paymentService = Mockery::mock(PaymentService::class);
         $paymentService->expects("getPayableOrderBySlug")->andReturn($order);
@@ -497,9 +504,9 @@ class PaymentControllerTest extends TestCase
         $order = ModelFactory::createOrder();
         $config = new Config();
         $currentSite = Mockery::mock(CurrentSite::class);
-        $currentSite->expects("getOption")->with("payment_iban")->andReturn("PAYMENT_IBAN");
-        $currentSite->expects("getOption")->with("payment_check")->andReturn(null);
-        $currentSite->expects("getOption")->with("name_for_check_payment")->andReturn(null);
+        $currentSite->shouldReceive("getOption")->with("payment_iban")->andReturn("PAYMENT_IBAN");
+        $currentSite->shouldReceive("getOption")->with("payment_check")->andReturn(null);
+        $currentSite->shouldReceive("getOption")->with("name_for_check_payment")->andReturn(null);
         $templateService = Helpers::getTemplateService();
         $paymentService = Mockery::mock(PaymentService::class);
         $paymentService->expects("getPayableOrderBySlug")->andReturn($order);
@@ -527,9 +534,9 @@ class PaymentControllerTest extends TestCase
         $order = ModelFactory::createOrder();
         $config = new Config();
         $currentSite = Mockery::mock(CurrentSite::class);
-        $currentSite->expects("getOption")->with("payment_iban")->andReturn(null);
-        $currentSite->expects("getOption")->with("payment_check")->andReturn(1);
-        $currentSite->expects("getOption")->with("name_for_check_payment")->andReturn("L’ordre");
+        $currentSite->shouldReceive("getOption")->with("payment_iban")->andReturn(null);
+        $currentSite->shouldReceive("getOption")->with("payment_check")->andReturn(1);
+        $currentSite->shouldReceive("getOption")->with("name_for_check_payment")->andReturn("L’ordre");
         $templateService = Helpers::getTemplateService();
         $paymentService = Mockery::mock(PaymentService::class);
         $paymentService->expects("getPayableOrderBySlug")->andReturn($order);
@@ -588,7 +595,7 @@ class PaymentControllerTest extends TestCase
         );
 
         $paymentService = Mockery::mock(PaymentService::class);
-        $paymentService->expects("getPayableOrderBySlug")->andReturn($order);
+        $paymentService->shouldReceive("getPayableOrderBySlug")->andReturn($order);
         $paymentService->expects("createPayplugPaymentForOrder")->with($order)
             ->andThrows($badRequestException);
         $loggerService = Mockery::mock(LoggerService::class);
@@ -630,10 +637,8 @@ class PaymentControllerTest extends TestCase
         $loggerService = Mockery::mock(LoggerService::class);
         $loggerService->expects("log")->with("payplug", "ERROR", "Payplug configuration not found.");
         $mailer = Mockery::mock(Mailer::class);
-        $mailer->expects("send")->once();
         $currentSite = Mockery::mock(CurrentSite::class);
         $urlGenerator = Mockery::mock(UrlGenerator::class);
-        $urlGenerator->expects("generate");
         $templateService = Helpers::getTemplateService();
 
         // then
@@ -666,10 +671,8 @@ class PaymentControllerTest extends TestCase
         $loggerService = Mockery::mock(LoggerService::class);
         $loggerService->expects("log")->with("payplug", "ERROR", "Missing payplug private key.");
         $mailer = Mockery::mock(Mailer::class);
-        $mailer->expects("send")->once();
         $currentSite = Mockery::mock(CurrentSite::class);
         $urlGenerator = Mockery::mock(UrlGenerator::class);
-        $urlGenerator->expects("generate");
         $templateService = Helpers::getTemplateService();
 
         // then
@@ -702,10 +705,8 @@ class PaymentControllerTest extends TestCase
         $loggerService = Mockery::mock(LoggerService::class);
         $loggerService->expects("log")->with("payplug", "ERROR", "Order unknown-url not found.");
         $mailer = Mockery::mock(Mailer::class);
-        $mailer->expects("send")->once();
         $currentSite = Mockery::mock(CurrentSite::class);
         $urlGenerator = Mockery::mock(UrlGenerator::class);
-        $urlGenerator->expects("generate");
         $templateService = Helpers::getTemplateService();
 
         // then
@@ -752,10 +753,8 @@ class PaymentControllerTest extends TestCase
         $httpMock->shouldReceive("close");
         HttpClient::$REQUEST_HANDLER = $httpMock;
         $mailer = Mockery::mock(Mailer::class);
-        $mailer->expects("send")->once();
         $currentSite = Mockery::mock(CurrentSite::class);
         $urlGenerator = Mockery::mock(UrlGenerator::class);
-        $urlGenerator->expects("generate");
         $templateService = Helpers::getTemplateService();
 
         // when
@@ -790,10 +789,8 @@ class PaymentControllerTest extends TestCase
         $loggerService = Mockery::mock(LoggerService::class);
         $loggerService->shouldReceive("log");
         $mailer = Mockery::mock(Mailer::class);
-        $mailer->expects("send")->once();
         $currentSite = Mockery::mock(CurrentSite::class);
         $urlGenerator = Mockery::mock(UrlGenerator::class);
-        $urlGenerator->expects("generate");
         $templateService = Helpers::getTemplateService();
 
         // then
@@ -839,10 +836,8 @@ class PaymentControllerTest extends TestCase
         $httpMock->shouldReceive("close");
         HttpClient::$REQUEST_HANDLER = $httpMock;
         $mailer = Mockery::mock(Mailer::class);
-        $mailer->expects("send")->once();
         $currentSite = Mockery::mock(CurrentSite::class);
         $urlGenerator = Mockery::mock(UrlGenerator::class);
-        $urlGenerator->expects("generate");
         $templateService = Helpers::getTemplateService();
 
         // when
@@ -890,10 +885,8 @@ class PaymentControllerTest extends TestCase
         $httpMock->shouldReceive("close");
         HttpClient::$REQUEST_HANDLER = $httpMock;
         $mailer = Mockery::mock(Mailer::class);
-        $mailer->expects("send")->once();
         $currentSite = Mockery::mock(CurrentSite::class);
         $urlGenerator = Mockery::mock(UrlGenerator::class);
-        $urlGenerator->expects("generate");
         $templateService = Helpers::getTemplateService();
 
         // then
@@ -946,10 +939,8 @@ class PaymentControllerTest extends TestCase
         $httpMock->shouldReceive("close");
         HttpClient::$REQUEST_HANDLER = $httpMock;
         $mailer = Mockery::mock(Mailer::class);
-        $mailer->expects("send")->once();
         $currentSite = Mockery::mock(CurrentSite::class);
         $urlGenerator = Mockery::mock(UrlGenerator::class);
-        $urlGenerator->expects("generate");
         $templateService = Helpers::getTemplateService();
 
         // then

--- a/tests/AppBundle/Controller/PostControllerTest.php
+++ b/tests/AppBundle/Controller/PostControllerTest.php
@@ -55,6 +55,11 @@ class PostControllerTest extends TestCase
         PostQuery::create()->deleteAll();
     }
 
+    public function tearDown(): void
+    {
+        Mockery::close();
+    }
+
     /** showAction */
 
     /**
@@ -189,7 +194,7 @@ class PostControllerTest extends TestCase
 
         $currentUser = Mockery::mock(CurrentUser::class);
         $currentUser->expects("authPublisher");
-        $currentUser->expects("isAdmin")->andReturn(true);
+        $currentUser->shouldReceive("isAdmin")->andReturn(true);
         $queryParamsService = Mockery::mock(QueryParamsService::class);
         $queryParamsService->expects("parse");
         $queryParamsService->expects("getInteger")->with("category_id")->andReturn(0);
@@ -248,7 +253,7 @@ class PostControllerTest extends TestCase
         $bodyParams->expects("getInteger")->with("category_id")->andReturn(3);
         $bodyParams->expects("get")->with("post_link")->andReturn("https://example.net");
         $bodyParams->expects("get")->with("post_illustration_legend")->andReturn("Légende de l'illustration");
-        $bodyParams->expects("getBoolean")->with("post_status")->andReturn(true);
+        $bodyParams->shouldReceive("getBoolean")->with("post_status")->andReturn(true);
         $bodyParams->expects("getBoolean")->with("post_selected")->andReturn(false);
         $bodyParams->expects("get")->with("post_date")->andReturn("2019-04-28 02:42");
         $bodyParams->expects("getBoolean")->with("delete_illustration")->andReturn(false);
@@ -327,7 +332,7 @@ class PostControllerTest extends TestCase
         $bodyParams->expects("getInteger")->with("category_id")->andReturn(3);
         $bodyParams->expects("get")->with("post_link")->andReturn("https://example.net");
         $bodyParams->expects("get")->with("post_illustration_legend")->andReturn("Légende de l'illustration");
-        $bodyParams->expects("getBoolean")->with("post_status")->andReturn(true);
+        $bodyParams->shouldReceive("getBoolean")->with("post_status")->andReturn(true);
         $bodyParams->expects("getBoolean")->with("post_selected")->andReturn(false);
         $bodyParams->expects("get")->with("post_date")->andReturn("2019-04-28 02:42");
         $bodyParams->expects("getBoolean")->with("delete_illustration")->andReturn(false);

--- a/tests/AppBundle/Controller/RedirectionControllerTest.php
+++ b/tests/AppBundle/Controller/RedirectionControllerTest.php
@@ -41,6 +41,11 @@ class RedirectionControllerTest extends TestCase
         RedirectionQuery::create()->deleteAll();
     }
 
+    public function tearDown(): void
+    {
+        Mockery::close();
+    }
+
     /**
      * @throws PropelException
      * @throws Exception
@@ -87,8 +92,8 @@ class RedirectionControllerTest extends TestCase
         $currentSite->method("getId")->willReturn($site->getId());
         $bodyParamsService = Mockery::mock(BodyParamsService::class);
         $bodyParamsService->expects("parse");
-        $bodyParamsService->expects("get")->with("old_url")->andReturn("/old-url");
-        $bodyParamsService->expects("get")->with("new_url")->andReturn("/new-url");
+        $bodyParamsService->shouldReceive("get")->with("old_url")->andReturn("/old-url");
+        $bodyParamsService->shouldReceive("get")->with("new_url")->andReturn("/new-url");
         $flashMessageService = Mockery::mock(FlashMessagesService::class);
         $flashMessageService
             ->expects("add")
@@ -133,8 +138,8 @@ class RedirectionControllerTest extends TestCase
         $currentSite->method("getId")->willReturn($site->getId());
         $bodyParamsService = Mockery::mock(BodyParamsService::class);
         $bodyParamsService->expects("parse");
-        $bodyParamsService->expects("get")->with("old_url")->andReturn("/old-url");
-        $bodyParamsService->expects("get")->with("new_url")->andReturn("/other-new-url");
+        $bodyParamsService->shouldReceive("get")->with("old_url")->andReturn("/old-url");
+        $bodyParamsService->shouldReceive("get")->with("new_url")->andReturn("/other-new-url");
         $flashMessageService = Mockery::mock(FlashMessagesService::class);
         $flashMessageService
             ->expects("add")

--- a/tests/AppBundle/Controller/SpecialOfferControllerTest.php
+++ b/tests/AppBundle/Controller/SpecialOfferControllerTest.php
@@ -26,6 +26,7 @@ use Biblys\Test\ModelFactory;
 use Exception;
 use Mockery;
 use Model\Article;
+use Model\SpecialOfferQuery;
 use PHPUnit\Framework\TestCase;
 use Propel\Runtime\Exception\PropelException;
 use Symfony\Component\HttpFoundation\Request;
@@ -42,6 +43,19 @@ require_once __DIR__ . "/../../setUp.php";
 
 class SpecialOfferControllerTest extends TestCase
 {
+    /**
+     * @throws PropelException
+     */
+    public function setUp(): void
+    {
+        SpecialOfferQuery::create()->deleteAll();
+    }
+
+    public function tearDown(): void
+    {
+        Mockery::close();
+    }
+
     /* INDEX ACTION */
 
     /**
@@ -63,9 +77,11 @@ class SpecialOfferControllerTest extends TestCase
         $templateService = Mockery::mock(TemplateService::class);
         $templateService
             ->shouldReceive("renderResponse")
-            ->with('AppBundle:SpecialOffer:index.html.twig', [
-                'offers' => [$offer],
-            ], true)
+            ->with(
+                'AppBundle:SpecialOffer:index.html.twig',
+                Mockery::on(fn($args) => count($args['offers']) === 1 && $args['offers'][0]->getId() === $offer->getId()),
+                true,
+            )
             ->andReturn(new Response());
 
         // when

--- a/tests/AppBundle/Controller/UserControllerTest.php
+++ b/tests/AppBundle/Controller/UserControllerTest.php
@@ -63,6 +63,11 @@ class UserControllerTest extends TestCase
         UserQuery::create()->deleteAll();
     }
 
+    public function tearDown(): void
+    {
+        Mockery::close();
+    }
+
 
     /**
      * @throws SyntaxError
@@ -83,9 +88,9 @@ class UserControllerTest extends TestCase
         $currentUser = Mockery::mock(CurrentUser::class);
         $currentUser->shouldReceive('authAdmin')->andReturns();
         $queryParamsService = Mockery::mock(QueryParamsService::class);
-        $queryParamsService->expects("parse")->andReturns();
-        $queryParamsService->expects("getInteger")->with("p")->andReturn(0);
-        $queryParamsService->expects("get")->with("q")->andReturn("");
+        $queryParamsService->shouldReceive("parse")->andReturns();
+        $queryParamsService->shouldReceive("getInteger")->with("p")->andReturn(0);
+        $queryParamsService->shouldReceive("get")->with("q")->andReturn("");
         $templateService = Helpers::getTemplateService();
 
         // when
@@ -114,9 +119,9 @@ class UserControllerTest extends TestCase
         $currentUser = Mockery::mock(CurrentUser::class);
         $currentUser->shouldReceive('authAdmin')->andReturns();
         $queryParamsService = Mockery::mock(QueryParamsService::class);
-        $queryParamsService->expects("parse")->andReturns();
-        $queryParamsService->expects("getInteger")->with("p")->andReturn(0);
-        $queryParamsService->expects("get")->with("q")->andReturn("looking-for");
+        $queryParamsService->shouldReceive("parse")->andReturns();
+        $queryParamsService->shouldReceive("getInteger")->with("p")->andReturn(0);
+        $queryParamsService->shouldReceive("get")->with("q")->andReturn("looking-for");
         $templateService = Helpers::getTemplateService();
 
         // when
@@ -169,12 +174,12 @@ class UserControllerTest extends TestCase
         $currentUser = Mockery::mock(CurrentUser::class);
         $currentUser->shouldReceive("authAdmin")->andReturns();
         $flashMessages = Mockery::mock(FlashMessagesService::class);
-        $flashMessages->expects("add")->with(
+        $flashMessages->shouldReceive("add")->with(
             "success",
             "L'utilisateur user-to-delete@example.org a bien été supprimé."
         );
         $urlGenerator = Mockery::mock(UrlGenerator::class);
-        $urlGenerator->expects("generate")->with("user_index")->andReturn("/admin/users");
+        $urlGenerator->shouldReceive("generate")->with("user_index")->andReturn("/admin/users");
 
         // when
         $response = $controller->deleteAction($currentUser, $urlGenerator, $flashMessages, $userToDelete->getId());
@@ -199,12 +204,12 @@ class UserControllerTest extends TestCase
         $currentUser = Mockery::mock(CurrentUser::class);
         $currentUser->shouldReceive("authAdmin")->andReturns();
         $flashMessages = Mockery::mock(FlashMessagesService::class);
-        $flashMessages->expects("add")->with(
+        $flashMessages->shouldReceive("add")->with(
             "error",
             "Impossible de supprimer le compte user-with-orders@example.org car il a des commandes."
         );
         $urlGenerator = Mockery::mock(UrlGenerator::class);
-        $urlGenerator->expects("generate")->with("user_admin_informations", ["id" => $userToDelete->getId()])
+        $urlGenerator->shouldReceive("generate")->with("user_admin_informations", ["id" => $userToDelete->getId()])
             ->andReturn("/users/123");
 
         // when
@@ -239,10 +244,10 @@ class UserControllerTest extends TestCase
             ->with("openid_axys")
             ->willReturn("/openid/axys");
         $queryParams = Mockery::mock(QueryParamsService::class);
-        $queryParams->expects("parse")->andReturn("");
-        $queryParams->expects("get")->with("return_url")->andReturn("");
+        $queryParams->shouldReceive("parse")->andReturn("");
+        $queryParams->shouldReceive("get")->with("return_url")->andReturn("");
         $config = Mockery::mock(Config::class);
-        $config->expects("isAxysEnabled")->andReturns(false);
+        $config->shouldReceive("isAxysEnabled")->andReturns(false);
 
         // when
         $response = $userController->login($queryParams, $currentUser, $urlGenerator, $config);
@@ -272,10 +277,10 @@ class UserControllerTest extends TestCase
             ->with("openid_axys")
             ->willReturn("/openid/axys");
         $queryParams = Mockery::mock(QueryParamsService::class);
-        $queryParams->expects("parse")->andReturn("");
-        $queryParams->expects("get")->with("return_url")->andReturn("");
+        $queryParams->shouldReceive("parse")->andReturn("");
+        $queryParams->shouldReceive("get")->with("return_url")->andReturn("");
         $config = Mockery::mock(Config::class);
-        $config->expects("isAxysEnabled")->andReturns(true);
+        $config->shouldReceive("isAxysEnabled")->andReturns(true);
 
         // when
         $response = $userController->login($queryParams, $currentUser, $urlGenerator, $config);
@@ -305,10 +310,10 @@ class UserControllerTest extends TestCase
             ->with("openid_axys", ["return_url" => "url_to_return_to"])
             ->willReturn("/openid/axys?return_url=url_to_return_to");
         $queryParams = Mockery::mock(QueryParamsService::class);
-        $queryParams->expects("parse")->andReturn("");
-        $queryParams->expects("get")->with("return_url")->andReturn("url_to_return_to");
+        $queryParams->shouldReceive("parse")->andReturn("");
+        $queryParams->shouldReceive("get")->with("return_url")->andReturn("url_to_return_to");
         $config = Mockery::mock(Config::class);
-        $config->expects("isAxysEnabled")->andReturns(false);
+        $config->shouldReceive("isAxysEnabled")->andReturns(false);
 
         // when
         $response = $userController->login($queryParams, $currentUser, $urlGenerator, $config);
@@ -337,10 +342,10 @@ class UserControllerTest extends TestCase
             ->with("main_home")
             ->willReturn("/");
         $queryParams = Mockery::mock(QueryParamsService::class);
-        $queryParams->expects("parse")->andReturn("");
-        $queryParams->expects("get")->with("return_url")->andReturn("");
+        $queryParams->shouldReceive("parse")->andReturn("");
+        $queryParams->shouldReceive("get")->with("return_url")->andReturn("");
         $config = Mockery::mock(Config::class);
-        $config->expects("isAxysEnabled")->andReturns(false);
+        $config->shouldReceive("isAxysEnabled")->andReturns(false);
 
         // when
         $response = $userController->login($queryParams, $currentUser, $urlGenerator, $config);
@@ -377,18 +382,18 @@ class UserControllerTest extends TestCase
             ->andReturn($expectedResponse);
         $templateService->shouldReceive("render")->andReturn("mail body");
         $tokenService = Mockery::mock(TokenService::class);
-        $tokenService->expects("createLoginToken")->andReturn("token");
+        $tokenService->shouldReceive("createLoginToken")->andReturn("token");
         $urlGenerator = Mockery::mock(UrlGenerator::class);
-        $urlGenerator->expects("generate")->andReturn("login_url");
+        $urlGenerator->shouldReceive("generate")->andReturn("login_url");
         $mailer = Mockery::mock(Mailer::class);
-        $mailer->expects("validateEmail")->andThrow(
+        $mailer->shouldReceive("validateEmail")->andThrow(
             new InvalidEmailAddressException("L'adresse invalid-email est invalide.")
         );
         $bodyParamsService = Mockery::mock(BodyParamsService::class);
-        $bodyParamsService->expects("parse")->andReturns();
-        $bodyParamsService->expects("get")->with("email")->andReturn("invalid-email");
-        $bodyParamsService->expects("get")->with("return_url")->andReturn("/continue");
-        $bodyParamsService->expects("get")->with("username")->andReturn("");
+        $bodyParamsService->shouldReceive("parse")->andReturns();
+        $bodyParamsService->shouldReceive("get")->with("email")->andReturn("invalid-email");
+        $bodyParamsService->shouldReceive("get")->with("return_url")->andReturn("/continue");
+        $bodyParamsService->shouldReceive("get")->with("username")->andReturn("");
 
         // then
         $this->expectException(BadRequestHttpException::class);
@@ -428,18 +433,18 @@ class UserControllerTest extends TestCase
             ->andReturn($expectedResponse);
         $templateService->shouldReceive("render")->andReturn("mail body");
         $tokenService = Mockery::mock(TokenService::class);
-        $tokenService->expects("createLoginToken")->andReturn("token");
+        $tokenService->shouldReceive("createLoginToken")->andReturn("token");
         $urlGenerator = Mockery::mock(UrlGenerator::class);
-        $urlGenerator->expects("generate")->andReturn("login_url");
+        $urlGenerator->shouldReceive("generate")->andReturn("login_url");
         $mailer = Mockery::mock(Mailer::class);
-        $mailer->expects("validateEmail");
-        $mailer->expects("send");
+        $mailer->shouldReceive("validateEmail");
+        $mailer->shouldReceive("send");
 
         $bodyParamsService = Mockery::mock(BodyParamsService::class);
-        $bodyParamsService->expects("parse")->andReturns();
-        $bodyParamsService->expects("get")->with("email")->andReturn("user@example.net");
-        $bodyParamsService->expects("get")->with("return_url")->andReturn("/continue");
-        $bodyParamsService->expects("get")->with("username")->andReturn("");
+        $bodyParamsService->shouldReceive("parse")->andReturns();
+        $bodyParamsService->shouldReceive("get")->with("email")->andReturn("user@example.net");
+        $bodyParamsService->shouldReceive("get")->with("return_url")->andReturn("/continue");
+        $bodyParamsService->shouldReceive("get")->with("username")->andReturn("");
 
         // when
         $returnedResponse = $controller->sendLoginEmailAction(
@@ -491,17 +496,17 @@ class UserControllerTest extends TestCase
             ->andReturn($expectedResponse);
         $templateService->shouldReceive("render")->andReturn("mail body");
         $tokenService = Mockery::mock(TokenService::class);
-        $tokenService->expects("createLoginToken")->andReturn("token");
+        $tokenService->shouldReceive("createLoginToken")->andReturn("token");
         $urlGenerator = Mockery::mock(UrlGenerator::class);
-        $urlGenerator->expects("generate")->andReturn("login_url");
+        $urlGenerator->shouldReceive("generate")->andReturn("login_url");
         $mailer = Mockery::mock(Mailer::class);
-        $mailer->expects("validateEmail");
-        $mailer->expects("send");
+        $mailer->shouldReceive("validateEmail");
+        $mailer->shouldReceive("send");
         $bodyParamsService = Mockery::mock(BodyParamsService::class);
-        $bodyParamsService->expects("parse")->andReturns();
-        $bodyParamsService->expects("get")->with("email")->andReturn("user@example.net");
-        $bodyParamsService->expects("get")->with("return_url")->andReturn("/continue");
-        $bodyParamsService->expects("get")->with("username")->andReturn("honeypot");
+        $bodyParamsService->shouldReceive("parse")->andReturns();
+        $bodyParamsService->shouldReceive("get")->with("email")->andReturn("user@example.net");
+        $bodyParamsService->shouldReceive("get")->with("return_url")->andReturn("/continue");
+        $bodyParamsService->shouldReceive("get")->with("username")->andReturn("honeypot");
 
         // when
         $response = $controller->sendLoginEmailAction(
@@ -548,17 +553,17 @@ class UserControllerTest extends TestCase
         $templateService->shouldReceive("render")
             ->andReturn($expectedMailBody);
         $mailer = Mockery::mock(Mailer::class);
-        $mailer->expects("validateEmail");
-        $mailer->expects("send");
+        $mailer->shouldReceive("validateEmail");
+        $mailer->shouldReceive("send");
         $tokenService = Mockery::mock(TokenService::class);
-        $tokenService->expects("createLoginToken")->andReturn("token");
+        $tokenService->shouldReceive("createLoginToken")->andReturn("token");
         $urlGenerator = Mockery::mock(UrlGenerator::class);
-        $urlGenerator->expects("generate")->andReturn("login_url");
+        $urlGenerator->shouldReceive("generate")->andReturn("login_url");
         $bodyParamsService = Mockery::mock(BodyParamsService::class);
-        $bodyParamsService->expects("parse")->andReturns();
-        $bodyParamsService->expects("get")->with("email")->andReturn("user@example.net");
-        $bodyParamsService->expects("get")->with("return_url")->andReturn("/continue");
-        $bodyParamsService->expects("get")->with("username")->andReturn("");
+        $bodyParamsService->shouldReceive("parse")->andReturns();
+        $bodyParamsService->shouldReceive("get")->with("email")->andReturn("user@example.net");
+        $bodyParamsService->shouldReceive("get")->with("return_url")->andReturn("/continue");
+        $bodyParamsService->shouldReceive("get")->with("username")->andReturn("");
 
         // when
         $returnedResponse = $controller->sendLoginEmailAction(
@@ -604,10 +609,10 @@ class UserControllerTest extends TestCase
         $site = ModelFactory::createSite();
         ModelFactory::createUser(email: "new-@paronymie.fr");
         $queryParamsService = Mockery::mock(QueryParamsService::class);
-        $queryParamsService->expects("parse")->with(["token" => ["type" => "string"]]);
-        $queryParamsService->expects("get")->with("token")->andReturn("signup_token");
+        $queryParamsService->shouldReceive("parse")->with(["token" => ["type" => "string"]]);
+        $queryParamsService->shouldReceive("get")->with("token")->andReturn("signup_token");
         $tokenService = Mockery::mock(TokenService::class);
-        $tokenService->expects("decodeLoginToken")->andReturn([
+        $tokenService->shouldReceive("decodeLoginToken")->andReturn([
             "email" => "existing-user@paronymie.fr",
             "action" => "login-by-email",
             "after_login_url" => "/continue",
@@ -640,10 +645,10 @@ class UserControllerTest extends TestCase
         $site = ModelFactory::createSite();
         ModelFactory::createUser(email: "existing-user@paronymie.fr");
         $queryParamsService = Mockery::mock(QueryParamsService::class);
-        $queryParamsService->expects("parse")->with(["token" => ["type" => "string"]]);
-        $queryParamsService->expects("get")->with("token")->andReturn("signup_token");
+        $queryParamsService->shouldReceive("parse")->with(["token" => ["type" => "string"]]);
+        $queryParamsService->shouldReceive("get")->with("token")->andReturn("signup_token");
         $tokenService = Mockery::mock(TokenService::class);
-        $tokenService->expects("decodeLoginToken")->andReturn([
+        $tokenService->shouldReceive("decodeLoginToken")->andReturn([
             "email" => "existing-user@paronymie.fr",
             "action" => "signup-by-email",
             "after_login_url" => "/continue",
@@ -675,23 +680,23 @@ class UserControllerTest extends TestCase
         // given
         $controller = new UserController();
         $queryParamsService = Mockery::mock(QueryParamsService::class);
-        $queryParamsService->expects("parse")->with(["token" => ["type" => "string"]]);
-        $queryParamsService->expects("get")->with("token")->andReturn("signup_token");
+        $queryParamsService->shouldReceive("parse")->with(["token" => ["type" => "string"]]);
+        $queryParamsService->shouldReceive("get")->with("token")->andReturn("signup_token");
         $tokenService = Mockery::mock(TokenService::class);
-        $tokenService->expects("decodeLoginToken")->andReturn([
+        $tokenService->shouldReceive("decodeLoginToken")->andReturn([
             "email" => "new-user@paronymie.fr",
             "action" => "signup-by-email",
             "after_login_url" => "/continue",
         ]);
-        $tokenService->expects("createLoginToken")->andReturn("token");
+        $tokenService->shouldReceive("createLoginToken")->andReturn("token");
         $site = ModelFactory::createSite(title: "Paronymie ltd");
         $currentSite = new CurrentSite($site);
         $urlGenerator = Mockery::mock(UrlGenerator::class);
-        $urlGenerator->expects("generate")->andReturn("/login_url");
+        $urlGenerator->shouldReceive("generate")->andReturn("/login_url");
         $flashBag = Mockery::mock(FlashBag::class);
-        $flashBag->expects("add");
+        $flashBag->shouldReceive("add");
         $session = Mockery::mock(Session::class);
-        $session->expects("getFlashBag")->andReturn($flashBag);
+        $session->shouldReceive("getFlashBag")->andReturn($flashBag);
 
         // when
         $response = $controller->signupWithTokenAction(
@@ -725,10 +730,10 @@ class UserControllerTest extends TestCase
         $controller = new UserController();
         $request = new Request();
         $queryParamsService = Mockery::mock(QueryParamsService::class);
-        $queryParamsService->expects("parse")->with(["token" => ["type" => "string"]]);
-        $queryParamsService->expects("get")->with("token")->andReturn("login_token");
+        $queryParamsService->shouldReceive("parse")->with(["token" => ["type" => "string"]]);
+        $queryParamsService->shouldReceive("get")->with("token")->andReturn("login_token");
         $tokenService = Mockery::mock(TokenService::class);
-        $tokenService->expects("decodeLoginToken")->andThrows(new InvalidTokenException());
+        $tokenService->shouldReceive("decodeLoginToken")->andThrows(new InvalidTokenException());
         $currentSite = Mockery::mock(CurrentSite::class);
         $currentUser = Mockery::mock(CurrentUser::class);
 
@@ -759,10 +764,10 @@ class UserControllerTest extends TestCase
         $controller = new UserController();
         $request = new Request();
         $queryParamsService = Mockery::mock(QueryParamsService::class);
-        $queryParamsService->expects("parse")->with(["token" => ["type" => "string"]]);
-        $queryParamsService->expects("get")->with("token")->andReturn("login_token");
+        $queryParamsService->shouldReceive("parse")->with(["token" => ["type" => "string"]]);
+        $queryParamsService->shouldReceive("get")->with("token")->andReturn("login_token");
         $tokenService = Mockery::mock(TokenService::class);
-        $tokenService->expects("decodeLoginToken")->andReturn(["email" => "unknown@paronymie.fr"]);
+        $tokenService->shouldReceive("decodeLoginToken")->andReturn(["email" => "unknown@paronymie.fr"]);
         $site = ModelFactory::createSite();
         $currentSite = new CurrentSite($site);
         $currentUser = Mockery::mock(CurrentUser::class);
@@ -793,10 +798,10 @@ class UserControllerTest extends TestCase
         $request->query->set("token", "login_token");
         $request->cookies->set("visitor_uid", "visitor_token");
         $queryParamsService = Mockery::mock(QueryParamsService::class);
-        $queryParamsService->expects("parse")->with(["token" => ["type" => "string"]]);
-        $queryParamsService->expects("get")->with("token")->andReturn("login_token");
+        $queryParamsService->shouldReceive("parse")->with(["token" => ["type" => "string"]]);
+        $queryParamsService->shouldReceive("get")->with("token")->andReturn("login_token");
         $tokenService = Mockery::mock(TokenService::class);
-        $tokenService->expects("decodeLoginToken")->andReturn([
+        $tokenService->shouldReceive("decodeLoginToken")->andReturn([
             "email" => "user@paronymie.fr",
             "action" => "login-by-email",
             "after_login_url" => "/after_login_url",
@@ -805,8 +810,8 @@ class UserControllerTest extends TestCase
         $currentSite = new CurrentSite($site);
         $user = ModelFactory::createUser(email: "user@paronymie.fr");
         $currentUser = Mockery::mock(CurrentUser::class);
-        $currentUser->expects("setUser")->with($user);
-        $currentUser->expects("transfertVisitorCartToUser")->with("visitor_token");
+        $currentUser->shouldReceive("setUser")->with($user);
+        $currentUser->shouldReceive("transfertVisitorCartToUser")->with("visitor_token");
 
         // when
         $response = $controller->loginWithTokenAction(
@@ -851,10 +856,10 @@ class UserControllerTest extends TestCase
         $request->query->set("token", "login_token");
         $request->cookies->set("visitor_uid", "visitor_token");
         $queryParamsService = Mockery::mock(QueryParamsService::class);
-        $queryParamsService->expects("parse")->with(["token" => ["type" => "string"]]);
-        $queryParamsService->expects("get")->with("token")->andReturn("login_token");
+        $queryParamsService->shouldReceive("parse")->with(["token" => ["type" => "string"]]);
+        $queryParamsService->shouldReceive("get")->with("token")->andReturn("login_token");
         $tokenService = Mockery::mock(TokenService::class);
-        $tokenService->expects("decodeLoginToken")->andReturn([
+        $tokenService->shouldReceive("decodeLoginToken")->andReturn([
             "email" => "user@paronymie.fr",
             "action" => "login-with-oidc",
             "after_login_url" => "",
@@ -863,8 +868,8 @@ class UserControllerTest extends TestCase
         $currentSite = new CurrentSite($site);
         $user = ModelFactory::createUser(email: "user@paronymie.fr");
         $currentUser = Mockery::mock(CurrentUser::class);
-        $currentUser->expects("setUser")->with($user);
-        $currentUser->expects("transfertVisitorCartToUser")->with("visitor_token");
+        $currentUser->shouldReceive("setUser")->with($user);
+        $currentUser->shouldReceive("transfertVisitorCartToUser")->with("visitor_token");
 
         // when
         $controller->loginWithTokenAction(
@@ -899,9 +904,9 @@ class UserControllerTest extends TestCase
 
         $currentSite = new CurrentSite($site);
         $currentUser = Mockery::mock(CurrentUser::class);
-        $currentUser->expects("getUser")->andReturn($user);
+        $currentUser->shouldReceive("getUser")->andReturn($user);
         $templateService = Mockery::mock(TemplateService::class);
-        $templateService->expects("renderResponse")
+        $templateService->shouldReceive("renderResponse")
             ->andReturn(new Response("Vous êtes connecté·e à l'aide d'un compte Axys."));
 
         // when
@@ -934,10 +939,10 @@ class UserControllerTest extends TestCase
         $currentSite = new CurrentSite($site);
         ModelFactory::createAuthenticationMethod(user: $user);
         $currentUser = Mockery::mock(CurrentUser::class);
-        $currentUser->expects("getUser")->andReturn($user);
+        $currentUser->shouldReceive("getUser")->andReturn($user);
 
         $templateService = Mockery::mock(TemplateService::class);
-        $templateService->expects("renderResponse")->andReturn(new Response("Vous êtes connecté·e à l'aide d'un compte Axys."));
+        $templateService->shouldReceive("renderResponse")->andReturn(new Response("Vous êtes connecté·e à l'aide d'un compte Axys."));
 
         // when
         $response = $userController->account($currentSite, $currentUser, $templateService);
@@ -959,9 +964,9 @@ class UserControllerTest extends TestCase
         // given
         $userController = new UserController();
         $flashBag = Mockery::mock(FlashBag::class);
-        $flashBag->expects("add");
+        $flashBag->shouldReceive("add");
         $session = Mockery::mock(Session::class);
-        $session->expects("getFlashBag")->andReturn($flashBag);
+        $session->shouldReceive("getFlashBag")->andReturn($flashBag);
 
         // when
         $response = $userController->logout($session);
@@ -996,8 +1001,8 @@ class UserControllerTest extends TestCase
         $request = new Request();
         $request->request->set("new_email", "old-email@paronymie.fr");
         $currentUser = Mockery::mock(CurrentUser::class);
-        $currentUser->expects("authUser");
-        $currentUser->expects("getUser")->andReturn($user);
+        $currentUser->shouldReceive("authUser");
+        $currentUser->shouldReceive("getUser")->andReturn($user);
         $tokenService = Mockery::mock(TokenService::class);
         $templateService = Mockery::mock(TemplateService::class);
         $mailer = Mockery::mock(Mailer::class);
@@ -1037,12 +1042,12 @@ class UserControllerTest extends TestCase
         $request = new Request();
         $request->request->set("new_email", "new-email");
         $currentUser = Mockery::mock(CurrentUser::class);
-        $currentUser->expects("authUser");
-        $currentUser->expects("getUser")->andReturn(ModelFactory::createUser());
+        $currentUser->shouldReceive("authUser");
+        $currentUser->shouldReceive("getUser")->andReturn(ModelFactory::createUser());
         $tokenService = Mockery::mock(TokenService::class);
         $templateService = Mockery::mock(TemplateService::class);
         $mailer = Mockery::mock(Mailer::class);
-        $mailer->expects("validateEmail")->andThrow(InvalidEmailAddressException::class);
+        $mailer->shouldReceive("validateEmail")->andThrow(InvalidEmailAddressException::class);
         $flashMessages = Mockery::mock(FlashMessagesService::class);
         $urlGenerator = Mockery::mock(UrlGenerator::class);
 
@@ -1082,16 +1087,16 @@ class UserControllerTest extends TestCase
         $request->request->set("new_email", "new-email@paronymie.fr");
         $currentUser = new CurrentUser($user, "token");
         $tokenService = Mockery::mock(TokenService::class);
-        $tokenService->expects("createEmailUpdateToken");
+        $tokenService->shouldReceive("createEmailUpdateToken");
         $templateService = Mockery::mock(TemplateService::class);
-        $templateService->expects("render")->andReturn("email body");
+        $templateService->shouldReceive("render")->andReturn("email body");
         $mailer = Mockery::mock(Mailer::class);
-        $mailer->expects("validateEmail");
-        $mailer->expects("send");
+        $mailer->shouldReceive("validateEmail");
+        $mailer->shouldReceive("send");
         $flashMessages = Mockery::mock(FlashMessagesService::class);
-        $flashMessages->expects("add");
+        $flashMessages->shouldReceive("add");
         $urlGenerator = Mockery::mock(UrlGenerator::class);
-        $urlGenerator->expects("generate")->andReturn("/user/account");
+        $urlGenerator->shouldReceive("generate")->andReturn("/user/account");
 
         // when
         $response = $userController->requestEmailUpdateAction(
@@ -1138,13 +1143,13 @@ class UserControllerTest extends TestCase
         $loggedInUser = ModelFactory::createUser();
 
         $currentUser = Mockery::mock(CurrentUser::class);
-        $currentUser->expects("authUser");
-        $currentUser->expects("getUser")->andReturn($loggedInUser);
+        $currentUser->shouldReceive("authUser");
+        $currentUser->shouldReceive("getUser")->andReturn($loggedInUser);
         $queryParams = Mockery::mock(QueryParamsService::class);
-        $queryParams->expects("parse");
-        $queryParams->expects("get")->andReturn("token");
+        $queryParams->shouldReceive("parse");
+        $queryParams->shouldReceive("get")->andReturn("token");
         $tokenService = Mockery::mock(TokenService::class);
-        $tokenService->expects("decodeEmailUpdateToken")
+        $tokenService->shouldReceive("decodeEmailUpdateToken")
             ->andThrow(InvalidTokenException::class);
         $urlGenerator = Mockery::mock(UrlGenerator::class);
         $flashMessages = Mockery::mock(FlashMessagesService::class);
@@ -1176,13 +1181,13 @@ class UserControllerTest extends TestCase
         $tokenUser = ModelFactory::createUser();
 
         $currentUser = Mockery::mock(CurrentUser::class);
-        $currentUser->expects("authUser");
-        $currentUser->expects("getUser")->andReturn($loggedInUser);
+        $currentUser->shouldReceive("authUser");
+        $currentUser->shouldReceive("getUser")->andReturn($loggedInUser);
         $queryParams = Mockery::mock(QueryParamsService::class);
-        $queryParams->expects("parse");
-        $queryParams->expects("get")->andReturn("token");
+        $queryParams->shouldReceive("parse");
+        $queryParams->shouldReceive("get")->andReturn("token");
         $tokenService = Mockery::mock(TokenService::class);
-        $tokenService->expects("decodeEmailUpdateToken")
+        $tokenService->shouldReceive("decodeEmailUpdateToken")
             ->andReturn(["user_id" => $tokenUser->getId(), "new_email" => "new-email@paronymie.fr"]);
         $urlGenerator = Mockery::mock(UrlGenerator::class);
         $flashMessages = Mockery::mock(FlashMessagesService::class);
@@ -1214,18 +1219,18 @@ class UserControllerTest extends TestCase
         $user = ModelFactory::createUser(email: "old-email@paronymie.fr");
 
         $currentUser = Mockery::mock(CurrentUser::class);
-        $currentUser->expects("authUser");
-        $currentUser->expects("getUser")->andReturn($user);
+        $currentUser->shouldReceive("authUser");
+        $currentUser->shouldReceive("getUser")->andReturn($user);
         $queryParams = Mockery::mock(QueryParamsService::class);
-        $queryParams->expects("parse");
-        $queryParams->expects("get")->andReturn("token");
+        $queryParams->shouldReceive("parse");
+        $queryParams->shouldReceive("get")->andReturn("token");
         $tokenService = Mockery::mock(TokenService::class);
-        $tokenService->expects("decodeEmailUpdateToken")
+        $tokenService->shouldReceive("decodeEmailUpdateToken")
             ->andReturn(["user_id" => $user->getId(), "new_email" => "new-email@paronymie.fr"]);
         $urlGenerator = Mockery::mock(UrlGenerator::class);
-        $urlGenerator->expects("generate")->andReturn("/user/account");
+        $urlGenerator->shouldReceive("generate")->andReturn("/user/account");
         $flashMessages = Mockery::mock(FlashMessagesService::class);
-        $flashMessages->expects("add");
+        $flashMessages->shouldReceive("add");
 
         // when
         $response = $userController->updateEmailAction(
@@ -1270,7 +1275,7 @@ class UserControllerTest extends TestCase
 
         $user = ModelFactory::createUser();
         $currentUser = Mockery::mock(CurrentUser::class);
-        $currentUser->expects("authUser")->andReturns();
+        $currentUser->shouldReceive("authUser")->andReturns();
         $currentUser->shouldReceive("getUser")->andReturn($user);
         $templateService = Helpers::getTemplateService();
 
@@ -1307,7 +1312,7 @@ class UserControllerTest extends TestCase
 
         $user = ModelFactory::createUser();
         $currentUser = Mockery::mock(CurrentUser::class);
-        $currentUser->expects("authUser")->andReturns();
+        $currentUser->shouldReceive("authUser")->andReturns();
         $currentUser->shouldReceive("getUser")->andReturn($user);
 
         $site = ModelFactory::createSite();
@@ -1315,8 +1320,8 @@ class UserControllerTest extends TestCase
         
 
         $queryParams = Mockery::mock(QueryParamsService::class);
-        $queryParams->expects("parse");
-        $queryParams->expects("get")->andReturn("0");
+        $queryParams->shouldReceive("parse");
+        $queryParams->shouldReceive("get")->andReturn("0");
 
         $templateService = Mockery::mock(TemplateService::class);
         $templateService->shouldReceive("renderResponse")->andReturn(
@@ -1366,16 +1371,16 @@ class UserControllerTest extends TestCase
 
         $user = ModelFactory::createUser();
         $currentUser = Mockery::mock(CurrentUser::class);
-        $currentUser->expects("authAdmin")->andReturns();
+        $currentUser->shouldReceive("authAdmin")->andReturns();
 
         $site = ModelFactory::createSite();
         $currentSite = Mockery::mock(CurrentSite::class);
         
 
         $queryParams = Mockery::mock(QueryParamsService::class);
-        $queryParams->expects("parse");
-        $queryParams->expects("get")->with("q")->andReturn("");
-        $queryParams->expects("get")->with("p")->andReturn("0");
+        $queryParams->shouldReceive("parse");
+        $queryParams->shouldReceive("get")->with("q")->andReturn("");
+        $queryParams->shouldReceive("get")->with("p")->andReturn("0");
 
         $templateService = Helpers::getTemplateService();
 


### PR DESCRIPTION
## Problème. 

Certains paiements ne déclenchent pas de création d'une ligne dans la table `payments`.

## Solution
 
cf. #416 

- [x] Vente rapide depuis le stock
- [x] Modification d'une commande
  - [x] Ajouter un controller pour créer manuellement un paiement
  - [x] Ajouter un formulaire pour créer un paiement depuis la page d'édition d'une commande
  - [x] Désactiver les champs de formulaire qui peuvent modifiés par d'autres actions
