### PR TITLE
Correctif 3.13.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Historique des modifications
 
+## 3.13.3 (DEV)
+
+- Les commandes contenant uniquement un abonnement n'étaient plus marquées 
+  comme expédiée automatiquement. C'est corrigé.
+
 ## 3.13.2 (24 juin 2026)
 
 ### Corrections

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Historique des modifications
 
-## 3.13.3 (DEV)
+## 3.13.3 (1er juillet 2026)
 
 - Les commandes contenant uniquement un abonnement n'étaient plus marquées 
   comme expédiée automatiquement. C'est corrigé.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 - Les commandes contenant uniquement un abonnement n'étaient plus marquées 
   comme expédiée automatiquement. C'est corrigé.
+- Le fichier d'export pour Mondial Relay indiquait toujours la France comme
+  pays du point relais de livraison, même pour une commande expédiée vers un
+  point relais d'un autre pays (ex. Belgique). C'est corrigé.
 
 ## 3.13.2 (24 juin 2026)
 

--- a/inc/constants.php
+++ b/inc/constants.php
@@ -15,4 +15,4 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-const BIBLYS_VERSION = "3.13.2";
+const BIBLYS_VERSION = "3.13.3-dev";

--- a/inc/constants.php
+++ b/inc/constants.php
@@ -15,4 +15,4 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-const BIBLYS_VERSION = "3.13.3-dev";
+const BIBLYS_VERSION = "3.13.3";

--- a/src/ApiBundle/Controller/OrderController.php
+++ b/src/ApiBundle/Controller/OrderController.php
@@ -112,7 +112,7 @@ class OrderController extends Controller
                 "FR",                                                            # O - Code Pays Collecte
                 "R",                                                             # P - Type Livraison (R = Relais)
                 $order->getMondialRelayPickupPointCode(),                        # Q - Id Relais de Livraison
-                "FR",                                                            # R - Code Pays du Relais de Livraison (FR = France)
+                $order->getCountry()->getCode(),                                 # R - Code Pays du Relais de Livraison
                 "24R",                                                           # S - Mode de livraison (24R = Point Relais)
                 "FR",                                                            # T - Code Langue du Destinataire
                 "1",                                                             # U - Nombre de colis

--- a/src/Usecase/MarkOrderAsPaidUsecase.php
+++ b/src/Usecase/MarkOrderAsPaidUsecase.php
@@ -111,11 +111,11 @@ class MarkOrderAsPaidUsecase
                     items: $downloadableItems,
                     sendEmail: true,
                 );
+            }
 
-                if (!$order->containsPhysicalArticles()) {
-                    $order->setShippingDate(new DateTime());
-                    $order->save();
-                }
+            if (!$order->containsPhysicalArticles()) {
+                $order->setShippingDate(new DateTime());
+                $order->save();
             }
 
             $con->commit();

--- a/tests/ApiBundle/Controller/OrderControllerTest.php
+++ b/tests/ApiBundle/Controller/OrderControllerTest.php
@@ -57,12 +57,14 @@ class OrderControllerTest extends TestCase
 
         $site = ModelFactory::createSite();
         $shippingFee = ModelFactory::createShippingOption(type: "mondial-relay");
+        $country = ModelFactory::createCountry(name: "Belgique", code: "BE");
         $order = ModelFactory::createOrder(
             shippingOption: $shippingFee,
             firstName: "Éléonore",
             lastName: "Champollion",
             postalCode: "02330",
             city: "Plymouth",
+            country: $country,
             phone: "+33.6-01 02/03;04",
             mondialRelayPickupPointCode: "123456",
         );
@@ -98,7 +100,7 @@ class OrderControllerTest extends TestCase
             "APPARTEMENT 2",           # F - Adresse du destinataire (Complément d'adresse) (F)
             "PLYMOUTH",                # G - Ville du destinataire (O)
             "02330",                   # H - Code Postal du destinataire (O)
-            "FR",                      # I - Pays du destinataire (O)
+            "BE",                      # I - Pays du destinataire (O)
             "+33601020304",            # J - Téléphone fixe du destinataire (F)
             "",                        # K - Téléphone cellulaire (F)
             "SILAS.COADE@PARONYMIE.FR", # L - Adresse e-mail du destinataire (F)
@@ -107,7 +109,7 @@ class OrderControllerTest extends TestCase
             "FR",                      # O - Code Pays Collecte
             "R",                       # P - Type Livraison (R = Relais)
             "123456",                  # Q - Id Relais de Livraison
-            "FR",                      # R - Code Pays du Relais de Livraison (FR = France)
+            "BE",                      # R - Code Pays du Relais de Livraison
             "24R",                     # S - Mode de livraison (24R = Point Relais)
             "FR",                      # T - Code Langue du Destinataire
             "1",                       # U - Nombre de colis

--- a/tests/Usecase/MarkOrderAsPaidUsecaseTest.php
+++ b/tests/Usecase/MarkOrderAsPaidUsecaseTest.php
@@ -156,6 +156,55 @@ class MarkOrderAsPaidUsecaseTest extends TestCase
      * @throws TransportExceptionInterface
      * @throws \Exception
      */
+    public function testMarkingAsPaidOrderWithSubscriptionArticle(): void
+    {
+        // given
+        $subscriptionArticle = ModelFactory::createArticle(typeId: ArticleType::SUBSCRIPTION);
+        $stockItem = ModelFactory::createStockItem(article: $subscriptionArticle);
+        $order = ModelFactory::createOrder(
+            slug: "order-sub",
+            email: "payer@paronymie.fr",
+        );
+        $order->addStockItem($stockItem);
+
+        $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
+        $urlGenerator->expects($this->once())->method("generate")->with(
+            "legacy_order",
+            ["url" => "order-sub"],
+        )->willReturn("https://paronymie.fr/order/order-sub");
+        $templateService = Helpers::getTemplateService();
+        $mailer = $this->createMock(Mailer::class);
+        $mailer->expects($this->once())->method("send");
+
+        $addArticleToUserLibraryUsecase = $this->getMockBuilder(AddArticleToUserLibraryUsecase::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(["execute"])
+            ->getMock();
+        $addArticleToUserLibraryUsecase->expects($this->never())->method("execute");
+
+        $usecase = new MarkOrderAsPaidUsecase(
+            urlGenerator: $urlGenerator,
+            templateService: $templateService,
+            mailer: $mailer,
+            addArticleToUserLibraryUsecase: $addArticleToUserLibraryUsecase,
+        );
+
+        // when
+        $usecase->execute($order, payedAmountInCents: 999, paymentMode: "Carte bancaire");
+
+        // then
+        $order->reload();
+        $this->assertTrue($order->isPaid(), "order is marked as paid");
+        $this->assertTrue($order->isShipped(), "order is automatically marked as shipped");
+    }
+
+    /**
+     * @throws PropelException
+     * @throws InvalidEmailAddressException
+     * @throws Exception
+     * @throws TransportExceptionInterface
+     * @throws \Exception
+     */
     public function testMarkingAsPaidOrderWithBothArticleTypes(): void
     {
         // given


### PR DESCRIPTION
- Les commandes contenant uniquement un abonnement n'étaient plus marquées 
  comme expédiée automatiquement. C'est corrigé.
- Le fichier d'export pour Mondial Relay indiquait toujours la France comme
  pays du point relais de livraison, même pour une commande expédiée vers un
  point relais d'un autre pays (ex. Belgique). C'est corrigé.