### PR TITLE
ci: add build-assets job to test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,23 @@ name: Test
 on: push
 
 jobs:
+  build-assets:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v6
+
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 'lts/*'
+
+    - name: Install JS dependencies
+      run: yarn install --frozen-lockfile
+
+    - name: Build assets
+      run: composer build:prod
+
   test:
 
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Changements

- Ajout d'un job `build-assets` dans le workflow CI qui installe les dépendances JS et vérifie que le build de production fonctionne
- Ce job est un prérequis pour sécuriser les mises à jour des dépendances npm (correction de vulnérabilités Dependabot)

## Plan de test

- [ ] Le job `build-assets` apparaît dans la CI sur GitHub Actions
- [ ] Le job s'exécute avec succès (`yarn install` + `composer build:prod`)
- [ ] Les assets sont correctement compilés sans erreur webpack