### PR TITLE
Réconcilier automatiquement un compte existant lors de la connexion SSO Axys

### DIFF
--- a/src/AppBundle/Controller/OpenIDConnectController.php
+++ b/src/AppBundle/Controller/OpenIDConnectController.php
@@ -124,6 +124,7 @@ class OpenIDConnectController extends Controller
                 $authenticationMethod = self::_importUserFromAxys(
                     $currentSite,
                     $email,
+                    $emailVerified,
                     $externalId,
                     $oidcTokens
                 );
@@ -198,6 +199,7 @@ class OpenIDConnectController extends Controller
     private static function _importUserFromAxys(
         CurrentSite       $currentSite,
         string            $email,
+        bool              $emailVerified,
         string            $externalId,
         TokenSetInterface $oidcTokens
     ): AuthenticationMethod
@@ -206,9 +208,21 @@ class OpenIDConnectController extends Controller
 
         $userWithEmail = UserQuery::create()->findOneByEmail($email);
         if ($userWithEmail) {
-            throw new AccessDeniedHttpException(
-                "Il existe déjà un compte {$currentSite->getTitle()} pour l'adresse $email"
-            );
+            if (!$emailVerified) {
+                throw new AccessDeniedHttpException(
+                    "Il existe déjà un compte {$currentSite->getTitle()} pour l'adresse $email"
+                );
+            }
+
+            $authenticationMethod = new AuthenticationMethod();
+            $authenticationMethod->setUser($userWithEmail);
+            $authenticationMethod->setIdentityProvider("axys");
+            $authenticationMethod->setExternalId($externalId);
+            $authenticationMethod->setAccessToken($oidcTokens->getAccessToken());
+            $authenticationMethod->setIdToken($oidcTokens->getIdToken());
+            $authenticationMethod->save();
+
+            return $authenticationMethod;
         }
 
         try {

--- a/tests/AppBundle/Controller/OpenIDConnectControllerTest.php
+++ b/tests/AppBundle/Controller/OpenIDConnectControllerTest.php
@@ -271,6 +271,112 @@ class OpenIDConnectControllerTest extends TestCase
      * @throws PropelException
      * @throws Exception
      */
+    public function testCallbackLinksExistingAccountWhenEmailIsVerified(): void
+    {
+        // given
+        $externalId = "AXYS_NEW_ID";
+        $email = "existing-user@example.com";
+        $site = ModelFactory::createSite();
+        $currentSite = new CurrentSite($site);
+        $openIDConnectProviderService = $this->_buildOIDCProviderService(
+            externalId: $externalId,
+            email: $email,
+            emailVerifiedAt: new DateTime("2024-01-01 00:00:00"),
+        );
+
+        $existingUser = ModelFactory::createUser(email: $email);
+
+        $request = self::_buildCallbackRequest();
+        $controller = new OpenIDConnectController();
+        $queryParamsService = Mockery::mock(QueryParamsService::class);
+        $queryParamsService->shouldReceive("parse")->with([
+            "code" => ["type" => "string"],
+            "state" => ["type" => "string"],
+            "error" => ["type" => "string", "default" => null],
+        ]);
+        $queryParamsService->shouldReceive("get")->with("error")->andReturn("");
+        $tokenService = Mockery::mock(TokenService::class);
+        $tokenService->expects("createLoginToken")->andReturn("login_token");
+        $urlGenerator = Mockery::mock(UrlGenerator::class);
+        $urlGenerator->expects("generate")->andReturn("/login-with-token");
+
+        // when
+        $response = $controller->callback(
+            request: $request,
+            currentSite: $currentSite,
+            config: new Config(["axys" => ["client_secret" => $this->testSecretKey]]),
+            openIDConnectProviderService: $openIDConnectProviderService,
+            queryParams: $queryParamsService,
+            templateService: $this->createMock(TemplateService::class),
+            tokenService: $tokenService,
+            urlGenerator: $urlGenerator,
+        );
+
+        // then
+        $this->assertEquals(302, $response->getStatusCode());
+
+        $authenticationMethod = AuthenticationMethodQuery::create()
+            ->filterByUser($existingUser)
+            ->filterByIdentityProvider("axys")
+            ->filterByExternalId($externalId)
+            ->findOne();
+        $this->assertNotNull($authenticationMethod, "Une AuthenticationMethod doit être créée pour l'utilisateur existant");
+
+        $userCount = UserQuery::create()->filterByEmail($email)->count();
+        $this->assertEquals(1, $userCount, "Aucun nouvel utilisateur ne doit être créé");
+    }
+
+    /**
+     * @throws PropelException
+     * @throws Exception
+     */
+    public function testCallbackWithAlreadyExistingEmailNotVerified(): void
+    {
+        // given
+        $externalId = "AXYS_NEW_ID";
+        $email = "existing-user@example.com";
+        $site = ModelFactory::createSite(title: "Ma Librairie");
+        $currentSite = new CurrentSite($site);
+        $openIDConnectProviderService = $this->_buildOIDCProviderService(
+            externalId: $externalId,
+            email: $email,
+        );
+
+        ModelFactory::createUser(email: $email);
+
+        $request = self::_buildCallbackRequest();
+        $controller = new OpenIDConnectController();
+        $queryParamsService = Mockery::mock(QueryParamsService::class);
+        $queryParamsService->shouldReceive("parse")->with([
+            "code" => ["type" => "string"],
+            "state" => ["type" => "string"],
+            "error" => ["type" => "string", "default" => null],
+        ]);
+        $queryParamsService->shouldReceive("get")->with("error")->andReturn("");
+        $tokenService = Mockery::mock(TokenService::class);
+        $urlGenerator = Mockery::mock(UrlGenerator::class);
+
+        // then
+        $this->expectException(AccessDeniedHttpException::class);
+        $this->expectExceptionMessage("Il existe déjà un compte Ma Librairie pour l'adresse existing-user@example.com");
+
+        // when
+        $controller->callback(
+            request: $request,
+            currentSite: $currentSite,
+            config: new Config(["axys" => ["client_secret" => $this->testSecretKey]]),
+            openIDConnectProviderService: $openIDConnectProviderService,
+            queryParams: $queryParamsService,
+            templateService: $this->createMock(TemplateService::class),
+            tokenService: $tokenService,
+            urlGenerator: $urlGenerator,
+        );
+    }
+
+    /**
+     * @throws PropelException
+     * @throws Exception
+     */
     public function testCallbackWithUserImport()
     {
         // given


### PR DESCRIPTION
## Contexte

Quand un utilisateur tentait de se connecter via Axys SSO avec un email pour lequel un compte Biblys existait déjà (sans `AuthenticationMethod` Axys associée), le système levait une exception HTTP 403. L'utilisateur était bloqué sans possibilité de récupérer son compte.

## Changements

- **`OpenIDConnectController::_importUserFromAxys`** — ajout d'un paramètre `bool $emailVerified`. Si un compte Biblys existe pour cet email et que l'email est certifié par Axys, l'`AuthenticationMethod` est créée sur le compte existant (liaison transparente). Si l'email n'est pas vérifié, l'exception `AccessDeniedHttpException` est maintenue.
- **`OpenIDConnectControllerTest`** — 2 nouveaux tests couvrant les deux cas.

## Plan de test

- [ ] Se connecter via Axys SSO avec un email pour lequel il existe un compte Biblys sans compte Axys lié → la connexion réussit, le compte est lié
- [ ] Vérifier qu'aucun nouveau compte n'est créé dans ce cas
- [ ] Se connecter via Axys SSO avec un email non vérifié côté Axys qui correspond à un compte existant → erreur 403 maintenue
- [ ] Se connecter via Axys SSO avec un compte déjà lié → comportement nominal inchangé
- [ ] Se connecter via Axys SSO avec un email inconnu → création de compte normale inchangée