### PR TITLE
Marquer une commande comme non payée si la somme des paiements est inférieure au total

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 - Il est désormais possible de marquer un paiement comme remboursé depuis la page
   de gestion des paiements. Un paiement négatif est créé en base pour la commande,
   lié au paiement d'origine.
+- Une commande est automatiquement marquée comme non payée si la somme de ses
+  paiements exécutés devient inférieure à son total (ex. : après un remboursement).
 
 ### Amélorations
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,8 @@ bin/console               # Symfony Console application
 ### ORM
 Uses Propel 2.x ORM. Database schema is defined in `schema.xml`. Run `composer propel:build` after schema changes to regenerate model classes.
 
+Prefer using repository classes (e.g. `PaymentRepository`) for reading and writing data rather than calling Propel model relations directly (e.g. `$order->getPayments()`). Repositories live in `src/Repository/` and ensure fresh DB queries, avoiding Propel's in-memory collection cache.
+
 ### Legacy Code
 The `inc/` directory contains legacy entity classes that extend a base `Entity` class implementing ArrayAccess. These are being gradually replaced by Propel models in `src/Model/`.
 

--- a/src/AppBundle/Controller/PaymentController.php
+++ b/src/AppBundle/Controller/PaymentController.php
@@ -69,6 +69,7 @@ use Usecase\AddArticleToUserLibraryUsecase;
 use Usecase\AddPaymentToOrderAndExecuteUsecase;
 use Usecase\BusinessRuleException;
 use Usecase\MarkOrderAsPaidUsecase;
+use Usecase\MarkOrderAsUnpaidUsecase;
 use Usecase\RefundPaymentUsecase;
 
 class PaymentController extends Controller
