### PR TITLE
Caisse : scaffolding, indexAction et template Twig (PR 1/8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 3.14.0 (DEV)
 
+### Caisse
+
+- La caisse est désormais accessible via la nouvelle URL `/admin/caisse`.
+
 ### Maintenance
 
 - L'adapter jQuery de CKEditor a été mis à jour vers la version CKEditor 4 LTS (2025),

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,16 @@ Tests use PHPUnit 10. Test setup in `tests/setUp.php` initializes Propel and cre
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md) for the git flow branching model, versioning, and commit conventions used in this repository.
 
+### Langue — règle critique
+
+- **Titres de PR et issues** : en français, **sans** préfixe Conventional Commits (`feat:`, `fix:`, `chore:`…)
+- **Messages de commit et noms de branches** : en anglais, avec préfixe Conventional Commits
+
+| ❌ FAUX (titre de PR) | ✅ CORRECT (titre de PR) |
+|---|---|
+| `feat: add point-of-sale scaffolding` | `Caisse : scaffolding et template Twig` |
+| `fix: correct HTML entity escaping` | `Corriger l'échappement des entités HTML` |
+
 ## Docker Development
 
 ```bash

--- a/controllers/common/php/adm_checkout.php
+++ b/controllers/common/php/adm_checkout.php
@@ -21,21 +21,14 @@ use Biblys\Legacy\LegacyCodeHelper;
 use Biblys\Service\FlashMessagesService;
 use Biblys\Service\Images\ImagesService;
 use Model\Payment;
-use Model\UserQuery;
 use Usecase\RecordShopPaymentsUsecase;
-use Biblys\Service\CurrentSite;
-use Biblys\Service\CurrentUser;
 use Propel\Runtime\Exception\PropelException;
-use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
-/** @var CurrentSite $currentSite */
-/** @var CurrentUser $currentUser */
 /** @var Request $request */
 
 /**
@@ -43,90 +36,32 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
  */
 return function (
     Request              $request,
-    CurrentUser          $currentUser,
-    CurrentSite          $currentSite,
     ImagesService        $imagesService,
-    FlashMessagesService $flashMessagesService
-): Response|JsonResponse|RedirectResponse {
+    FlashMessagesService $flashMessagesService,
+): JsonResponse|RedirectResponse {
     $_SQL = LegacyCodeHelper::getGlobalDatabaseConnection();
 
-    $request->attributes->set("page_title", "Caisse");
-
-    $enableTemporaryAccess = $request->query->getInt("enable_temporary_access");
-    if ($enableTemporaryAccess === 1) {
-        $redirectResponse = new RedirectResponse("/pages/adm_checkout");
-        $bypassCookie = new Cookie("bypass_cash_register_check", "1", new DateTime("tomorrow"));
-        $redirectResponse->headers->setCookie($bypassCookie);
-        $flashMessagesService->add("info", "La caisse a été réactivée jusqu'à demain.");
-        return $redirectResponse;
-    }
-
-    $bypassCookie = $request->cookies->get("bypass_cash_register_check");
-    if ($currentSite->getSite()->getTva() === "fr" && !$bypassCookie) {
-        return new Response(<<<HTML
-            <div class="alert alert-danger">
-                <p class="alert-heading lead">
-                    <span class="fa-solid fa-circle-xmark"></span>
-                    <strong>La caisse est désactivée, car la gestion de la TVA est activée.</strong><br/>
-                </p>
-                <p>
-                  La loi de finances pour 2025 interdit l'usage d'un logiciel de caisse non certifié pour un 
-                  professionnel assujetti à la TVA. Pour réactiver la caisse, désactivez la gestion de la TVA.
-                </p>
-                <p>
-                    <a class="btn btn-warning" href="https://blog.biblys.org/posts/certification-nf-525-logiciels-de-caisse/" target="_blank">
-                        <i class="fa fa-external-link"></i>
-                        En savoir plus
-                    </a>
-                    <a class="btn btn-danger" href="/pages/adm_checkout?enable_temporary_access=1">
-                        <i class="fa-solid fa-clock"></i>
-                        Réactiver temporairement la caisse
-                    </a>
-                </p>
-            </div>
-        HTML);
-    }
-
     $cm = new CartManager();
-
     $cartId = $request->query->get("cart_id");
+
     if (!$cartId) {
-        $cartForCurrentSeller = $cm->get([
-            "cart_type" => "shop",
-            "cart_seller_id" => $currentUser->getUser()->getId(),
-            "cart_count" => 0
-        ]);
-
-        if ($cartForCurrentSeller) {
-            return new RedirectResponse("/pages/adm_checkout?cart_id={$cartForCurrentSeller->get('id')}");
-        }
-
-        $newCartForCurrentSeller = $cm->create();
-        $newCartForCurrentSeller->set("cart_type", "shop");
-        $newCartForCurrentSeller->set("cart_seller_id", $currentUser->getUser()->getId());
-        $newCartForCurrentSeller = $cm->update($newCartForCurrentSeller);
-        return new RedirectResponse("/pages/adm_checkout?cart_id={$newCartForCurrentSeller->get('id')}");
+        return new RedirectResponse("/admin/caisse");
     }
 
     /** @var Cart $cart */
-    $cart = $cm->get(array('cart_id' => $cartId));
+    $cart = $cm->get(['cart_id' => $cartId]);
     if (!$cart) {
         throw new NotFoundHttpException("Panier $cartId introuvable");
     }
 
-    /* ACTIONS */
-
-// Enregistrer la vente
+    // Enregistrer la vente
     if (isset($_POST['validate'])) {
-
         try {
             $_SQL->beginTransaction();
 
-            // Create new order
             $_O = new OrderManager();
             $order = $_O->create();
 
-            // Update order info
             if (!empty($_POST['seller_id'])) $order->set('seller_id', $_POST['seller_id']);
             if (!empty($_POST['customer_id'])) $order->set('customer_id', $_POST['customer_id']);
 
@@ -138,10 +73,7 @@ return function (
             $order->set('order_payment_left', $_POST['cart_togive']);
             $order->set('order_payment_date', date('Y-m-d H:i:s'));
 
-            // Hydrate order from cart
             $_O->hydrateFromCart($order, $cart);
-
-            // Update order
             $order = $_O->update($order);
 
             $shopPaymentsUsecase = new RecordShopPaymentsUsecase();
@@ -151,7 +83,6 @@ return function (
                 Payment::MODE_CARD  => (int) $_POST['cart_card'],
             ]);
 
-            // Reset cart
             $cm->vacuum($cart);
             $cm->delete($cart);
 
@@ -161,24 +92,31 @@ return function (
             throw $e;
         }
 
-        $r = array('created_order' => $order->get('order_id'));
-
         if ($request->isXmlHttpRequest()) {
-            return new JsonResponse($r);
+            return new JsonResponse(['created_order' => $order->get('order_id')]);
         }
+
+        return new RedirectResponse("/admin/caisse");
     }
 
-// Changer le nom du panier
+    // Changer le nom du panier
     if (isset($_POST['set_title'])) {
+        $params = [];
         $cart->set('cart_title', $_POST['set_title']);
         $cart = $cm->update($cart);
-        if ($cart->get('cart_title') == $_POST['set_title']) $params['success'] = "Le nom du panier a bien été modifié.";
-        else $params['error'] = "Le nom du panier n'a pas pu être modifié.";
+        if ($cart->get('cart_title') == $_POST['set_title']) {
+            $params['success'] = "Le nom du panier a bien été modifié.";
+        } else {
+            $params['error'] = "Le nom du panier n'a pas pu être modifié.";
+        }
         if ($request->isXmlHttpRequest()) {
             return new JsonResponse($params);
         }
-    } // Changer le client du panier
-    elseif (isset($_POST['set_customer'])) {
+        return new RedirectResponse("/admin/caisse?cart_id=$cartId");
+    }
+
+    // Changer le client du panier
+    if (isset($_POST['set_customer'])) {
         $params = [];
         try {
             $cart->set('customer_id', $_POST['set_customer']);
@@ -195,20 +133,20 @@ return function (
 
         if ($request->isXmlHttpRequest()) {
             return new JsonResponse($params);
-        } else {
-            return new RedirectResponse(sprintf("/pages/adm_checkout?%s", http_build_query($params)));
         }
+        return new RedirectResponse("/admin/caisse?cart_id=$cartId");
     }
 
-    $copyToRemoveId = (int)$request->query->get('remove_stock', false);
-
+    $copyToRemoveId = (int) $request->query->get('remove_stock', false);
     $add = $request->query->get("add");
-    $stockItemToAddId = (int)$request->query->get("id");
+    $stockItemToAddId = (int) $request->query->get("id");
+
+    // Ajouter un exemplaire au panier
     if ($add && $stockItemToAddId) {
         if ($add === "stock") {
             try {
                 $cm->addStock($cart, $_GET["id"]);
-                $params["success"] = "L'exemplaire n&deg; $stockItemToAddId a été ajouté au panier.";
+                $params["success"] = "L'exemplaire n° $stockItemToAddId a été ajouté au panier.";
                 $cm->updateFromStock($cart);
             } catch (CannotAddStockItemToCartException $exception) {
                 throw new BadRequestHttpException($exception->getMessage(), $exception);
@@ -222,308 +160,42 @@ return function (
                     }
                 }
                 return new JsonResponse($params);
-            } else {
-                return new RedirectResponse(sprintf("/pages/adm_checkout?%s", http_build_query($params)));
             }
+
+            return new RedirectResponse("/admin/caisse?cart_id=$cartId");
         }
-    } // Retirer du panier
-    elseif ($copyToRemoveId) {
+    }
+
+    // Retirer un exemplaire du panier
+    if ($copyToRemoveId) {
         $sm = new StockManager();
         /** @var Stock $copyToRemove */
         $copyToRemove = $sm->getById($copyToRemoveId);
         $params = [];
         if ($copyToRemove) {
             if ($cm->removeStock($copyToRemove)) {
-                $params['success'] = 'L\'exemplaire n&deg; ' . $copyToRemove->get('id') . ' a été retiré du panier et remis en stock.';
+                $params['success'] = "L'exemplaire n° {$copyToRemove->get('id')} a été retiré du panier et remis en stock.";
                 $cm->updateFromStock($cart);
             }
         } else {
-            $params['error'] = 'L\'exemplaire n&deg; ' . $_GET['id'] . ' n\'a pas pu être supprimé du panier.';
+            $params['error'] = "L'exemplaire n° $copyToRemoveId n'a pas pu être supprimé du panier.";
         }
         if ($request->isXmlHttpRequest()) {
             return new JsonResponse($params);
-        } else {
-            return new RedirectResponse(sprintf("/pages/adm_checkout?%s", http_build_query($params)));
         }
-    } // Vider le panier
-    elseif (isset($_GET['vacuum_cart'])) {
+        return new RedirectResponse("/admin/caisse?cart_id=$cartId");
+    }
 
+    // Vider le panier
+    if (isset($_GET['vacuum_cart'])) {
         if ($cm->vacuum($cart)) {
-            $params['success'] = 'Le panier n&deg; ' . $cart->get('cart_id') . ' a été vidé !';
+            $flashMessagesService->add("success", "Le panier a été vidé.");
         } else {
-            $params['error'] = 'Le panier n&deg; ' . $cart->get('cart_id') . ' n\'a pas pu être vidé.';
+            $flashMessagesService->add("error", "Le panier n'a pas pu être vidé.");
         }
-
-        return new RedirectResponse(sprintf("/pages/adm_checkout?%s", http_build_query($params)));
+        return new RedirectResponse("/admin/caisse?cart_id=$cartId");
     }
 
-
-    /* AUTRES */
-
-// Client du panier en cours
-    $customer_field = '
-    <input type="text" name="customer" id="customer" placeholder="Rechercher un client..." class="event verylong">
-    <input type="hidden" name="customer_id" id="customer_id" required>
-    <span id="newsletter2" class="hidden">
-        <input type="checkbox" name="customer_mailing" id="customer_mailing" value="1" disabled>
-        <label for="customer_mailing" class="after">Abonné à la newsletter</label>
-    </span>
-';
-
-    if ($cart->has('customer_id')) {
-        $_CUSTOMERS = new CustomerManager();
-
-        if ($customer = $_CUSTOMERS->get(array('customer_id' => $cart->get('customer_id')))) {
-
-            if ($customer->get('customer_newsletter') == 1) $newsletter_checked = ' checked';
-            else $newsletter_checked = NULL;
-
-            $customer_field = '
-            <input type="text" name="customer" id="customer" placeholder="Rechercher un client..." value="' . $customer->get('customer_last_name') . ', ' . $customer->get('customer_first_name') . ' (' . $customer->get('customer_email') . ')' . '" readonly class="pointer event verylong">
-            <input type="hidden" name="customer_id" id="customer_id" value="' . $customer->get('customer_id') . '" required>
-            <span id="newsletter">
-                <input type="checkbox" name="customer_mailing" id="customer_mailing" value="1" disabled="disabled" ' . $newsletter_checked . '>
-                <label for="customer_mailing" class="after">Abonné à la newsletter</label>
-            </span>
-        ';
-        }
-    }
-
-// Current cart's seller
-    $seller_field = null;
-    if ($cart->has('seller_id')) {
-        $seller = UserQuery::create()->findPk($cart->get('seller_id'));
-        if ($seller) {
-            $seller_field = '
-            <input type="text" name="seller" id="seller" value="' . $seller->getEmail() . '" class="long" required readonly>
-            <input type="hidden" name="seller_id" id="seller_id" value="' . $seller->getId() . '" required>
-        ';
-        }
-    } else trigger_error('No seller id.');
-
-// Livres du panier en cours
-    $cart_content = NULL;
-    $cart_count = 0;
-    $cart_total = 0;
-    $stock = $cm->getStock($cart);
-    foreach ($stock as $s) {
-        $cart_content .= $cart->getLine($imagesService, $s);
-        $cart_count++;
-        $cart_total += $s->get('selling_price');
-    }
-
-    $cm->updateFromStock($cart);
-
-    // Paniers sauvegardés & VPC
-    $s_carts = $cm->getAll();
-
-    $shop_carts = NULL;
-    foreach ($s_carts as $shopCart) {
-        $seller = "Vendeur inconnu";
-        if ($shopCart->has('seller_id')) {
-            $seller = "Utilisateur Axys n°{$shopCart->get('seller_id')}";
-        }
-        if ($shopCart->has('seller_user_id')) {
-            $sellerUser = UserQuery::create()->findPk($shopCart->get('seller_user_id'));
-            $seller = $sellerUser->getEmail();
-        }
-
-        $s_cart = '
-        <tr>
-            <td><a href="/pages/adm_checkout?cart_id=' . $shopCart->get('cart_id') . '">' . $shopCart->get('cart_title') . '</a></td>
-            <td>' . ($seller) . '</td>
-            <td>' . ($shopCart->has('customer') ? $shopCart->get('customer')->get('first_name') . ' ' . $shopCart->get('customer')->get('last_name') : null) . '</td>
-            <td class="right">' . $shopCart->get('cart_count') . '</td>
-            <td class="right">' . currency($shopCart->get('cart_amount') / 100) . '</td>
-            <td class="center">
-                <a href="/pages/adm_checkout?cart_id=' . $shopCart->get('cart_id') . '&vacuum_cart=1" data-confirm="Voulez-vous vraiment VIDER ce panier et remettre ' . $shopCart->get('cart_count') . ' exemplaire' . s($shopCart->get('cart_count')) . ' en vente ?" title="Vider le panier et remettre ' . $shopCart->get('cart_count') . ' exemplaire' . s($shopCart->get('cart_count')) . ' en vente." class="btn btn-danger btn-sm">
-                    <i class="fa fa-trash-can"></i>
-                </a>
-            </td>
-        </tr>
-    ';
-        if ($shopCart->get('cart_count') > 0) {
-            if ($shopCart->get('cart_type') == 'shop') $shop_carts .= $s_cart;
-        }
-    }
-
-    if (isset($_GET['success'])) $alert = '<p class="success">' . $_GET['success'] . '</p>';
-    elseif (isset($_GET['error'])) $alert = '<p class="error">' . $_GET['error'] . '</p>';
-    elseif (isset($_GET['order_created'])) $alert = '<p class="success">La vente a été enregistrée sous le numéro ' . $_GET['order_created'] . '.</p>';
-    else $alert = NULL;
-
-    $request->attributes->set('page_title', 'Caisse');
-    $content = '';
-
-    if ($currentSite->getSite()->getTva() === 'fr') {
-        $content .= '
-        <div class="alert alert-warning">
-            <p>
-            
-                <span class="fa fa-warning"></span>
-                ' . "<strong>La caisse Biblys n'est pas un logiciel de caisse certifié.</strong><br/>
-            </p>
-            <p>
-                <em><small>
-                    Le fait, pour une personne assujettie à la taxe sur la valeur ajoutée, de ne pas 
-                    justifier, par la production de l'attestation ou du certificat prévus au 3° bis 
-                    du I de l'article 286, que le ou les logiciels ou systèmes de caisse qu'elle 
-                    détient satisfont aux conditions d'inaltérabilité, de sécurisation, de conservation 
-                    et d'archivage des données prévues par ces mêmes dispositions 
-                    <strong>est sanctionné par une amende de 7 500 € par logiciel ou système de 
-                    caisse concerné</strong>.
-                    (<a href='https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000037100434/2018-06-23'>Article 1770 du Code général des impôts</a>)
-                </small></em>
-            </p>
-            " . '
-            <p>
-                <a class="btn btn-warning" href="https://www.economie.gouv.fr/entreprises/professionnels-logiciels-caisse">
-                    En savoir plus
-                </a>
-            </p>
-        </div>';
-    }
-
-    $content .= '
-    <h1>
-      <i class="fa-solid fa-cash-register"></i>
-      Caisse
-    </h1>
-
-    ' . $alert . '
-
-    <form id="createCustomer" hidden>
-        <fieldset>
-            <p>
-                <label for="customer_last_name">Nom :</label>
-                <input type="text" id="customer_last_name" name="customer_last_name" required>
-            </p>
-            <p>
-                <label for="customer_first_name">Prénom :</label>
-                <input type="text" id="customer_first_name" name="customer_first_name">
-            </p>
-            <p>
-                <label for="customer_email">Adresse e-mail :</label>
-                <input type="email" id="customer_email" name="customer_email" class="long">
-            </p>
-            <p>
-                <label for="customer_phone">Téléphone :</label>
-                <input type="number" id="customer_phone" name="customer_phone">
-            </p>
-            <p class="center">
-                <input type="checkbox" name="customer_newsletter" id="customer_newsletter" value="1" checked>
-                <label for="customer_newsletter" class="after">Abonner à la newsletter</label>
-            </p>
-            <div class="right"><input type="submit" value="Valider" /></div>
-        </fieldset>
-    </form>
-
-    <h3>
-        <span id="cart_title" class="event pointer" contenteditable>' . $cart->get('cart_title') . '</span>
-    </h3>
-
-    <form>
-        <fieldset>
-
-            <input type="hidden" id="cart_id" name="cart_id" value=' . $cart->get('cart_id') . '>
-
-            <p>
-                <label for="seller">Libraire :</label>
-                ' . $seller_field . '
-            <p>
-
-            <p>
-                <label for="customer">Client :</label>
-                ' . $customer_field . '
-            </p>
-
-        </fieldset>
-    </form>
-
-    <h3>Encaissement</h3>
-
-    <table class="admin-table">
-        <thead>
-            <tr>
-                <th>Montant</th>
-                <th>Espèces</th>
-                <th>Chèque</th>
-                <th>Carte</th>
-                <th>À régler</th>
-                <th>À rendre</th>
-            </tr>
-        </thead>
-        <tbody>
-            <tr>
-                <td class="right" id="cart_total" data-value="' . $cart_total . '">' . currency($cart_total / 100) . '</td>
-                <td class="center"><input id="cart_cash" class="cart_payment" type="number" step="0.01" min=0 max=999 style="text-align: right;"></td>
-                <td class="center"><input id="cart_cheque" class="cart_payment" type="number" step="0.01" min=0 max=999 style="text-align: right;"></td>
-                <td class="center"><input id="cart_card" class="cart_payment" type="number" step="0.01" min=0 max=999 style="text-align: right;"></td>
-                <td id="cart_topay" data-value=' . $cart_total . ' class="right">' . currency($cart_total / 100) . '</td>
-                <td id="cart_togive" data-value=0 class="right">' . currency(0 / 100) . '</td>
-            </tr>
-        </tbody>
-    </table>
-
-    <br>
-    <form id="checkout" class="event">
-        <fieldset class="center">
-            <button class="btn btn-primary" type="submit">Enregistrer la vente</button>
-        </fieldset>
-    </form>
-
-    <h3>Panier en cours (<span id="cart_count">' . $cart_count . '</span> article<span id="cart_count_s">' . s($cart_count) . '</span>)</h3>
-
-    <form id="checkout_add" class="event">
-        <fieldset>
-
-            <p>
-                <label for="checkout_add_input">Ajouter un article :</label>
-                <input type="text" name="checkout_add_input" id="checkout_add_input" class="verylong event" autocomplete="off" autofocus>
-            </p>
-
-        </fieldset>
-    </form>
-
-    <table id="checkout_add_results" class="admin-table">
-    </table>
-
-    <table id="checkout_cart" class="admin-table">
-        <thead>
-            <tr>
-                <th>Ref.</th>
-                <th></th>
-                <th>Article</th>
-                <th>Prix</th>
-                <th></th>
-            </tr>
-        </thead>
-        <tbody>
-            ' . $cart_content . '
-        </tbody>
-    </table>
-
-    <br>
-    <h3>Autres paniers</h3>
-    <p><a href="/pages/adm_checkout?new_cart" class="btn btn-primary">Nouveau panier</a></p>
-
-    <table class="admin-table">
-        <thead>
-            <tr>
-                <th>Nom</th>
-                <th>Libraire</th>
-                <th>Client</th>
-                <th>Articles</th>
-                <th>Montant</th>
-                <th></th>
-            </tr>
-        </thead>
-        <tbody>
-            ' . $shop_carts . '
-        </tbody>
-    </table>
-
-';
-
-    return new Response($content);
+    // Requête non-AJAX sans action : rediriger vers la nouvelle URL
+    return new RedirectResponse("/admin/caisse?cart_id=$cartId");
 };

--- a/public/common/js/biblys-admin.js
+++ b/public/common/js/biblys-admin.js
@@ -376,7 +376,7 @@ function reloadAdminEvents() {
           data: data,
           dataType: 'json'
         })
-          .success(function() {
+          .done(function() {
             window.location.href = '/admin/caisse';
           })
           .fail(function(res) {

--- a/public/common/js/biblys-admin.js
+++ b/public/common/js/biblys-admin.js
@@ -376,8 +376,8 @@ function reloadAdminEvents() {
           data: data,
           dataType: 'json'
         })
-          .success(function(res) {
-            window.location.href = '/pages/adm_checkout?order_created=' + res.created_order;
+          .success(function() {
+            window.location.href = '/admin/caisse';
           })
           .fail(function(res) {
             var json = res.responseJSON;

--- a/src/AppBundle/Controller/PointOfSaleController.php
+++ b/src/AppBundle/Controller/PointOfSaleController.php
@@ -1,0 +1,162 @@
+<?php
+/*
+ * Copyright (C) 2026 Clément Latzarus
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+
+namespace AppBundle\Controller;
+
+use Biblys\Service\CurrentSite;
+use Biblys\Service\CurrentUser;
+use Biblys\Service\FlashMessagesService;
+use Biblys\Service\Images\ImagesService;
+use Biblys\Service\TemplateService;
+use CartManager;
+use CustomerManager;
+use DateTime;
+use Framework\Controller;
+use Model\UserQuery;
+use Propel\Runtime\Exception\PropelException;
+use Symfony\Component\HttpFoundation\Cookie;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\Generator\UrlGenerator;
+use Twig\Error\LoaderError;
+use Twig\Error\RuntimeError;
+use Twig\Error\SyntaxError;
+
+class PointOfSaleController extends Controller
+{
+    /**
+     * @throws PropelException
+     * @throws LoaderError
+     * @throws RuntimeError
+     * @throws SyntaxError
+     */
+    public function indexAction(
+        Request              $request,
+        CurrentUser          $currentUser,
+        CurrentSite          $currentSite,
+        ImagesService        $imagesService,
+        FlashMessagesService $flashMessagesService,
+        TemplateService      $templateService,
+        UrlGenerator         $urlGenerator,
+    ): Response|RedirectResponse
+    {
+        $currentUser->authAdmin();
+
+        $request->attributes->set('page_title', 'Caisse');
+
+        $enableTemporaryAccess = $request->query->getInt("enable_temporary_access");
+        if ($enableTemporaryAccess === 1) {
+            $redirectResponse = new RedirectResponse("/admin/point-of-sale");
+            $bypassCookie = new Cookie("bypass_cash_register_check", "1", new DateTime("tomorrow"));
+            $redirectResponse->headers->setCookie($bypassCookie);
+            $flashMessagesService->add("info", "La caisse a été réactivée jusqu'à demain.");
+            return $redirectResponse;
+        }
+
+        $isTvaEnabled = $currentSite->getSite()->getTva() === "fr";
+        $bypassCookie = $request->cookies->get("bypass_cash_register_check");
+        if ($isTvaEnabled && !$bypassCookie) {
+            return $templateService->renderResponse("AppBundle:PointOfSale:index.html.twig", [
+                'tva_blocked' => true,
+            ], isPrivate: true);
+        }
+
+        $cm = new CartManager();
+
+        $cartId = $request->query->get("cart_id");
+        if (!$cartId) {
+            $cartForCurrentSeller = $cm->get([
+                "cart_type" => "shop",
+                "cart_seller_id" => $currentUser->getUser()->getId(),
+                "cart_count" => 0,
+            ]);
+
+            if ($cartForCurrentSeller) {
+                return new RedirectResponse("/admin/point-of-sale?cart_id={$cartForCurrentSeller->get('id')}");
+            }
+
+            $newCart = $cm->create();
+            $newCart->set("cart_type", "shop");
+            $newCart->set("cart_seller_id", $currentUser->getUser()->getId());
+            $newCart = $cm->update($newCart);
+            return new RedirectResponse("/admin/point-of-sale?cart_id={$newCart->get('id')}");
+        }
+
+        $cart = $cm->get(['cart_id' => $cartId]);
+        if (!$cart) {
+            throw new NotFoundHttpException("Panier $cartId introuvable");
+        }
+
+        $seller = null;
+        if ($cart->has('seller_id')) {
+            $seller = UserQuery::create()->findPk($cart->get('seller_id'));
+        }
+
+        $customer = null;
+        if ($cart->has('customer_id')) {
+            $customerManager = new CustomerManager();
+            $customer = $customerManager->get(['customer_id' => $cart->get('customer_id')]);
+        }
+
+        $cartContent = '';
+        $cartCount = 0;
+        $cartTotal = 0;
+        foreach ($cm->getStock($cart) as $stockEntity) {
+            $cartContent .= $cart->getLine($imagesService, $stockEntity);
+            $cartCount++;
+            $cartTotal += $stockEntity->get('selling_price');
+        }
+        $cm->updateFromStock($cart);
+
+        $shopCarts = [];
+        foreach ($cm->getAll() as $shopCart) {
+            if ($shopCart->get('cart_count') > 0 && $shopCart->get('cart_type') === 'shop') {
+                $cartSeller = null;
+                if ($shopCart->has('seller_user_id')) {
+                    $cartSeller = UserQuery::create()->findPk($shopCart->get('seller_user_id'));
+                } elseif ($shopCart->has('seller_id')) {
+                    $cartSeller = UserQuery::create()->findPk($shopCart->get('seller_id'));
+                }
+                $shopCarts[] = [
+                    'id' => $shopCart->get('cart_id'),
+                    'title' => $shopCart->get('cart_title'),
+                    'seller_email' => $cartSeller?->getEmail() ?? "Vendeur inconnu",
+                    'customer_name' => $shopCart->has('customer')
+                        ? $shopCart->get('customer')->get('first_name') . ' ' . $shopCart->get('customer')->get('last_name')
+                        : null,
+                    'count' => $shopCart->get('cart_count'),
+                    'amount' => $shopCart->get('cart_amount'),
+                ];
+            }
+        }
+
+        return $templateService->renderResponse("AppBundle:PointOfSale:index.html.twig", [
+            'tva_blocked' => false,
+            'is_tva_enabled' => $isTvaEnabled,
+            'cart' => $cart,
+            'cart_content' => $cartContent,
+            'cart_count' => $cartCount,
+            'cart_total' => $cartTotal,
+            'seller' => $seller,
+            'customer' => $customer,
+            'shop_carts' => $shopCarts,
+        ], isPrivate: true);
+    }
+}

--- a/src/AppBundle/Controller/PointOfSaleController.php
+++ b/src/AppBundle/Controller/PointOfSaleController.php
@@ -63,7 +63,7 @@ class PointOfSaleController extends Controller
 
         $enableTemporaryAccess = $request->query->getInt("enable_temporary_access");
         if ($enableTemporaryAccess === 1) {
-            $redirectResponse = new RedirectResponse("/admin/point-of-sale");
+            $redirectResponse = new RedirectResponse("/admin/caisse");
             $bypassCookie = new Cookie("bypass_cash_register_check", "1", new DateTime("tomorrow"));
             $redirectResponse->headers->setCookie($bypassCookie);
             $flashMessagesService->add("info", "La caisse a été réactivée jusqu'à demain.");
@@ -89,14 +89,14 @@ class PointOfSaleController extends Controller
             ]);
 
             if ($cartForCurrentSeller) {
-                return new RedirectResponse("/admin/point-of-sale?cart_id={$cartForCurrentSeller->get('id')}");
+                return new RedirectResponse("/admin/caisse?cart_id={$cartForCurrentSeller->get('id')}");
             }
 
             $newCart = $cm->create();
             $newCart->set("cart_type", "shop");
             $newCart->set("cart_seller_id", $currentUser->getUser()->getId());
             $newCart = $cm->update($newCart);
-            return new RedirectResponse("/admin/point-of-sale?cart_id={$newCart->get('id')}");
+            return new RedirectResponse("/admin/caisse?cart_id={$newCart->get('id')}");
         }
 
         $cart = $cm->get(['cart_id' => $cartId]);

--- a/src/AppBundle/Controller/PointOfSaleController.php
+++ b/src/AppBundle/Controller/PointOfSaleController.php
@@ -22,6 +22,7 @@ use Biblys\Service\CurrentSite;
 use Biblys\Service\CurrentUser;
 use Biblys\Service\FlashMessagesService;
 use Biblys\Service\Images\ImagesService;
+use Biblys\Service\QueryParamsService;
 use Biblys\Service\TemplateService;
 use CartManager;
 use CustomerManager;
@@ -55,13 +56,17 @@ class PointOfSaleController extends Controller
         FlashMessagesService $flashMessagesService,
         TemplateService      $templateService,
         UrlGenerator         $urlGenerator,
+        QueryParamsService   $queryParams,
     ): Response|RedirectResponse
     {
         $currentUser->authAdmin();
 
-        $request->attributes->set('page_title', 'Caisse');
+        $queryParams->parse([
+            "enable_temporary_access" => ["type" => "numeric", "default" => 0],
+            "cart_id" => ["type" => "numeric", "default" => null],
+        ]);
 
-        $enableTemporaryAccess = $request->query->getInt("enable_temporary_access");
+        $enableTemporaryAccess = $queryParams->getInteger("enable_temporary_access");
         if ($enableTemporaryAccess === 1) {
             $redirectResponse = new RedirectResponse("/admin/caisse");
             $bypassCookie = new Cookie("bypass_cash_register_check", "1", new DateTime("tomorrow"));
@@ -80,7 +85,7 @@ class PointOfSaleController extends Controller
 
         $cm = new CartManager();
 
-        $cartId = $request->query->get("cart_id");
+        $cartId = $queryParams->getInteger("cart_id");
         if (!$cartId) {
             $cartForCurrentSeller = $cm->get([
                 "cart_type" => "shop",

--- a/src/AppBundle/Resources/views/PointOfSale/index.html.twig
+++ b/src/AppBundle/Resources/views/PointOfSale/index.html.twig
@@ -103,7 +103,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
     </form>
 
     <h3>
-      <span id="cart_title" class="event pointer" contenteditable>{{ cart.get('cart_title') }}</span>
+      <span id="cart_title" class="event pointer" contenteditable>{{ cart.get('cart_title')|raw }}</span>
     </h3>
 
     <form>
@@ -160,12 +160,12 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
       </thead>
       <tbody>
         <tr>
-          <td class="right" id="cart_total" data-value="{{ cart_total }}">{{ cart_total|currency(true) }}</td>
+          <td class="right" id="cart_total" data-value="{{ cart_total }}">{{ cart_total|currency(true)|raw }}</td>
           <td class="center"><input id="cart_cash" class="cart_payment" type="number" step="0.01" min=0 max=999 style="text-align: right;"></td>
           <td class="center"><input id="cart_cheque" class="cart_payment" type="number" step="0.01" min=0 max=999 style="text-align: right;"></td>
           <td class="center"><input id="cart_card" class="cart_payment" type="number" step="0.01" min=0 max=999 style="text-align: right;"></td>
-          <td id="cart_topay" data-value="{{ cart_total }}" class="right">{{ cart_total|currency(true) }}</td>
-          <td id="cart_togive" data-value=0 class="right">{{ 0|currency(true) }}</td>
+          <td id="cart_topay" data-value="{{ cart_total }}" class="right">{{ cart_total|currency(true)|raw }}</td>
+          <td id="cart_togive" data-value=0 class="right">{{ 0|currency(true)|raw }}</td>
         </tr>
       </tbody>
     </table>
@@ -228,7 +228,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
             <td>{{ shopCart.seller_email }}</td>
             <td>{{ shopCart.customer_name }}</td>
             <td class="right">{{ shopCart.count }}</td>
-            <td class="right">{{ shopCart.amount|currency(true) }}</td>
+            <td class="right">{{ shopCart.amount|currency(true)|raw }}</td>
             <td class="center">
               <a href="/pages/adm_checkout?cart_id={{ shopCart.id }}&vacuum_cart=1"
                  data-confirm="Voulez-vous vraiment VIDER ce panier et remettre {{ shopCart.count }} exemplaire{% if shopCart.count > 1 %}s{% endif %} en vente ?"

--- a/src/AppBundle/Resources/views/PointOfSale/index.html.twig
+++ b/src/AppBundle/Resources/views/PointOfSale/index.html.twig
@@ -208,7 +208,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
     <br>
     <h3>Autres paniers</h3>
-    <p><a href="/pages/adm_checkout?new_cart" class="btn btn-primary">Nouveau panier</a></p>
+    <p><a href="/admin/caisse" class="btn btn-primary">Nouveau panier</a></p>
 
     <table class="admin-table">
       <thead>
@@ -224,7 +224,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
       <tbody>
         {% for shopCart in shop_carts %}
           <tr>
-            <td><a href="/pages/adm_checkout?cart_id={{ shopCart.id }}">{{ shopCart.title }}</a></td>
+            <td><a href="/admin/caisse?cart_id={{ shopCart.id }}">{{ shopCart.title }}</a></td>
             <td>{{ shopCart.seller_email }}</td>
             <td>{{ shopCart.customer_name }}</td>
             <td class="right">{{ shopCart.count }}</td>

--- a/src/AppBundle/Resources/views/PointOfSale/index.html.twig
+++ b/src/AppBundle/Resources/views/PointOfSale/index.html.twig
@@ -1,0 +1,247 @@
+{#
+Copyright (C) 2026 Clément Latzarus
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, version 3.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#}
+
+{% extends "layout:admin.html.twig" %}
+
+{% block title %}Caisse{% endblock %}
+
+{% block main %}
+
+  {% if tva_blocked %}
+
+    <div class="alert alert-danger">
+      <p class="alert-heading lead">
+        <span class="fa-solid fa-circle-xmark"></span>
+        <strong>La caisse est désactivée, car la gestion de la TVA est activée.</strong>
+      </p>
+      <p>
+        La loi de finances pour 2025 interdit l'usage d'un logiciel de caisse non certifié pour un
+        professionnel assujetti à la TVA. Pour réactiver la caisse, désactivez la gestion de la TVA.
+      </p>
+      <p>
+        <a class="btn btn-warning" href="https://blog.biblys.org/posts/certification-nf-525-logiciels-de-caisse/" target="_blank">
+          <i class="fa fa-external-link"></i>
+          En savoir plus
+        </a>
+        <a class="btn btn-danger" href="/admin/point-of-sale?enable_temporary_access=1">
+          <i class="fa-solid fa-clock"></i>
+          Réactiver temporairement la caisse
+        </a>
+      </p>
+    </div>
+
+  {% else %}
+
+    {% if is_tva_enabled %}
+      <div class="alert alert-warning">
+        <p>
+          <span class="fa fa-warning"></span>
+          <strong>La caisse Biblys n'est pas un logiciel de caisse certifié.</strong>
+        </p>
+        <p>
+          <em><small>
+            Le fait, pour une personne assujettie à la taxe sur la valeur ajoutée, de ne pas
+            justifier, par la production de l'attestation ou du certificat prévus au 3° bis
+            du I de l'article 286, que le ou les logiciels ou systèmes de caisse qu'elle
+            détient satisfont aux conditions d'inaltérabilité, de sécurisation, de conservation
+            et d'archivage des données prévues par ces mêmes dispositions
+            <strong>est sanctionné par une amende de 7 500 € par logiciel ou système de
+              caisse concerné</strong>.
+            (<a href="https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000037100434/2018-06-23">Article 1770 du Code général des impôts</a>)
+          </small></em>
+        </p>
+        <p>
+          <a class="btn btn-warning" href="https://www.economie.gouv.fr/entreprises/professionnels-logiciels-caisse">
+            En savoir plus
+          </a>
+        </p>
+      </div>
+    {% endif %}
+
+    <h1>
+      <i class="fa-solid fa-cash-register"></i>
+      Caisse
+    </h1>
+
+    <form id="createCustomer" hidden>
+      <fieldset>
+        <p>
+          <label for="customer_last_name">Nom :</label>
+          <input type="text" id="customer_last_name" name="customer_last_name" required>
+        </p>
+        <p>
+          <label for="customer_first_name">Prénom :</label>
+          <input type="text" id="customer_first_name" name="customer_first_name">
+        </p>
+        <p>
+          <label for="customer_email">Adresse e-mail :</label>
+          <input type="email" id="customer_email" name="customer_email" class="long">
+        </p>
+        <p>
+          <label for="customer_phone">Téléphone :</label>
+          <input type="number" id="customer_phone" name="customer_phone">
+        </p>
+        <p class="center">
+          <input type="checkbox" name="customer_newsletter" id="customer_newsletter" value="1" checked>
+          <label for="customer_newsletter" class="after">Abonner à la newsletter</label>
+        </p>
+        <div class="right"><input type="submit" value="Valider"/></div>
+      </fieldset>
+    </form>
+
+    <h3>
+      <span id="cart_title" class="event pointer" contenteditable>{{ cart.get('cart_title') }}</span>
+    </h3>
+
+    <form>
+      <fieldset>
+
+        <input type="hidden" id="cart_id" name="cart_id" value="{{ cart.get('cart_id') }}">
+
+        <p>
+          <label for="seller">Libraire :</label>
+          {% if seller %}
+            <input type="text" name="seller" id="seller" value="{{ seller.getEmail() }}" class="long" required readonly>
+            <input type="hidden" name="seller_id" id="seller_id" value="{{ seller.getId() }}" required>
+          {% endif %}
+        </p>
+
+        <p>
+          <label for="customer">Client :</label>
+          {% if customer %}
+            <input type="text" name="customer" id="customer"
+                   placeholder="Rechercher un client..."
+                   value="{{ customer.get('customer_last_name') }}, {{ customer.get('customer_first_name') }} ({{ customer.get('customer_email') }})"
+                   readonly class="pointer event verylong">
+            <input type="hidden" name="customer_id" id="customer_id" value="{{ customer.get('customer_id') }}" required>
+            <span id="newsletter">
+              <input type="checkbox" name="customer_mailing" id="customer_mailing" value="1" disabled
+                  {% if customer.get('customer_newsletter') == 1 %}checked{% endif %}>
+              <label for="customer_mailing" class="after">Abonné à la newsletter</label>
+            </span>
+          {% else %}
+            <input type="text" name="customer" id="customer" placeholder="Rechercher un client..." class="event verylong">
+            <input type="hidden" name="customer_id" id="customer_id" required>
+            <span id="newsletter2" class="hidden">
+              <input type="checkbox" name="customer_mailing" id="customer_mailing" value="1" disabled>
+              <label for="customer_mailing" class="after">Abonné à la newsletter</label>
+            </span>
+          {% endif %}
+        </p>
+
+      </fieldset>
+    </form>
+
+    <h3>Encaissement</h3>
+
+    <table class="admin-table">
+      <thead>
+        <tr>
+          <th>Montant</th>
+          <th>Espèces</th>
+          <th>Chèque</th>
+          <th>Carte</th>
+          <th>À régler</th>
+          <th>À rendre</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td class="right" id="cart_total" data-value="{{ cart_total }}">{{ cart_total|currency(true) }}</td>
+          <td class="center"><input id="cart_cash" class="cart_payment" type="number" step="0.01" min=0 max=999 style="text-align: right;"></td>
+          <td class="center"><input id="cart_cheque" class="cart_payment" type="number" step="0.01" min=0 max=999 style="text-align: right;"></td>
+          <td class="center"><input id="cart_card" class="cart_payment" type="number" step="0.01" min=0 max=999 style="text-align: right;"></td>
+          <td id="cart_topay" data-value="{{ cart_total }}" class="right">{{ cart_total|currency(true) }}</td>
+          <td id="cart_togive" data-value=0 class="right">{{ 0|currency(true) }}</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <br>
+    <form id="checkout" class="event">
+      <fieldset class="center">
+        <button class="btn btn-primary" type="submit">Enregistrer la vente</button>
+      </fieldset>
+    </form>
+
+    <h3>Panier en cours (<span id="cart_count">{{ cart_count }}</span> article<span id="cart_count_s">{% if cart_count > 1 %}s{% endif %}</span>)</h3>
+
+    <form id="checkout_add" class="event">
+      <fieldset>
+        <p>
+          <label for="checkout_add_input">Ajouter un article :</label>
+          <input type="text" name="checkout_add_input" id="checkout_add_input" class="verylong event" autocomplete="off" autofocus>
+        </p>
+      </fieldset>
+    </form>
+
+    <table id="checkout_add_results" class="admin-table">
+    </table>
+
+    <table id="checkout_cart" class="admin-table">
+      <thead>
+        <tr>
+          <th>Ref.</th>
+          <th></th>
+          <th>Article</th>
+          <th>Prix</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        {{ cart_content|raw }}
+      </tbody>
+    </table>
+
+    <br>
+    <h3>Autres paniers</h3>
+    <p><a href="/pages/adm_checkout?new_cart" class="btn btn-primary">Nouveau panier</a></p>
+
+    <table class="admin-table">
+      <thead>
+        <tr>
+          <th>Nom</th>
+          <th>Libraire</th>
+          <th>Client</th>
+          <th>Articles</th>
+          <th>Montant</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for shopCart in shop_carts %}
+          <tr>
+            <td><a href="/pages/adm_checkout?cart_id={{ shopCart.id }}">{{ shopCart.title }}</a></td>
+            <td>{{ shopCart.seller_email }}</td>
+            <td>{{ shopCart.customer_name }}</td>
+            <td class="right">{{ shopCart.count }}</td>
+            <td class="right">{{ shopCart.amount|currency(true) }}</td>
+            <td class="center">
+              <a href="/pages/adm_checkout?cart_id={{ shopCart.id }}&vacuum_cart=1"
+                 data-confirm="Voulez-vous vraiment VIDER ce panier et remettre {{ shopCart.count }} exemplaire{% if shopCart.count > 1 %}s{% endif %} en vente ?"
+                 title="Vider le panier et remettre {{ shopCart.count }} exemplaire{% if shopCart.count > 1 %}s{% endif %} en vente."
+                 class="btn btn-danger btn-sm">
+                <i class="fa fa-trash-can"></i>
+              </a>
+            </td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+
+  {% endif %}
+
+{% endblock %}

--- a/src/AppBundle/Resources/views/PointOfSale/index.html.twig
+++ b/src/AppBundle/Resources/views/PointOfSale/index.html.twig
@@ -36,7 +36,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
           <i class="fa fa-external-link"></i>
           En savoir plus
         </a>
-        <a class="btn btn-danger" href="/admin/point-of-sale?enable_temporary_access=1">
+        <a class="btn btn-danger" href="/admin/caisse?enable_temporary_access=1">
           <i class="fa-solid fa-clock"></i>
           Réactiver temporairement la caisse
         </a>

--- a/src/AppBundle/routes.yml
+++ b/src/AppBundle/routes.yml
@@ -412,7 +412,7 @@ openid_callback:
 # Point of Sale
 
 point_of_sale_index:
-  path: /admin/point-of-sale
+  path: /admin/caisse
   controller: AppBundle\Controller\PointOfSaleController::indexAction
   methods: [GET]
 

--- a/src/AppBundle/routes.yml
+++ b/src/AppBundle/routes.yml
@@ -409,6 +409,13 @@ openid_callback:
   controller: AppBundle\Controller\OpenIDConnectController::callback
   methods: GET
 
+# Point of Sale
+
+point_of_sale_index:
+  path: /admin/point-of-sale
+  controller: AppBundle\Controller\PointOfSaleController::indexAction
+  methods: [GET]
+
 # Orders
 
 order_index:

--- a/tests/AppBundle/Controller/Legacy/AdmCheckoutTest.php
+++ b/tests/AppBundle/Controller/Legacy/AdmCheckoutTest.php
@@ -18,12 +18,9 @@
 
 namespace AppBundle\Controller\Legacy;
 
-use Biblys\Service\CurrentSite;
-use Biblys\Service\CurrentUser;
 use Biblys\Service\FlashMessagesService;
 use Biblys\Service\Images\ImagesService;
 use Biblys\Test\EntityFactory;
-use Biblys\Test\ModelFactory;
 use Mockery;
 use Model\Payment;
 use Model\PaymentQuery;
@@ -59,7 +56,6 @@ class AdmCheckoutTest extends TestCase
     {
         // given
         $controller = $this->getController();
-        $site = ModelFactory::createSite();
         $cart = EntityFactory::createCart();
 
         $_GET["cart_id"] = $cart->get("id");
@@ -74,14 +70,9 @@ class AdmCheckoutTest extends TestCase
         $request->query->set("cart_id", $cart->get("id"));
         $request->headers->set("X-Requested-With", "XMLHttpRequest");
 
-        $currentSite = Mockery::mock(CurrentSite::class);
-        $currentSite->shouldReceive("getSite")->andReturn($site);
-
         // when
         $controller(
             $request,
-            Mockery::mock(CurrentUser::class),
-            $currentSite,
             Mockery::mock(ImagesService::class),
             Mockery::mock(FlashMessagesService::class),
         );

--- a/tests/AppBundle/Controller/PointOfSaleControllerTest.php
+++ b/tests/AppBundle/Controller/PointOfSaleControllerTest.php
@@ -22,12 +22,11 @@ use Biblys\Service\CurrentSite;
 use Biblys\Service\CurrentUser;
 use Biblys\Service\FlashMessagesService;
 use Biblys\Service\Images\ImagesService;
+use Biblys\Service\QueryParamsService;
 use Biblys\Test\EntityFactory;
 use Biblys\Test\Helpers;
 use Biblys\Test\ModelFactory;
-use CartManager;
 use Mockery;
-use Model\Site;
 use PHPUnit\Framework\TestCase;
 use Propel\Runtime\Exception\PropelException;
 use Symfony\Component\HttpFoundation\Request;
@@ -76,6 +75,7 @@ class PointOfSaleControllerTest extends TestCase
             Mockery::mock(FlashMessagesService::class),
             Helpers::getTemplateService(),
             Mockery::mock(UrlGenerator::class),
+            new QueryParamsService($request),
         );
 
         // then
@@ -110,6 +110,7 @@ class PointOfSaleControllerTest extends TestCase
             $flashMessages,
             Helpers::getTemplateService(),
             Mockery::mock(UrlGenerator::class),
+            new QueryParamsService($request),
         );
 
         // then
@@ -144,6 +145,7 @@ class PointOfSaleControllerTest extends TestCase
             Mockery::mock(FlashMessagesService::class),
             Helpers::getTemplateService(),
             Mockery::mock(UrlGenerator::class),
+            new QueryParamsService($request),
         );
 
         // then
@@ -173,6 +175,7 @@ class PointOfSaleControllerTest extends TestCase
             Mockery::mock(FlashMessagesService::class),
             Helpers::getTemplateService(),
             Mockery::mock(UrlGenerator::class),
+            new QueryParamsService($request),
         );
 
         // then
@@ -204,6 +207,7 @@ class PointOfSaleControllerTest extends TestCase
             Mockery::mock(FlashMessagesService::class),
             Helpers::getTemplateService(),
             Mockery::mock(UrlGenerator::class),
+            new QueryParamsService($request),
         );
     }
 }

--- a/tests/AppBundle/Controller/PointOfSaleControllerTest.php
+++ b/tests/AppBundle/Controller/PointOfSaleControllerTest.php
@@ -114,7 +114,7 @@ class PointOfSaleControllerTest extends TestCase
 
         // then
         $this->assertEquals(302, $response->getStatusCode());
-        $this->assertEquals("/admin/point-of-sale", $response->headers->get("Location"));
+        $this->assertEquals("/admin/caisse", $response->headers->get("Location"));
         $this->assertNotNull($response->headers->getCookies()[0] ?? null, "should set bypass cookie");
         $this->assertEquals("bypass_cash_register_check", $response->headers->getCookies()[0]->getName());
     }
@@ -148,7 +148,7 @@ class PointOfSaleControllerTest extends TestCase
 
         // then
         $this->assertEquals(302, $response->getStatusCode());
-        $this->assertStringStartsWith("/admin/point-of-sale?cart_id=", $response->headers->get("Location"));
+        $this->assertStringStartsWith("/admin/caisse?cart_id=", $response->headers->get("Location"));
     }
 
     /**

--- a/tests/AppBundle/Controller/PointOfSaleControllerTest.php
+++ b/tests/AppBundle/Controller/PointOfSaleControllerTest.php
@@ -1,0 +1,209 @@
+<?php
+/*
+ * Copyright (C) 2026 Clément Latzarus
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+
+namespace AppBundle\Controller;
+
+use Biblys\Service\CurrentSite;
+use Biblys\Service\CurrentUser;
+use Biblys\Service\FlashMessagesService;
+use Biblys\Service\Images\ImagesService;
+use Biblys\Test\EntityFactory;
+use Biblys\Test\Helpers;
+use Biblys\Test\ModelFactory;
+use CartManager;
+use Mockery;
+use Model\Site;
+use PHPUnit\Framework\TestCase;
+use Propel\Runtime\Exception\PropelException;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Generator\UrlGenerator;
+
+require_once __DIR__ . "/../../setUp.php";
+
+class PointOfSaleControllerTest extends TestCase
+{
+    private function _getController(): PointOfSaleController
+    {
+        return new PointOfSaleController();
+    }
+
+    private function _getCurrentSiteMock(string $tva = ""): CurrentSite
+    {
+        $site = ModelFactory::createSite();
+        $site->setTva($tva);
+        $site->save();
+
+        $currentSite = Mockery::mock(CurrentSite::class);
+        $currentSite->shouldReceive("getSite")->andReturn($site);
+        $currentSite->shouldReceive("getTitle")->andReturn("Éditions Paronymie");
+        $currentSite->shouldReceive("getOption")->andReturn(null);
+        return $currentSite;
+    }
+
+    /**
+     * @throws PropelException
+     */
+    public function testIndexActionReturnsTvaBlockWhenTvaEnabledWithoutBypass(): void
+    {
+        // given
+        $controller = $this->_getController();
+        $request = new Request();
+
+        $currentUser = Mockery::mock(CurrentUser::class);
+        $currentUser->expects("authAdmin");
+
+        // when
+        $response = $controller->indexAction(
+            $request,
+            $currentUser,
+            $this->_getCurrentSiteMock(tva: "fr"),
+            Mockery::mock(ImagesService::class),
+            Mockery::mock(FlashMessagesService::class),
+            Helpers::getTemplateService(),
+            Mockery::mock(UrlGenerator::class),
+        );
+
+        // then
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertStringContainsString(
+            "La caisse est désactivée, car la gestion de la TVA est activée.",
+            $response->getContent()
+        );
+    }
+
+    /**
+     * @throws PropelException
+     */
+    public function testIndexActionRedirectsWhenTvaBypassIsRequested(): void
+    {
+        // given
+        $controller = $this->_getController();
+        $request = new Request(query: ['enable_temporary_access' => '1']);
+
+        $currentUser = Mockery::mock(CurrentUser::class);
+        $currentUser->expects("authAdmin");
+
+        $flashMessages = Mockery::mock(FlashMessagesService::class);
+        $flashMessages->expects("add")->with("info", "La caisse a été réactivée jusqu'à demain.");
+
+        // when
+        $response = $controller->indexAction(
+            $request,
+            $currentUser,
+            $this->_getCurrentSiteMock(tva: "fr"),
+            Mockery::mock(ImagesService::class),
+            $flashMessages,
+            Helpers::getTemplateService(),
+            Mockery::mock(UrlGenerator::class),
+        );
+
+        // then
+        $this->assertEquals(302, $response->getStatusCode());
+        $this->assertEquals("/admin/point-of-sale", $response->headers->get("Location"));
+        $this->assertNotNull($response->headers->getCookies()[0] ?? null, "should set bypass cookie");
+        $this->assertEquals("bypass_cash_register_check", $response->headers->getCookies()[0]->getName());
+    }
+
+    /**
+     * @throws PropelException
+     */
+    public function testIndexActionRedirectsToCartWhenNoCartIdProvided(): void
+    {
+        // given
+        $controller = $this->_getController();
+        $request = new Request();
+
+        $currentUser = Mockery::mock(CurrentUser::class);
+        $currentUser->expects("authAdmin");
+
+        $user = Mockery::mock(\Model\User::class);
+        $user->shouldReceive("getId")->andReturn(999);
+        $currentUser->shouldReceive("getUser")->andReturn($user);
+
+        // when
+        $response = $controller->indexAction(
+            $request,
+            $currentUser,
+            $this->_getCurrentSiteMock(),
+            Mockery::mock(ImagesService::class),
+            Mockery::mock(FlashMessagesService::class),
+            Helpers::getTemplateService(),
+            Mockery::mock(UrlGenerator::class),
+        );
+
+        // then
+        $this->assertEquals(302, $response->getStatusCode());
+        $this->assertStringStartsWith("/admin/point-of-sale?cart_id=", $response->headers->get("Location"));
+    }
+
+    /**
+     * @throws PropelException
+     */
+    public function testIndexActionReturnsPageWithCartId(): void
+    {
+        // given
+        $controller = $this->_getController();
+        $cart = EntityFactory::createCart();
+        $request = new Request(query: ['cart_id' => $cart->get('id')]);
+
+        $currentUser = Mockery::mock(CurrentUser::class);
+        $currentUser->expects("authAdmin");
+
+        // when
+        $response = $controller->indexAction(
+            $request,
+            $currentUser,
+            $this->_getCurrentSiteMock(),
+            Mockery::mock(ImagesService::class),
+            Mockery::mock(FlashMessagesService::class),
+            Helpers::getTemplateService(),
+            Mockery::mock(UrlGenerator::class),
+        );
+
+        // then
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertStringContainsString("Caisse", $response->getContent());
+    }
+
+    /**
+     * @throws PropelException
+     */
+    public function testIndexActionReturns404WhenCartNotFound(): void
+    {
+        // given
+        $controller = $this->_getController();
+        $request = new Request(query: ['cart_id' => '99999']);
+
+        $currentUser = Mockery::mock(CurrentUser::class);
+        $currentUser->expects("authAdmin");
+
+        // then
+        $this->expectException(\Symfony\Component\HttpKernel\Exception\NotFoundHttpException::class);
+
+        // when
+        $controller->indexAction(
+            $request,
+            $currentUser,
+            $this->_getCurrentSiteMock(),
+            Mockery::mock(ImagesService::class),
+            Mockery::mock(FlashMessagesService::class),
+            Helpers::getTemplateService(),
+            Mockery::mock(UrlGenerator::class),
+        );
+    }
+}


### PR DESCRIPTION
## Résumé

Première PR de la migration incrémentale de la caisse (issue #512).

Crée le `PointOfSaleController` avec son `indexAction` et son template Twig, rendant la nouvelle URL `/admin/caisse` fonctionnelle. Simplifie `adm_checkout.php` pour ne conserver que les handlers AJAX, qui redirigent toutes les requêtes d'affichage vers la nouvelle URL.

## Changements

- Ajout de la route `point_of_sale_index` (`GET /admin/caisse`)
- Création de `PointOfSaleController::indexAction` qui migre la logique d'affichage de `adm_checkout.php` :
  - Authentification admin
  - Gestion du bloc TVA et du bypass temporaire (`enable_temporary_access` + cookie)
  - Get-or-create du panier caisse pour le vendeur courant avec redirection
  - Chargement du vendeur, du client, du contenu du panier et des autres paniers
- Création du template `AppBundle/Resources/views/PointOfSale/index.html.twig` remplaçant le HTML inline
- Simplification de `adm_checkout.php` :
  - Suppression du code d'affichage, du bloc TVA et de la logique get-or-create
  - Conservation des seuls handlers AJAX/actions (validate, set_title, set_customer, add stock, remove stock, vacuum_cart)
  - Toutes les requêtes non-AJAX sans action redirigent vers `/admin/caisse`
  - Tous les redirects internes mis à jour vers `/admin/caisse`
- Mise à jour de `biblys-admin.js` : après validation de vente, redirige vers `/admin/caisse`
- Mise à jour du template : "Nouveau panier" et liens de navigation des autres paniers pointent vers `/admin/caisse`
- Ajout de `PointOfSaleControllerTest` avec 5 tests

## Plan de test

- [x] `composer test` passe (hors échec pré-existant dans `PaymentControllerTest`)
- [x] La nouvelle URL `/admin/caisse` affiche la page de la caisse (200)
- [x] Naviguer vers `/pages/adm_checkout?cart_id=X` redirige vers `/admin/caisse?cart_id=X`
- [x] Naviguer vers `/pages/adm_checkout` (sans cart_id) redirige vers `/admin/caisse`
- [x] Le bloc TVA s'affiche quand la TVA est activée sans cookie de bypass
- [x] Le lien "Réactiver temporairement" redirige vers `/admin/caisse` et pose le cookie
- [x] La caisse complète (ajout article → validation vente) fonctionne via le JS existant
- [x] Après validation de vente, redirection vers `/admin/caisse`
- [x] "Vider le panier" vide le panier et redirige vers `/admin/caisse?cart_id=X`
- [ ] "Nouveau panier" et liens des autres paniers utilisent `/admin/caisse`

Closes #512 (point 1/8)