### PR TITLE
Correctif 3.13.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ content/cache
 # IDE config files
 .idea
 .vscode
+
+# Git worktrees
+.worktrees

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Historique des modifications
 
+## 3.13.1 (DEV)
+
+### Corrections
+
+- Dans la caisse, l'ajout au panier d'un exemplaire dont le prix de vente
+  n'est pas renseigné (ex. exemplaire gratuit) provoquait l'affichage de
+  "NaN €" pour les montants à régler et à rendre. C'est corrigé.
+
 ## 3.13.0 (3 juin 2026)
 
 ### Conformité NF525

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Historique des modifications
 
-## 3.13.1 (DEV)
+## 3.13.1 (16 juin 2026)
 
 ### Corrections
 

--- a/inc/Cart.class.php
+++ b/inc/Cart.class.php
@@ -84,7 +84,7 @@ class Cart extends Entity
                         de ' . authors($articleEntity->get('authors')) . '<br>
                         Ed. ' . $articleEntity->get('publisher')->get('name') . '
                     </td>
-                    <td class="va-middle right stock_selling_price" data-price="' . $stockEntity->get('selling_price') . '">
+                    <td class="va-middle right stock_selling_price" data-price="' . (int) $stockEntity->get('selling_price') . '">
                         ' . $stockEntity->get('condition') . '
                         ' . currency($stockEntity->get('selling_price') / 100) . '
                     </td>

--- a/inc/constants.php
+++ b/inc/constants.php
@@ -15,4 +15,4 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-const BIBLYS_VERSION = "3.13.0";
+const BIBLYS_VERSION = "3.13.1-dev";

--- a/tests/CartTest.php
+++ b/tests/CartTest.php
@@ -23,6 +23,7 @@
 
 use Biblys\Exception\CannotAddStockItemToCartException;
 use Biblys\Legacy\LegacyCodeHelper;
+use Biblys\Service\Images\ImagesService;
 use Biblys\Test\EntityFactory;
 use Biblys\Test\ModelFactory;
 use Entity\Exception\CartException;
@@ -235,6 +236,44 @@ class CartTest extends PHPUnit\Framework\TestCase
 
         // when
         $cm->addStock($targetCart, $stockItem);
+    }
+
+    /**
+     * Test that getLine renders a numeric data-price attribute for items
+     * that have no selling price set (e.g. free copies), so that the
+     * front-end JS total (which uses parseInt on data-price) doesn't turn
+     * into NaN.
+     * @throws Exception
+     */
+    public function testGetLineDataPriceIsZeroForFreeStockItem()
+    {
+        // given
+        $cm = new CartManager();
+        $sm = new StockManager();
+        $cart = $cm->create(['cart_type' => 'shop']);
+
+        $article = EntityFactory::createArticle(['article_url' => 'free-item-test']);
+        $stock = EntityFactory::createStock(['article_id' => $article->get('id')]);
+        $stock->set('stock_selling_price', null);
+        $sm->update($stock);
+        $stock = $sm->reload($stock);
+
+        $this->carts = [$cart];
+        $this->stocks = [$stock];
+        $this->article = $article;
+
+        $imagesService = Mockery::mock(ImagesService::class);
+        $imagesService->shouldReceive('getImageUrlFor')->andReturn(null);
+
+        // when
+        $line = $cart->getLine($imagesService, $stock);
+
+        // then
+        $this->assertStringContainsString(
+            'data-price="0"',
+            $line,
+            "Free items should have a data-price of 0, not empty, to avoid NaN in the front-end JS total computation"
+        );
     }
 
     /**


### PR DESCRIPTION
## Corrections

- Dans la caisse, l'ajout au panier d'un exemplaire dont le prix de vente n'est pas renseigné (ex. exemplaire gratuit) provoquait l'affichage de "NaN €" pour les montants à régler et à rendre. C'est corrigé.