### PR TITLE
Limit order postal code length

### DIFF
--- a/controllers/common/php/order_delivery.php
+++ b/controllers/common/php/order_delivery.php
@@ -685,7 +685,7 @@ return function (
                     Code postal
                     <span class="required-field-indicator">*</span>
                 </label>
-                <input type="text" name="order_postalcode" id="order_postalcode" value="' . $orderEntity->get('postalcode') . '" class="order-delivery-form__input" required />
+                <input type="text" name="order_postalcode" id="order_postalcode" value="' . $orderEntity->get('postalcode') . '" class="order-delivery-form__input" maxlength="16" required />
             </div>
 
             <div class="order-delivery-form__field order-delivery-form__field--half">

--- a/src/Biblys/Legacy/OrderDeliveryHelpers.php
+++ b/src/Biblys/Legacy/OrderDeliveryHelpers.php
@@ -85,6 +85,12 @@ class OrderDeliveryHelpers
             );
         }
 
+        if (strlen((string) $request->request->get('order_postalcode')) > 16) {
+            throw new OrderDetailsValidationException(
+                'Le champ &laquo;&nbsp;Code Postal&nbsp;&raquo; ne doit pas d&eacute;passer 16 caract&egrave;res.'
+            );
+        }
+
         if (empty($request->request->get('order_city'))) {
             throw new OrderDetailsValidationException(
                 'Le champ &laquo;&nbsp;Ville&nbsp;&raquo; est obligatoire !'

--- a/tests/Biblys/Legacy/OrderDeliveryHelpersTest.php
+++ b/tests/Biblys/Legacy/OrderDeliveryHelpersTest.php
@@ -127,6 +127,42 @@ class OrderDeliveryHelpersTest extends TestCase
      * @throws OrderDetailsValidationException
      * @throws Exception
      */
+    public function testValidateOrderDetailsThrowsWhenPostalCodeIsTooLong()
+    {
+        // given
+        $request = new Request();
+        $request->request->set("order_firstname", "Victor");
+        $request->request->set("order_lastname", "Hugo");
+        $request->request->set("order_address1", "Place des Vosges");
+        $request->request->set("order_postalcode", "12345678901234567");
+        $request->request->set("order_city", "Paris");
+        $request->request->set("country_id", 1);
+        $request->request->set("order_email", "victor.hugo@biblys.fr");
+        $request->request->set("cgv_checkbox", 1);
+        $request->request->set("order_phone", "");
+
+        $currentSite = Mockery::mock(CurrentSite::class);
+        $currentSite->shouldReceive("getOption")
+            ->with("order_phone_required")
+            ->andReturn(0);
+
+        $cart = Mockery::mock(Cart::class);
+        $cart->shouldReceive("containsDownloadableArticles")->andReturn(false);
+
+        // then
+        $this->expectException(OrderDetailsValidationException::class);
+        $this->expectExceptionMessage(
+            "Le champ &laquo;&nbsp;Code Postal&nbsp;&raquo; ne doit pas d&eacute;passer 16 caract&egrave;res."
+        );
+
+        // when
+        OrderDeliveryHelpers::validateOrderDetails($request, $currentSite, $cart);
+    }
+
+    /**
+     * @throws OrderDetailsValidationException
+     * @throws Exception
+     */
     public function testValidateOrderDetailsSucceedsWhenPhoneIsRequiredAndPresent()
     {
         // given


### PR DESCRIPTION
Fixes #82

## Summary
- add `maxlength="16"` to the order delivery postal code field
- reject order delivery details when `order_postalcode` is longer than 16 characters
- add a regression test for the backend postal code length validation

## Tests
- `php -l src/Biblys/Legacy/OrderDeliveryHelpers.php`
- `php -l controllers/common/php/order_delivery.php`
- `php -l tests/Biblys/Legacy/OrderDeliveryHelpersTest.php`
- `git diff --check`
- PHP smoke test for `OrderDeliveryHelpers::validateOrderDetails()` with a 17-character postal code