### PR TITLE
Caisse : ajout d'un exemplaire via la nouvelle route (point 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Caisse
 
 - La caisse est désormais accessible via la nouvelle URL `/admin/caisse`.
+- L'ajout d'un exemplaire au panier de caisse passe désormais par une route dédiée
+  du nouveau contrôleur Point of Sale.
 
 ### Maintenance
 

--- a/controllers/common/php/adm_checkout.php
+++ b/controllers/common/php/adm_checkout.php
@@ -21,7 +21,7 @@ use Biblys\Legacy\LegacyCodeHelper;
 use Biblys\Service\FlashMessagesService;
 use Biblys\Service\Images\ImagesService;
 use Model\Payment;
-use Usecase\RecordShopPaymentsUsecase;
+use Usecase\RecordPointOfSalePaymentsUsecase;
 use Propel\Runtime\Exception\PropelException;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -76,7 +76,7 @@ return function (
             $_O->hydrateFromCart($order, $cart);
             $order = $_O->update($order);
 
-            $shopPaymentsUsecase = new RecordShopPaymentsUsecase();
+            $shopPaymentsUsecase = new RecordPointOfSalePaymentsUsecase();
             $shopPaymentsUsecase->execute((int) $order->get('order_id'), [
                 Payment::MODE_CASH  => (int) $_POST['cart_cash'],
                 Payment::MODE_CHECK => (int) $_POST['cart_cheque'],

--- a/public/common/js/biblys-admin.js
+++ b/public/common/js/biblys-admin.js
@@ -434,18 +434,30 @@ function reloadAdminEvents() {
 
   // Ajouter un exemplaire au panier
   async function add_to_cart(cartId, stockId) {
-    const response = await fetch(`/pages/adm_checkout?cart_id=${cartId}&add=stock&id=${stockId}&_=${Date.now()}`, {
+    const response = await fetch(`/admin/pos/carts/${cartId}/items`, {
+      method: 'POST',
       headers: {
         'Accept': 'application/json',
-      }
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: `stock_id=${stockId}`,
     });
-    const json = await response.json();
 
     $('#checkout_add_input').removeClass('loading');
 
-    if (json.error) {
-      window._alert(json.error);
+    if (!response.ok) {
+      let message = "L'exemplaire n'a pas pu être ajouté au panier.";
+      try {
+        const error = await response.json();
+        if (error && error.message) message = error.message;
+      } catch (e) {
+        // réponse d'erreur non-JSON : on conserve le message générique
+      }
+      window._alert(message);
+      return;
     }
+
+    const json = await response.json();
 
     $('#checkout_add_results').html('');
     $('#checkout_add_input').val('');

--- a/src/AppBundle/Controller/PointOfSaleController.php
+++ b/src/AppBundle/Controller/PointOfSaleController.php
@@ -18,6 +18,8 @@
 
 namespace AppBundle\Controller;
 
+use Biblys\Exception\CannotAddStockItemToCartException;
+use Biblys\Service\BodyParamsService;
 use Biblys\Service\CurrentSite;
 use Biblys\Service\CurrentUser;
 use Biblys\Service\FlashMessagesService;
@@ -31,11 +33,14 @@ use Framework\Controller;
 use Model\UserQuery;
 use Propel\Runtime\Exception\PropelException;
 use Symfony\Component\HttpFoundation\Cookie;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Generator\UrlGenerator;
+use Usecase\AddStockItemToPointOfSaleCartUsecase;
 use Twig\Error\LoaderError;
 use Twig\Error\RuntimeError;
 use Twig\Error\SyntaxError;
@@ -130,24 +135,24 @@ class PointOfSaleController extends Controller
         }
         $cm->updateFromStock($cart);
 
-        $shopCarts = [];
-        foreach ($cm->getAll() as $shopCart) {
-            if ($shopCart->get('cart_count') > 0 && $shopCart->get('cart_type') === 'shop') {
+        $pointOfSaleCarts = [];
+        foreach ($cm->getAll() as $pointOfSaleCart) {
+            if ($pointOfSaleCart->get('cart_count') > 0 && $pointOfSaleCart->get('cart_type') === 'shop') {
                 $cartSeller = null;
-                if ($shopCart->has('seller_user_id')) {
-                    $cartSeller = UserQuery::create()->findPk($shopCart->get('seller_user_id'));
-                } elseif ($shopCart->has('seller_id')) {
-                    $cartSeller = UserQuery::create()->findPk($shopCart->get('seller_id'));
+                if ($pointOfSaleCart->has('seller_user_id')) {
+                    $cartSeller = UserQuery::create()->findPk($pointOfSaleCart->get('seller_user_id'));
+                } elseif ($pointOfSaleCart->has('seller_id')) {
+                    $cartSeller = UserQuery::create()->findPk($pointOfSaleCart->get('seller_id'));
                 }
-                $shopCarts[] = [
-                    'id' => $shopCart->get('cart_id'),
-                    'title' => $shopCart->get('cart_title'),
+                $pointOfSaleCarts[] = [
+                    'id' => $pointOfSaleCart->get('cart_id'),
+                    'title' => $pointOfSaleCart->get('cart_title'),
                     'seller_email' => $cartSeller?->getEmail() ?? "Vendeur inconnu",
-                    'customer_name' => $shopCart->has('customer')
-                        ? $shopCart->get('customer')->get('first_name') . ' ' . $shopCart->get('customer')->get('last_name')
+                    'customer_name' => $pointOfSaleCart->has('customer')
+                        ? $pointOfSaleCart->get('customer')->get('first_name') . ' ' . $pointOfSaleCart->get('customer')->get('last_name')
                         : null,
-                    'count' => $shopCart->get('cart_count'),
-                    'amount' => $shopCart->get('cart_amount'),
+                    'count' => $pointOfSaleCart->get('cart_count'),
+                    'amount' => $pointOfSaleCart->get('cart_amount'),
                 ];
             }
         }
@@ -161,7 +166,52 @@ class PointOfSaleController extends Controller
             'cart_total' => $cartTotal,
             'seller' => $seller,
             'customer' => $customer,
-            'shop_carts' => $shopCarts,
+            'point_of_sale_carts' => $pointOfSaleCarts,
         ], isPrivate: true);
+    }
+
+    /**
+     * @throws PropelException
+     */
+    public function addItemAction(
+        Request           $request,
+        CurrentUser       $currentUser,
+        ImagesService     $imagesService,
+        BodyParamsService $bodyParams,
+        int               $cartId,
+    ): Response
+    {
+        $currentUser->authAdmin();
+
+        $cm = new CartManager();
+        $cart = $cm->getById($cartId);
+        if (!$cart) {
+            throw new NotFoundHttpException("Panier $cartId introuvable");
+        }
+
+        $bodyParams->parse(["stock_id" => ["type" => "numeric", "default" => 0]]);
+        $stockItemId = $bodyParams->getInteger("stock_id");
+
+        try {
+            $usecase = new AddStockItemToPointOfSaleCartUsecase();
+            $usecase->execute($cartId, $stockItemId);
+        } catch (CannotAddStockItemToCartException $exception) {
+            throw new BadRequestHttpException($exception->getMessage(), $exception);
+        }
+
+        if (in_array("application/json", $request->getAcceptableContentTypes())) {
+            $line = "";
+            foreach ($cm->getStock($cart) as $stockItem) {
+                if ($stockItem->get("id") == $stockItemId) {
+                    $line = $cart->getLine($imagesService, $stockItem);
+                }
+            }
+            return new JsonResponse([
+                "success" => "L'exemplaire n° $stockItemId a été ajouté au panier.",
+                "line" => $line,
+            ]);
+        }
+
+        return new RedirectResponse("/admin/caisse?cart_id=$cartId");
     }
 }

--- a/src/AppBundle/Resources/views/PointOfSale/index.html.twig
+++ b/src/AppBundle/Resources/views/PointOfSale/index.html.twig
@@ -222,17 +222,17 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
         </tr>
       </thead>
       <tbody>
-        {% for shopCart in shop_carts %}
+        {% for pointOfSaleCart in point_of_sale_carts %}
           <tr>
-            <td><a href="/admin/caisse?cart_id={{ shopCart.id }}">{{ shopCart.title }}</a></td>
-            <td>{{ shopCart.seller_email }}</td>
-            <td>{{ shopCart.customer_name }}</td>
-            <td class="right">{{ shopCart.count }}</td>
-            <td class="right">{{ shopCart.amount|currency(true)|raw }}</td>
+            <td><a href="/admin/caisse?cart_id={{ pointOfSaleCart.id }}">{{ pointOfSaleCart.title }}</a></td>
+            <td>{{ pointOfSaleCart.seller_email }}</td>
+            <td>{{ pointOfSaleCart.customer_name }}</td>
+            <td class="right">{{ pointOfSaleCart.count }}</td>
+            <td class="right">{{ pointOfSaleCart.amount|currency(true)|raw }}</td>
             <td class="center">
-              <a href="/pages/adm_checkout?cart_id={{ shopCart.id }}&vacuum_cart=1"
-                 data-confirm="Voulez-vous vraiment VIDER ce panier et remettre {{ shopCart.count }} exemplaire{% if shopCart.count > 1 %}s{% endif %} en vente ?"
-                 title="Vider le panier et remettre {{ shopCart.count }} exemplaire{% if shopCart.count > 1 %}s{% endif %} en vente."
+              <a href="/pages/adm_checkout?cart_id={{ pointOfSaleCart.id }}&vacuum_cart=1"
+                 data-confirm="Voulez-vous vraiment VIDER ce panier et remettre {{ pointOfSaleCart.count }} exemplaire{% if pointOfSaleCart.count > 1 %}s{% endif %} en vente ?"
+                 title="Vider le panier et remettre {{ pointOfSaleCart.count }} exemplaire{% if pointOfSaleCart.count > 1 %}s{% endif %} en vente."
                  class="btn btn-danger btn-sm">
                 <i class="fa fa-trash-can"></i>
               </a>

--- a/src/AppBundle/routes.yml
+++ b/src/AppBundle/routes.yml
@@ -416,6 +416,13 @@ point_of_sale_index:
   controller: AppBundle\Controller\PointOfSaleController::indexAction
   methods: [GET]
 
+point_of_sale_add_item:
+  path: /admin/pos/carts/{cartId}/items
+  controller: AppBundle\Controller\PointOfSaleController::addItemAction
+  methods: [POST]
+  requirements:
+    cartId: \d+
+
 # Orders
 
 order_index:

--- a/src/Usecase/AddStockItemToPointOfSaleCartUsecase.php
+++ b/src/Usecase/AddStockItemToPointOfSaleCartUsecase.php
@@ -1,0 +1,42 @@
+<?php
+/*
+ * Copyright (C) 2026 Clément Latzarus
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+
+namespace Usecase;
+
+use Biblys\Exception\CannotAddStockItemToCartException;
+use CartManager;
+use Exception;
+use Propel\Runtime\Exception\PropelException;
+
+class AddStockItemToPointOfSaleCartUsecase
+{
+    /**
+     * Ajoute un exemplaire (stock item) à un panier caisse et met à jour ses totaux.
+     *
+     * @throws CannotAddStockItemToCartException si l'exemplaire est déjà réservé dans un panier caisse
+     * @throws PropelException
+     * @throws Exception si l'exemplaire est introuvable ou indisponible
+     */
+    public function execute(int $cartId, int $stockItemId): void
+    {
+        $cm = new CartManager();
+        $cart = $cm->getById($cartId);
+        $cm->addStock($cart, $stockItemId);
+        $cm->updateFromStock($cart);
+    }
+}

--- a/src/Usecase/RecordPointOfSalePaymentsUsecase.php
+++ b/src/Usecase/RecordPointOfSalePaymentsUsecase.php
@@ -21,7 +21,7 @@ use DateTime;
 use Model\Payment;
 use Propel\Runtime\Exception\PropelException;
 
-class RecordShopPaymentsUsecase
+class RecordPointOfSalePaymentsUsecase
 {
     /**
      * @param int $orderId

--- a/tests/AppBundle/Controller/PointOfSaleControllerTest.php
+++ b/tests/AppBundle/Controller/PointOfSaleControllerTest.php
@@ -18,6 +18,7 @@
 
 namespace AppBundle\Controller;
 
+use Biblys\Service\BodyParamsService;
 use Biblys\Service\CurrentSite;
 use Biblys\Service\CurrentUser;
 use Biblys\Service\FlashMessagesService;
@@ -208,6 +209,138 @@ class PointOfSaleControllerTest extends TestCase
             Helpers::getTemplateService(),
             Mockery::mock(UrlGenerator::class),
             new QueryParamsService($request),
+        );
+    }
+
+    /**
+     * @throws PropelException
+     */
+    public function testAddItemActionAddsStockAndReturnsJsonLine(): void
+    {
+        // given
+        $controller = $this->_getController();
+        $cart = ModelFactory::createCart();
+        $cart->setType("shop");
+        $cart->save();
+        $stock = ModelFactory::createStockItem(sellingPrice: 1899);
+
+        $request = new Request(request: ['stock_id' => $stock->getId()]);
+        $request->headers->set('Accept', 'application/json');
+
+        $currentUser = Mockery::mock(CurrentUser::class);
+        $currentUser->expects("authAdmin");
+
+        $imagesService = Mockery::mock(ImagesService::class);
+        $imagesService->shouldReceive("getImageUrlFor")->andReturn(null);
+
+        // when
+        $response = $controller->addItemAction(
+            $request,
+            $currentUser,
+            $imagesService,
+            new BodyParamsService($request),
+            $cart->getId(),
+        );
+
+        // then
+        $this->assertEquals(200, $response->getStatusCode());
+        $data = json_decode($response->getContent(), true);
+        $this->assertArrayHasKey('line', $data);
+        $this->assertStringContainsString("stock_" . $stock->getId(), $data['line']);
+        $stock->reload();
+        $this->assertEquals($cart->getId(), $stock->getCartId());
+    }
+
+    /**
+     * @throws PropelException
+     */
+    public function testAddItemActionRedirectsWhenNotAcceptingJson(): void
+    {
+        // given
+        $controller = $this->_getController();
+        $cart = ModelFactory::createCart();
+        $cart->setType("shop");
+        $cart->save();
+        $stock = ModelFactory::createStockItem();
+
+        $request = new Request(request: ['stock_id' => $stock->getId()]);
+
+        $currentUser = Mockery::mock(CurrentUser::class);
+        $currentUser->expects("authAdmin");
+
+        // when
+        $response = $controller->addItemAction(
+            $request,
+            $currentUser,
+            Mockery::mock(ImagesService::class),
+            new BodyParamsService($request),
+            $cart->getId(),
+        );
+
+        // then
+        $this->assertEquals(302, $response->getStatusCode());
+        $this->assertEquals(
+            "/admin/caisse?cart_id=" . $cart->getId(),
+            $response->headers->get("Location")
+        );
+    }
+
+    /**
+     * @throws PropelException
+     */
+    public function testAddItemActionReturns404WhenCartNotFound(): void
+    {
+        // given
+        $controller = $this->_getController();
+        $stock = ModelFactory::createStockItem();
+        $request = new Request(request: ['stock_id' => $stock->getId()]);
+
+        $currentUser = Mockery::mock(CurrentUser::class);
+        $currentUser->expects("authAdmin");
+
+        // then
+        $this->expectException(\Symfony\Component\HttpKernel\Exception\NotFoundHttpException::class);
+
+        // when
+        $controller->addItemAction(
+            $request,
+            $currentUser,
+            Mockery::mock(ImagesService::class),
+            new BodyParamsService($request),
+            99999,
+        );
+    }
+
+    /**
+     * @throws PropelException
+     */
+    public function testAddItemActionReturns400WhenStockAlreadyInAnotherPointOfSaleCart(): void
+    {
+        // given
+        $controller = $this->_getController();
+        $firstCart = ModelFactory::createCart();
+        $firstCart->setType("shop");
+        $firstCart->save();
+        $secondCart = ModelFactory::createCart();
+        $secondCart->setType("shop");
+        $secondCart->save();
+        $stock = ModelFactory::createStockItem(cart: $firstCart);
+
+        $request = new Request(request: ['stock_id' => $stock->getId()]);
+
+        $currentUser = Mockery::mock(CurrentUser::class);
+        $currentUser->expects("authAdmin");
+
+        // then
+        $this->expectException(\Symfony\Component\HttpKernel\Exception\BadRequestHttpException::class);
+
+        // when
+        $controller->addItemAction(
+            $request,
+            $currentUser,
+            Mockery::mock(ImagesService::class),
+            new BodyParamsService($request),
+            $secondCart->getId(),
         );
     }
 }

--- a/tests/Usecase/AddStockItemToPointOfSaleCartUsecaseTest.php
+++ b/tests/Usecase/AddStockItemToPointOfSaleCartUsecaseTest.php
@@ -1,0 +1,73 @@
+<?php
+/*
+ * Copyright (C) 2026 Clément Latzarus
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+
+namespace Usecase;
+
+use Biblys\Exception\CannotAddStockItemToCartException;
+use Biblys\Test\ModelFactory;
+use PHPUnit\Framework\TestCase;
+use Propel\Runtime\Exception\PropelException;
+
+class AddStockItemToPointOfSaleCartUsecaseTest extends TestCase
+{
+    /**
+     * @throws PropelException
+     */
+    public function testAddsStockItemToPointOfSaleCart(): void
+    {
+        // given
+        $cart = ModelFactory::createCart();
+        $cart->setType("shop");
+        $cart->save();
+        $stock = ModelFactory::createStockItem(sellingPrice: 1899);
+        $usecase = new AddStockItemToPointOfSaleCartUsecase();
+
+        // when
+        $usecase->execute($cart->getId(), $stock->getId());
+
+        // then
+        $stock->reload();
+        $this->assertEquals($cart->getId(), $stock->getCartId());
+        $cart->reload();
+        $this->assertEquals(1, $cart->getCount());
+        $this->assertEquals(1899, $cart->getAmount());
+    }
+
+    /**
+     * @throws PropelException
+     */
+    public function testThrowsWhenStockItemAlreadyInAnotherPointOfSaleCart(): void
+    {
+        // given
+        $firstCart = ModelFactory::createCart();
+        $firstCart->setType("shop");
+        $firstCart->save();
+        $secondCart = ModelFactory::createCart();
+        $secondCart->setType("shop");
+        $secondCart->save();
+        $stock = ModelFactory::createStockItem(cart: $firstCart);
+
+        $usecase = new AddStockItemToPointOfSaleCartUsecase();
+
+        // then
+        $this->expectException(CannotAddStockItemToCartException::class);
+
+        // when
+        $usecase->execute($secondCart->getId(), $stock->getId());
+    }
+}

--- a/tests/Usecase/RecordPointOfSalePaymentsUsecaseTest.php
+++ b/tests/Usecase/RecordPointOfSalePaymentsUsecaseTest.php
@@ -24,7 +24,7 @@ use Model\PaymentQuery;
 use PHPUnit\Framework\TestCase;
 use Propel\Runtime\Exception\PropelException;
 
-class RecordShopPaymentsUsecaseTest extends TestCase
+class RecordPointOfSalePaymentsUsecaseTest extends TestCase
 {
     /**
      * @throws PropelException
@@ -33,7 +33,7 @@ class RecordShopPaymentsUsecaseTest extends TestCase
     {
         // given
         $order = ModelFactory::createOrder();
-        $usecase = new RecordShopPaymentsUsecase();
+        $usecase = new RecordPointOfSalePaymentsUsecase();
 
         // when
         $usecase->execute($order->getId(), [Payment::MODE_CASH => 1000]);
@@ -53,7 +53,7 @@ class RecordShopPaymentsUsecaseTest extends TestCase
     {
         // given
         $order = ModelFactory::createOrder();
-        $usecase = new RecordShopPaymentsUsecase();
+        $usecase = new RecordPointOfSalePaymentsUsecase();
 
         // when
         $usecase->execute($order->getId(), [
@@ -73,7 +73,7 @@ class RecordShopPaymentsUsecaseTest extends TestCase
     {
         // given
         $order = ModelFactory::createOrder();
-        $usecase = new RecordShopPaymentsUsecase();
+        $usecase = new RecordPointOfSalePaymentsUsecase();
 
         // when
         $usecase->execute($order->getId(), [


### PR DESCRIPTION
## Contexte

Point 2 du plan de migration de la caisse vers l'architecture « Point of Sale » (#512) : migration de l'action « ajouter un exemplaire » depuis le legacy `controllers/common/php/adm_checkout.php` vers le `PointOfSaleController` moderne.

## Changements

- **Usecase** `AddStockItemToPointOfSaleCartUsecase` : encapsule l'ajout d'un exemplaire au panier caisse (managers legacy conservés à l'intérieur, conforme à la spec).
- **Action** `addItemAction` — `POST /admin/pos/carts/{id}/items` :
  - réponse **JSON** avec la ligne rendue si `Accept: application/json`, sinon **redirection** vers `/admin/caisse` ;
  - `CannotAddStockItemToCartException` (exemplaire déjà réservé) → **400** ; panier introuvable → **404**.
- **Front** : `add_to_cart()` (`biblys-admin.js`) pointe désormais vers la nouvelle route en POST. L'ancienne URL `/pages/adm_checkout` reste active (supprimée en PR 8).
- **Terminologie** : renommage « Shop » → « PointOfSale » dans la couche caisse (usecases, variables, template). Les valeurs persistées `cart_type="shop"` / `order_type="shop"` sont **inchangées**.
- **Tests** : utilisation de `ModelFactory` (Propel) plutôt qu'`EntityFactory` (legacy) pour les fixtures et les assertions.

## Plan de test

- [ ] `composer test` passe (1205 tests)
- [ ] `POST /admin/pos/carts/{id}/items` ajoute un exemplaire et renvoie la ligne en JSON
- [ ] Un exemplaire déjà réservé dans un autre panier caisse → **400**
- [ ] Panier introuvable → **404**
- [ ] Requête non-AJAX → redirection vers `/admin/caisse`
- [ ] L'ancienne URL `/pages/adm_checkout` continue de fonctionner
- [ ] Caisse de bout en bout : recherche d'article → ajout au panier

---

Point 2/8 de #512.
