### PR TITLE
Enregistrer les paiements des ventes caisse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Historique des modifications
 
+## 3.14.0 (DEV)
+
+### Confirmité NF525
+
+- Les paiements effectués lors d'une vente en caisse sont désormais enregistrés.
+
 ## 3.13.0 (3 juin 2026)
 
 ### Conformité NF525

--- a/controllers/common/php/adm_checkout.php
+++ b/controllers/common/php/adm_checkout.php
@@ -20,7 +20,9 @@ use Biblys\Exception\CannotAddStockItemToCartException;
 use Biblys\Legacy\LegacyCodeHelper;
 use Biblys\Service\FlashMessagesService;
 use Biblys\Service\Images\ImagesService;
+use Model\Payment;
 use Model\UserQuery;
+use Usecase\RecordShopPaymentsUsecase;
 use Biblys\Service\CurrentSite;
 use Biblys\Service\CurrentUser;
 use Propel\Runtime\Exception\PropelException;
@@ -141,6 +143,13 @@ return function (
 
             // Update order
             $order = $_O->update($order);
+
+            $shopPaymentsUsecase = new RecordShopPaymentsUsecase();
+            $shopPaymentsUsecase->execute((int) $order->get('order_id'), [
+                Payment::MODE_CASH  => (int) round((float) $_POST['cart_cash']  * 100),
+                Payment::MODE_CHECK => (int) round((float) $_POST['cart_cheque'] * 100),
+                Payment::MODE_CARD  => (int) round((float) $_POST['cart_card']  * 100),
+            ]);
 
             // Reset cart
             $cm->vacuum($cart);

--- a/controllers/common/php/adm_checkout.php
+++ b/controllers/common/php/adm_checkout.php
@@ -146,9 +146,9 @@ return function (
 
             $shopPaymentsUsecase = new RecordShopPaymentsUsecase();
             $shopPaymentsUsecase->execute((int) $order->get('order_id'), [
-                Payment::MODE_CASH  => (int) round((float) $_POST['cart_cash']  * 100),
-                Payment::MODE_CHECK => (int) round((float) $_POST['cart_cheque'] * 100),
-                Payment::MODE_CARD  => (int) round((float) $_POST['cart_card']  * 100),
+                Payment::MODE_CASH  => (int) $_POST['cart_cash'],
+                Payment::MODE_CHECK => (int) $_POST['cart_cheque'],
+                Payment::MODE_CARD  => (int) $_POST['cart_card'],
             ]);
 
             // Reset cart

--- a/src/Usecase/RecordShopPaymentsUsecase.php
+++ b/src/Usecase/RecordShopPaymentsUsecase.php
@@ -1,0 +1,46 @@
+<?php
+/*
+ * Copyright (C) 2026 Clément Latzarus
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace Usecase;
+
+use DateTime;
+use Model\Payment;
+use Propel\Runtime\Exception\PropelException;
+
+class RecordShopPaymentsUsecase
+{
+    /**
+     * @param int $orderId
+     * @param array<string, int> $paymentsByMode [mode => amountInCents]
+     * @throws PropelException
+     */
+    public function execute(int $orderId, array $paymentsByMode): void
+    {
+        foreach ($paymentsByMode as $mode => $amount) {
+            if ($amount <= 0) {
+                continue;
+            }
+
+            $payment = new Payment();
+            $payment->setOrderId($orderId);
+            $payment->setMode($mode);
+            $payment->setAmount($amount);
+            $payment->setExecuted(new DateTime());
+            $payment->save();
+        }
+    }
+}

--- a/tests/AppBundle/Controller/Legacy/AdmCheckoutTest.php
+++ b/tests/AppBundle/Controller/Legacy/AdmCheckoutTest.php
@@ -1,0 +1,102 @@
+<?php
+/*
+ * Copyright (C) 2026 Clément Latzarus
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+
+namespace AppBundle\Controller\Legacy;
+
+use Biblys\Service\CurrentSite;
+use Biblys\Service\CurrentUser;
+use Biblys\Service\FlashMessagesService;
+use Biblys\Service\Images\ImagesService;
+use Biblys\Test\EntityFactory;
+use Biblys\Test\ModelFactory;
+use Mockery;
+use Model\Payment;
+use Model\PaymentQuery;
+use PHPUnit\Framework\TestCase;
+use Propel\Runtime\ActiveQuery\Criteria;
+use Propel\Runtime\Exception\PropelException;
+use Symfony\Component\HttpFoundation\Request;
+
+require_once __DIR__ . "/../../../setUp.php";
+
+class AdmCheckoutTest extends TestCase
+{
+    private function getController(): callable
+    {
+        static $controller = null;
+        if ($controller === null) {
+            $controller = require __DIR__ . "/../../../../controllers/common/php/adm_checkout.php";
+        }
+        return $controller;
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $_GET = [];
+        $_POST = [];
+    }
+
+    /**
+     * @throws PropelException
+     */
+    public function testValidateRecordsShopPaymentAmountInCents(): void
+    {
+        // given
+        $controller = $this->getController();
+        $site = ModelFactory::createSite();
+        $cart = EntityFactory::createCart();
+
+        $_GET["cart_id"] = $cart->get("id");
+        $_POST["validate"] = "1";
+        $_POST["cart_cash"] = "2100"; // 21,00 € sent in cents by the front-end JS
+        $_POST["cart_cheque"] = "0";
+        $_POST["cart_card"] = "0";
+        $_POST["cart_topay"] = "0";
+        $_POST["cart_togive"] = "0";
+
+        $request = new Request();
+        $request->query->set("cart_id", $cart->get("id"));
+        $request->headers->set("X-Requested-With", "XMLHttpRequest");
+
+        $currentSite = Mockery::mock(CurrentSite::class);
+        $currentSite->shouldReceive("getSite")->andReturn($site);
+
+        // when
+        $controller(
+            $request,
+            Mockery::mock(CurrentUser::class),
+            $currentSite,
+            Mockery::mock(ImagesService::class),
+            Mockery::mock(FlashMessagesService::class),
+        );
+
+        // then
+        $payment = PaymentQuery::create()
+            ->filterByMode(Payment::MODE_CASH)
+            ->orderById(Criteria::DESC)
+            ->findOne();
+
+        $this->assertNotNull($payment, "should have recorded a cash payment");
+        $this->assertEquals(
+            2100,
+            $payment->getAmount(),
+            "a 21 € payment should be recorded as 2100 cents, not 210000"
+        );
+    }
+}

