### PR TITLE
Mettre à jour jQuery de 1.12.4 vers 3.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - L'adapter jQuery de CKEditor a été mis à jour vers la version CKEditor 4 LTS (2025),
   en préparation de la migration vers jQuery 4.
+- jQuery a été mis à jour de la version 1.12.4 (2016) vers la version 3.7.1 (LTS).
 
 ### Confirmité NF525
 

--- a/src/AppBundle/Resources/layout/_assets_js.html.twig
+++ b/src/AppBundle/Resources/layout/_assets_js.html.twig
@@ -18,7 +18,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
   <script type="text/javascript" src="{{ asset }}"></script>
 {% endfor %}
 
-<script type="text/javascript" src="https://code.jquery.com/jquery-1.12.4.min.js"></script>
+<script type="text/javascript" src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
 <script type="text/javascript" src="https://code.jquery.com/ui/1.14.1/jquery-ui.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/js/bootstrap.bundle.min.js"
         integrity="sha384-Fy6S3B9q64WdZWQUiU+q4/2Lc9npb8tCaSX9FK7E8HnRr0Jz8D6OP9dO5Vg3Q9ct"


### PR DESCRIPTION
## Changements

- `src/AppBundle/Resources/layout/_assets_js.html.twig` : remplace jQuery 1.12.4 (CDN) par jQuery 3.7.1

jQuery 4.0.0 n'est pas encore possible : Bootstrap 4.6.2 refuse explicitement jQuery ≥ 4 (`requires at least jQuery v1.9.1 but less than v4.0.0`). La migration vers jQuery 4 sera possible après la migration vers Bootstrap 5.

Fait partie de #490 (point 3).

## Plan de test

- [x] Ouvrir la page d'accueil et vérifier qu'il n'y a pas d'erreur JS dans la console du navigateur
- [x] **Tooltips (Tooltipster)** : survoler un élément avec un attribut `title` dans le back-office → une bulle doit apparaître
- [x] **Modales jQuery UI** : aller sur `/pages/adm_checkout`, cliquer sur "Créer une réservation" → la modale `#createResa` doit s'ouvrir
- [x] **Autocomplétion** : aller sur `/pages/adm_list`, utiliser le champ de recherche avec autocomplétion → les suggestions doivent apparaître
- [x] **Popover Bootstrap** : vérifier qu'un élément `[data-toggle=popover]` affiche son contenu au clic
- [x] **Requêtes AJAX** : supprimer un élément d'une liste en back-office via le bouton de suppression → l'opération doit se faire sans rechargement de page