### PR TITLE
Préciser la convention de rédaction des titres de PR

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,5 +78,5 @@ Types courants utilisés dans ce projet : `feat`, `fix`, `chore`, `docs`, `refac
 
 ## Langue
 
-- Les **issues et Pull Requests** sont rédigées en **français**.
+- Les **issues et Pull Requests** sont rédigées en **français**. Les titres de PR sont en français et sans préfixe de type Conventional Commits (ex. : "Ajouter le job build-assets à la CI", pas "ci: add build-assets job").
 - Les **messages de commit et les noms de branches** sont rédigés en **anglais**.


### PR DESCRIPTION
## Changements

- Précise dans `CONTRIBUTING.md` que les titres de PR sont en français et sans préfixe Conventional Commits (ex. : "Ajouter le job build-assets à la CI", pas "ci: add build-assets job")

## Plan de test

- [x] La section "Langue" de `CONTRIBUTING.md` est claire sur le format des titres de PR