--- a/tests/Usecase/RecordShopPaymentsUsecaseTest.php
+++ b/tests/Usecase/RecordShopPaymentsUsecaseTest.php
@@ -1,0 +1,90 @@
+<?php
+/*
+ * Copyright (C) 2026 Clément Latzarus
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+
+namespace Usecase;
+
+use Biblys\Test\ModelFactory;
+use Model\Payment;
+use Model\PaymentQuery;
+use PHPUnit\Framework\TestCase;
+use Propel\Runtime\Exception\PropelException;
+
+class RecordShopPaymentsUsecaseTest extends TestCase
+{
+    /**
+     * @throws PropelException
+     */
+    public function testCreatesOnePaymentForSingleMode(): void
+    {
+        // given
+        $order = ModelFactory::createOrder();
+        $usecase = new RecordShopPaymentsUsecase();
+
+        // when
+        $usecase->execute($order->getId(), [Payment::MODE_CASH => 1000]);
+
+        // then
+        $payments = PaymentQuery::create()->filterByOrderId($order->getId())->find();
+        $this->assertCount(1, $payments);
+        $this->assertEquals(Payment::MODE_CASH, $payments[0]->getMode());
+        $this->assertEquals(1000, $payments[0]->getAmount());
+        $this->assertNotNull($payments[0]->getExecuted());
+    }
+
+    /**
+     * @throws PropelException
+     */
+    public function testCreatesMultiplePaymentsForMultipleModes(): void
+    {
+        // given
+        $order = ModelFactory::createOrder();
+        $usecase = new RecordShopPaymentsUsecase();
+
+        // when
+        $usecase->execute($order->getId(), [
+            Payment::MODE_CASH  => 500,
+            Payment::MODE_CARD  => 500,
+        ]);
+
+        // then
+        $payments = PaymentQuery::create()->filterByOrderId($order->getId())->find();
+        $this->assertCount(2, $payments);
+    }
+
+    /**
+     * @throws PropelException
+     */
+    public function testSkipsZeroAmountModes(): void
+    {
+        // given
+        $order = ModelFactory::createOrder();
+        $usecase = new RecordShopPaymentsUsecase();
+
+        // when
+        $usecase->execute($order->getId(), [
+            Payment::MODE_CASH  => 1000,
+            Payment::MODE_CHECK => 0,
+            Payment::MODE_CARD  => 0,
+        ]);
+
+        // then
+        $payments = PaymentQuery::create()->filterByOrderId($order->getId())->find();
+        $this->assertCount(1, $payments);
+        $this->assertEquals(Payment::MODE_CASH, $payments[0]->getMode());
+    }
+}


### PR DESCRIPTION
## Changements

- Ajout du usecase `RecordShopPaymentsUsecase` qui crée une ligne `Payment` par mode de paiement utilisé (espèces, chèque, CB), en ignorant les montants nuls
- Intégration dans `adm_checkout.php` : le usecase est appelé lors de la validation d'une vente boutique, après la création de la commande
- Les montants POST (en euros, float) sont convertis en centimes avant d'être passés au usecase

## Plan de test

- [x] Effectuer une vente boutique en espèces uniquement et vérifier qu'une ligne `Payment` avec `mode = cash` est créée dans la table `payments`
- [x] Effectuer une vente boutique avec paiement mixte (ex. espèces + carte) et vérifier que deux lignes `Payment` sont créées
- [x] Vérifier qu'aucune ligne `Payment` n'est créée pour les modes dont le montant est 0
- [x] Vérifier qu'aucun e-mail de confirmation n'est envoyé lors d'une vente boutique