### PR TITLE
Correctif 3.13.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Historique des modifications
 
+## 3.13.2 (24 juin 2026)
+
+### Corrections
+
+- Une injection SQL dans la page d'administration des fournisseurs a été corrigée.
+
 ## 3.13.1 (16 juin 2026)
 
 ### Corrections

--- a/controllers/common/php/adm_supplier.php
+++ b/controllers/common/php/adm_supplier.php
@@ -62,9 +62,11 @@ if ($request->getMethod() === 'POST') {
 
 	// Updated linked articles
 	$params['articles_to_update'] = 0;
-	$articles = $_SQL->query("SELECT `articles`.`article_id` FROM `articles` JOIN `publishers` USING(`publisher_id`) JOIN `links` USING(`publisher_id`) WHERE `supplier_id` = '".$_POST["supplier_id"]."'");
+	$articles = $_SQL->prepare("SELECT `articles`.`article_id` FROM `articles` JOIN `publishers` USING(`publisher_id`) JOIN `links` USING(`publisher_id`) WHERE `supplier_id` = :supplier_id");
+	$articles->execute(['supplier_id' => $_POST["supplier_id"]]);
 	while ($a = $articles->fetch(PDO::FETCH_ASSOC)) {
-		$_SQL->exec("UPDATE `articles` SET `article_keywords_generated` = NULL, `article_updated` = NOW() WHERE `article_id` = ".$a["article_id"]." LIMIT 1");
+		$updateStmt = $_SQL->prepare("UPDATE `articles` SET `article_keywords_generated` = NULL, `article_updated` = NOW() WHERE `article_id` = :article_id LIMIT 1");
+		$updateStmt->execute(['article_id' => $a["article_id"]]);
 		$params['articles_to_update']++;
 	}
 

--- a/inc/constants.php
+++ b/inc/constants.php
@@ -15,4 +15,4 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-const BIBLYS_VERSION = "3.13.1-dev";
+const BIBLYS_VERSION = "3.13.2";


### PR DESCRIPTION
## Résumé

- Correction d'une injection SQL dans `controllers/common/php/adm_supplier.php` : remplacement des concaténations directes de `$_POST["supplier_id"]` et `$a["article_id"]` par des requêtes préparées avec paramètres liés
- Ajout de l'entrée `3.13.2` dans le CHANGELOG

Closes #518

## Plan de test

- [ ] Vérifier qu'une modification de fournisseur fonctionne normalement avec un `supplier_id` valide
- [ ] Vérifier qu'une valeur malveillante (ex. `1' OR '1'='1`) ne provoque pas de comportement inattendu
- [ ] Vérifier que les articles liés sont bien mis à jour après la sauvegarde