### PR TITLE
fix: replace removed jQuery APIs and remove dead datetimepicker code

### DIFF
--- a/public/common/js/article_edit.js
+++ b/public/common/js/article_edit.js
@@ -92,7 +92,7 @@ function initPublisherAutocomplete() {
           },
           success: function (data) {
             $('#collection_publisher').removeClass('loading');
-            const res = jQuery.parseJSON(data);
+            const res = JSON.parse(data);
             if (res.error) window._alert(res.error);
             else choose_publisher(res.publisher_id, res.publisher_name);
           },

--- a/public/common/js/common.js
+++ b/public/common/js/common.js
@@ -607,7 +607,7 @@ function reloadEvents(scope) {
   });
 
   // DateTimePicker
-  if (jQuery.isFunction(jQuery.fn.datetimepicker)) {
+  if (typeof jQuery.fn.datetimepicker === "function") {
     $('.datetime').datetimepicker({
       dateFormat: 'yy-mm-dd',
       timeFormat: 'hh:mm:ss'

--- a/public/common/js/common.js
+++ b/public/common/js/common.js
@@ -606,14 +606,6 @@ function reloadEvents(scope) {
     }
   });
 
-  // DateTimePicker
-  if (typeof jQuery.fn.datetimepicker === "function") {
-    $('.datetime').datetimepicker({
-      dateFormat: 'yy-mm-dd',
-      timeFormat: 'hh:mm:ss'
-    });
-  }
-
   // Select goto
   $('select.goto').change(function() {
     var valeur = $(this).val();


### PR DESCRIPTION
## Changements

- `public/common/js/article_edit.js` : remplace `jQuery.parseJSON(data)` par `JSON.parse(data)` (API supprimée dans jQuery 4)
- `public/common/js/common.js` : supprime le bloc d'initialisation du plugin datetimepicker, qui n'était jamais chargé (code mort)

Fait partie de #490 (point 2).

## Plan de test

- [ ] Ouvrir la page d'édition d'un article en back-office
- [ ] Taper quelques lettres dans le champ "Éditeur" et sélectionner une suggestion → le champ "Collection" doit se mettre à jour correctement
- [ ] Vérifier que le reste de la page fonctionne normalement (aucune régression liée à la suppression du datetimepicker)