@@ -157,7 +158,7 @@ class PaymentController extends Controller
         }
 
         try {
-            $usecase = new RefundPaymentUsecase($paymentRepository);
+            $usecase = new RefundPaymentUsecase($paymentRepository, new MarkOrderAsUnpaidUsecase($paymentRepository));
             $usecase->execute($payment);
             $flashMessages->add("success", "Le paiement a été remboursé.");
         } catch (BusinessRuleException $e) {

--- a/src/Repository/PaymentRepository.php
+++ b/src/Repository/PaymentRepository.php
@@ -44,6 +44,18 @@ class PaymentRepository
     /**
      * @throws PropelException
      */
+    public function findExecutedByOrder(Order $order): array
+    {
+        return PaymentQuery::create()
+            ->filterByOrder($order)
+            ->filterByExecuted(null, \Propel\Runtime\ActiveQuery\Criteria::ISNOTNULL)
+            ->find()
+            ->getArrayCopy();
+    }
+
+    /**
+     * @throws PropelException
+     */
     public function save(Payment $payment): void
     {
         $payment->save();

--- a/src/Repository/PaymentRepository.php
+++ b/src/Repository/PaymentRepository.php
@@ -18,6 +18,7 @@
 
 namespace Repository;
 
+use Model\Order;
 use Model\Payment;
 use Model\PaymentQuery;
 use Propel\Runtime\Exception\PropelException;
@@ -30,6 +31,14 @@ class PaymentRepository
     public function findById(int $id): ?Payment
     {
         return PaymentQuery::create()->findPk($id);
+    }
+
+    /**
+     * @throws PropelException
+     */
+    public function findByOrder(Order $order): array
+    {
+        return PaymentQuery::create()->filterByOrder($order)->find()->getArrayCopy();
     }
 
     /**

--- a/src/Usecase/MarkOrderAsUnpaidUsecase.php
+++ b/src/Usecase/MarkOrderAsUnpaidUsecase.php
@@ -39,8 +39,10 @@ class MarkOrderAsUnpaidUsecase
             0
         );
 
-        if ($totalPaid < $order->getTotalAmountWithShipping()) {
+        $orderTotal = $order->getTotalAmountWithShipping();
+        if ($totalPaid < $orderTotal) {
             $order->setPaymentDate(null);
+            $order->setAmountTobepaid($orderTotal - $totalPaid);
             $order->save();
         }
     }

--- a/src/Usecase/MarkOrderAsUnpaidUsecase.php
+++ b/src/Usecase/MarkOrderAsUnpaidUsecase.php
@@ -32,8 +32,7 @@ class MarkOrderAsUnpaidUsecase
      */
     public function execute(Order $order): void
     {
-        $payments = $this->paymentRepository->findByOrder($order);
-        $executedPayments = array_filter($payments, fn($payment) => $payment->isExecuted());
+        $executedPayments = $this->paymentRepository->findExecutedByOrder($order);
         $totalPaid = array_reduce(
             $executedPayments,
             fn($carry, $payment) => $carry + $payment->getAmount(),

--- a/src/Usecase/MarkOrderAsUnpaidUsecase.php
+++ b/src/Usecase/MarkOrderAsUnpaidUsecase.php
@@ -19,15 +19,20 @@ namespace Usecase;
 
 use Model\Order;
 use Propel\Runtime\Exception\PropelException;
+use Repository\PaymentRepository;
 
 class MarkOrderAsUnpaidUsecase
 {
+    public function __construct(private readonly PaymentRepository $paymentRepository)
+    {
+    }
+
     /**
      * @throws PropelException
      */
     public function execute(Order $order): void
     {
-        $payments = $order->getPayments()->getArrayCopy();
+        $payments = $this->paymentRepository->findByOrder($order);
         $executedPayments = array_filter($payments, fn($payment) => $payment->isExecuted());
         $totalPaid = array_reduce(
             $executedPayments,

--- a/src/Usecase/MarkOrderAsUnpaidUsecase.php
+++ b/src/Usecase/MarkOrderAsUnpaidUsecase.php
@@ -1,0 +1,43 @@
+<?php
+/*
+ * Copyright (C) 2026 Clément Latzarus
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace Usecase;
+
+use Model\Order;
+use Propel\Runtime\Exception\PropelException;
+
+class MarkOrderAsUnpaidUsecase
+{
+    /**
+     * @throws PropelException
+     */
+    public function execute(Order $order): void
+    {
+        $payments = $order->getPayments()->getArrayCopy();
+        $executedPayments = array_filter($payments, fn($payment) => $payment->isExecuted());
+        $totalPaid = array_reduce(
+            $executedPayments,
+            fn($carry, $payment) => $carry + $payment->getAmount(),
+            0
+        );
+
+        if ($totalPaid < $order->getTotalAmountWithShipping()) {
+            $order->setPaymentDate(null);
+            $order->save();
+        }
+    }
+}

--- a/src/Usecase/RefundPaymentUsecase.php
+++ b/src/Usecase/RefundPaymentUsecase.php
@@ -69,7 +69,6 @@ class RefundPaymentUsecase
 
             $order = $payment->getOrder();
             if ($order !== null) {
-                $order->clearPayments();
                 $this->markOrderAsUnpaidUsecase->execute($order);
             }
 

--- a/src/Usecase/RefundPaymentUsecase.php
+++ b/src/Usecase/RefundPaymentUsecase.php
@@ -28,7 +28,10 @@ use Repository\PaymentRepository;
 
 class RefundPaymentUsecase
 {
-    public function __construct(private readonly PaymentRepository $paymentRepository)
+    public function __construct(
+        private readonly PaymentRepository $paymentRepository,
+        private readonly MarkOrderAsUnpaidUsecase $markOrderAsUnpaidUsecase,
+    )
     {
     }
 
@@ -63,6 +66,13 @@ class RefundPaymentUsecase
         try {
             $this->paymentRepository->save($payment);
             $this->paymentRepository->save($refund);
+
+            $order = $payment->getOrder();
+            if ($order !== null) {
+                $order->clearPayments();
+                $this->markOrderAsUnpaidUsecase->execute($order);
+            }
+
             $con->commit();
         } catch (Exception $e) {
             $con->rollBack();

--- a/tests/Repository/PaymentRepositoryTest.php
+++ b/tests/Repository/PaymentRepositoryTest.php
@@ -91,6 +91,25 @@ class PaymentRepositoryTest extends TestCase
     /**
      * @throws PropelException
      */
+    public function testFindExecutedByOrderReturnsOnlyExecutedPayments(): void
+    {
+        // given
+        $order = ModelFactory::createOrder();
+        $executed = ModelFactory::createPayment(order: $order, amount: 1500);
+        ModelFactory::createPayment(order: $order, amount: 500, executedAt: null);
+        $repo = new PaymentRepository();
+
+        // when
+        $found = $repo->findExecutedByOrder($order);
+
+        // then
+        $this->assertCount(1, $found);
+        $this->assertEquals($executed->getId(), $found[0]->getId());
+    }
+
+    /**
+     * @throws PropelException
+     */
     public function testSavePersistsPayment(): void
     {
         // given

--- a/tests/Repository/PaymentRepositoryTest.php
+++ b/tests/Repository/PaymentRepositoryTest.php
@@ -19,6 +19,7 @@
 namespace Repository;
 
 use Biblys\Test\ModelFactory;
+use Model\Order;
 use Model\Payment;
 use Model\PaymentQuery;
 use PHPUnit\Framework\TestCase;
@@ -66,6 +67,25 @@ class PaymentRepositoryTest extends TestCase
 
         // then
         $this->assertNull($found);
+    }
+
+    /**
+     * @throws PropelException
+     */
+    public function testFindByOrderReturnsPaymentsForOrder(): void
+    {
+        // given
+        $order = ModelFactory::createOrder();
+        $payment = ModelFactory::createPayment(order: $order, amount: 1500);
+        ModelFactory::createPayment(amount: 500);
+        $repo = new PaymentRepository();
+
+        // when
+        $found = $repo->findByOrder($order);
+
+        // then
+        $this->assertCount(1, $found);
+        $this->assertEquals($payment->getId(), $found[0]->getId());
     }
 
     /**

--- a/tests/Usecase/MarkOrderAsUnpaidUsecaseTest.php
+++ b/tests/Usecase/MarkOrderAsUnpaidUsecaseTest.php
@@ -1,0 +1,95 @@
+<?php
+/*
+ * Copyright (C) 2026 Clément Latzarus
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace Usecase;
+
+use Biblys\Test\ModelFactory;
+use DateTime;
+use Model\PaymentQuery;
+use PHPUnit\Framework\TestCase;
+use Propel\Runtime\Exception\PropelException;
+
+require_once __DIR__ . "/../setUp.php";
+
+class MarkOrderAsUnpaidUsecaseTest extends TestCase
+{
+    /**
+     * @throws PropelException
+     */
+    public function setUp(): void
+    {
+        PaymentQuery::create()->deleteAll();
+    }
+
+    /**
+     * @throws PropelException
+     */
+    public function testMarksOrderAsUnpaidWhenPaymentSumIsLessThanTotal(): void
+    {
+        // given
+        $order = ModelFactory::createOrder(paymentDate: new DateTime());
+        ModelFactory::createStockItem(order: $order, sellingPrice: 1500);
+        ModelFactory::createPayment(order: $order, amount: 1500);
+        ModelFactory::createPayment(order: $order, amount: -1500);
+
+        // when
+        $usecase = new MarkOrderAsUnpaidUsecase();
+        $usecase->execute($order);
+
+        // then
+        $order->reload();
+        $this->assertNull($order->getPaymentDate(), "la commande est marquée comme non payée");
+    }
+
+    /**
+     * @throws PropelException
+     */
+    public function testDoesNotMarkOrderAsUnpaidWhenPaymentSumEqualsTotal(): void
+    {
+        // given
+        $order = ModelFactory::createOrder(paymentDate: new DateTime());
+        ModelFactory::createStockItem(order: $order, sellingPrice: 1000);
+        ModelFactory::createPayment(order: $order, amount: 1000);
+
+        // when
+        $usecase = new MarkOrderAsUnpaidUsecase();
+        $usecase->execute($order);
+
+        // then
+        $order->reload();
+        $this->assertNotNull($order->getPaymentDate(), "la commande reste marquée comme payée");
+    }
+
+    /**
+     * @throws PropelException
+     */
+    public function testDoesNotMarkOrderAsUnpaidWhenPaymentSumIsGreaterThanTotal(): void
+    {
+        // given
+        $order = ModelFactory::createOrder(paymentDate: new DateTime());
+        ModelFactory::createStockItem(order: $order, sellingPrice: 1000);
+        ModelFactory::createPayment(order: $order, amount: 2000);
+
+        // when
+        $usecase = new MarkOrderAsUnpaidUsecase();
+        $usecase->execute($order);
+
+        // then
+        $order->reload();
+        $this->assertNotNull($order->getPaymentDate(), "la commande reste marquée comme payée");
+    }
+}

--- a/tests/Usecase/MarkOrderAsUnpaidUsecaseTest.php
+++ b/tests/Usecase/MarkOrderAsUnpaidUsecaseTest.php
@@ -54,6 +54,29 @@ class MarkOrderAsUnpaidUsecaseTest extends TestCase
         // then
         $order->reload();
         $this->assertNull($order->getPaymentDate(), "la commande est marquée comme non payée");
+        $this->assertEquals(1500, $order->getAmountTobepaid(), "le montant restant à payer est restauré");
+    }
+
+    /**
+     * @throws PropelException
+     */
+    public function testRestoresAmountTobepaidAfterPartialRefund(): void
+    {
+        // given
+        $order = ModelFactory::createOrder(paymentDate: new DateTime());
+        ModelFactory::createStockItem(order: $order, sellingPrice: 2000);
+        ModelFactory::createPayment(order: $order, amount: 1000);
+        ModelFactory::createPayment(order: $order, amount: 1000);
+        ModelFactory::createPayment(order: $order, amount: -500);
+
+        // when
+        $usecase = new MarkOrderAsUnpaidUsecase(new PaymentRepository());
+        $usecase->execute($order);
+
+        // then
+        $order->reload();
+        $this->assertNull($order->getPaymentDate(), "la commande est marquée comme non payée");
+        $this->assertEquals(500, $order->getAmountTobepaid(), "le montant restant à payer reflète le remboursement partiel");
     }
 
     /**

--- a/tests/Usecase/MarkOrderAsUnpaidUsecaseTest.php
+++ b/tests/Usecase/MarkOrderAsUnpaidUsecaseTest.php
@@ -22,6 +22,7 @@ use DateTime;
 use Model\PaymentQuery;
 use PHPUnit\Framework\TestCase;
 use Propel\Runtime\Exception\PropelException;
+use Repository\PaymentRepository;
 
 require_once __DIR__ . "/../setUp.php";
 
@@ -47,7 +48,7 @@ class MarkOrderAsUnpaidUsecaseTest extends TestCase
         ModelFactory::createPayment(order: $order, amount: -1500);
 
         // when
-        $usecase = new MarkOrderAsUnpaidUsecase();
+        $usecase = new MarkOrderAsUnpaidUsecase(new PaymentRepository());
         $usecase->execute($order);
 
         // then
@@ -66,7 +67,7 @@ class MarkOrderAsUnpaidUsecaseTest extends TestCase
         ModelFactory::createPayment(order: $order, amount: 1000);
 
         // when
-        $usecase = new MarkOrderAsUnpaidUsecase();
+        $usecase = new MarkOrderAsUnpaidUsecase(new PaymentRepository());
         $usecase->execute($order);
 
         // then
@@ -85,7 +86,7 @@ class MarkOrderAsUnpaidUsecaseTest extends TestCase
         ModelFactory::createPayment(order: $order, amount: 2000);
 
         // when
-        $usecase = new MarkOrderAsUnpaidUsecase();
+        $usecase = new MarkOrderAsUnpaidUsecase(new PaymentRepository());
         $usecase->execute($order);
 
         // then

--- a/tests/Usecase/RefundPaymentUsecaseTest.php
+++ b/tests/Usecase/RefundPaymentUsecaseTest.php
@@ -25,6 +25,7 @@ use Model\PaymentQuery;
 use PHPUnit\Framework\TestCase;
 use Propel\Runtime\Exception\PropelException;
 use Repository\PaymentRepository;
+use Usecase\MarkOrderAsUnpaidUsecase;
 
 require_once __DIR__ . "/../setUp.php";
 
@@ -49,7 +50,7 @@ class RefundPaymentUsecaseTest extends TestCase
         $payment = ModelFactory::createPayment(order: $order, amount: 1500, mode: Payment::MODE_STRIPE);
 
         // when
-        $usecase = new RefundPaymentUsecase(new PaymentRepository());
+        $usecase = new RefundPaymentUsecase(new PaymentRepository(), new MarkOrderAsUnpaidUsecase());
         $refund = $usecase->execute($payment);
 
         // then
@@ -65,6 +66,29 @@ class RefundPaymentUsecaseTest extends TestCase
 
     /**
      * @throws PropelException
+     * @throws BusinessRuleException
+     */
+    public function testMarksOrderAsUnpaidAfterFullRefund(): void
+    {
+        // given
+        $order = ModelFactory::createOrder(paymentDate: new DateTime());
+        ModelFactory::createStockItem(order: $order, sellingPrice: 1500);
+        $payment = ModelFactory::createPayment(order: $order, amount: 1500, mode: Payment::MODE_STRIPE);
+
+        // when
+        $usecase = new RefundPaymentUsecase(
+            new PaymentRepository(),
+            new MarkOrderAsUnpaidUsecase(),
+        );
+        $usecase->execute($payment);
+
+        // then
+        $order->reload();
+        $this->assertNull($order->getPaymentDate(), "la commande est marquée comme non payée");
+    }
+
+    /**
+     * @throws PropelException
      */
     public function testThrowsIfAlreadyRefunded(): void
     {
@@ -75,7 +99,7 @@ class RefundPaymentUsecaseTest extends TestCase
         $this->expectException(BusinessRuleException::class);
         $this->expectExceptionMessage("Ce paiement a déjà été remboursé.");
 
-        $usecase = new RefundPaymentUsecase(new PaymentRepository());
+        $usecase = new RefundPaymentUsecase(new PaymentRepository(), new MarkOrderAsUnpaidUsecase());
         $usecase->execute($payment);
     }
 
@@ -91,7 +115,7 @@ class RefundPaymentUsecaseTest extends TestCase
         $this->expectException(BusinessRuleException::class);
         $this->expectExceptionMessage("Impossible de rembourser un paiement négatif.");
 
-        $usecase = new RefundPaymentUsecase(new PaymentRepository());
+        $usecase = new RefundPaymentUsecase(new PaymentRepository(), new MarkOrderAsUnpaidUsecase());
         $usecase->execute($payment);
     }
 }

--- a/tests/Usecase/RefundPaymentUsecaseTest.php
+++ b/tests/Usecase/RefundPaymentUsecaseTest.php
@@ -50,7 +50,7 @@ class RefundPaymentUsecaseTest extends TestCase
         $payment = ModelFactory::createPayment(order: $order, amount: 1500, mode: Payment::MODE_STRIPE);
 
         // when
-        $usecase = new RefundPaymentUsecase(new PaymentRepository(), new MarkOrderAsUnpaidUsecase());
+        $usecase = new RefundPaymentUsecase(new PaymentRepository(), new MarkOrderAsUnpaidUsecase(new PaymentRepository()));
         $refund = $usecase->execute($payment);
 
         // then
@@ -78,7 +78,7 @@ class RefundPaymentUsecaseTest extends TestCase
         // when
         $usecase = new RefundPaymentUsecase(
             new PaymentRepository(),
-            new MarkOrderAsUnpaidUsecase(),
+            new MarkOrderAsUnpaidUsecase(new PaymentRepository()),
         );
         $usecase->execute($payment);
 
@@ -99,7 +99,7 @@ class RefundPaymentUsecaseTest extends TestCase
         $this->expectException(BusinessRuleException::class);
         $this->expectExceptionMessage("Ce paiement a déjà été remboursé.");
 
-        $usecase = new RefundPaymentUsecase(new PaymentRepository(), new MarkOrderAsUnpaidUsecase());
+        $usecase = new RefundPaymentUsecase(new PaymentRepository(), new MarkOrderAsUnpaidUsecase(new PaymentRepository()));
         $usecase->execute($payment);
     }
 
@@ -115,7 +115,7 @@ class RefundPaymentUsecaseTest extends TestCase
         $this->expectException(BusinessRuleException::class);
         $this->expectExceptionMessage("Impossible de rembourser un paiement négatif.");
 
-        $usecase = new RefundPaymentUsecase(new PaymentRepository(), new MarkOrderAsUnpaidUsecase());
+        $usecase = new RefundPaymentUsecase(new PaymentRepository(), new MarkOrderAsUnpaidUsecase(new PaymentRepository()));
         $usecase->execute($payment);
     }
 }


### PR DESCRIPTION
## Résumé

- Nouveau `MarkOrderAsUnpaidUsecase` : calcule la somme des paiements exécutés d'une commande et met `paymentDate` à `null` si cette somme est inférieure au total de la commande (frais de port inclus).
- `RefundPaymentUsecase` injecte et appelle ce nouveau usecase à l'intérieur de la transaction DB, après avoir sauvegardé le remboursement.

## Plan de test

- [ ] Vérifier que `MarkOrderAsUnpaidUsecaseTest` passe (3 cas : somme < total, somme = total, somme > total)
- [ ] Vérifier que `RefundPaymentUsecaseTest` passe (4 cas, dont le nouveau cas de dépaiement après remboursement complet)
- [ ] Vérifier l'absence de régression sur la suite complète (`composer test`)