### PR TITLE
Implémenter une chaîne de signatures des paiements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Historique des modifications
 
+## 3.15.0 (DEV)
+
+### Conformité NF525
+
+- Chaque paiement enregistré est désormais signé par un hash chaîné au paiement
+  précédent (chaîne de signatures). L'historique des paiements devient ainsi
+  inaltérable : toute modification a posteriori du montant, de la date ou de la
+  commande d'un paiement est détectable.
+
 ## 3.14.0 (4 juillet 2026)
 
 ### Confirmité NF525

--- a/generated-migrations/PropelMigration_1783278001.php
+++ b/generated-migrations/PropelMigration_1783278001.php
@@ -1,0 +1,159 @@
+<?php
+
+/*
+ * Copyright (C) 2026 Clément Latzarus
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+use DateTime;
+use Model\PaymentHash;
+use Propel\Generator\Manager\MigrationManager;
+
+/**
+ * Data object containing the SQL and PHP code to migrate the database
+ * up to version 1783278001.
+ * Generated on 2026-07-05 19:00:01 by clement */
+class PropelMigration_1783278001{
+    /**
+     * @var string
+     */
+    public $comment = '';
+
+    /**
+     * @param \Propel\Generator\Manager\MigrationManager $manager
+     *
+     * @return null|false|void
+     */
+    public function preUp(MigrationManager $manager)
+    {
+        // add the pre-migration code here
+    }
+
+    /**
+     * @param \Propel\Generator\Manager\MigrationManager $manager
+     *
+     * @return null|false|void
+     */
+    public function postUp(MigrationManager $manager)
+    {
+        $con = $manager->getAdapterConnection('default');
+
+        $rows = $con
+            ->query("SELECT payment_id, payment_amount, payment_created, order_id
+                     FROM payments ORDER BY payment_id")
+            ->fetchAll(\PDO::FETCH_ASSOC);
+
+        $update = $con->prepare(
+            "UPDATE payments SET payment_hash = :hash, payment_hash_version = 1
+             WHERE payment_id = :id"
+        );
+
+        $previousHash = "";
+        foreach ($rows as $row) {
+            $createdAt = $row['payment_created'] !== null
+                ? new DateTime($row['payment_created'])
+                : null;
+
+            $hash = PaymentHash::compute(
+                1, // version PINÉE — jamais CURRENT_VERSION dans une migration
+                $row['payment_amount'] !== null ? (int) $row['payment_amount'] : null,
+                $createdAt,
+                $row['order_id'] !== null ? (int) $row['order_id'] : null,
+                $previousHash
+            );
+
+            $update->execute([':hash' => $hash, ':id' => $row['payment_id']]);
+            $previousHash = $hash;
+        }
+    }
+
+    /**
+     * @param \Propel\Generator\Manager\MigrationManager $manager
+     *
+     * @return null|false|void
+     */
+    public function preDown(MigrationManager $manager)
+    {
+        // add the pre-migration code here
+    }
+
+    /**
+     * @param \Propel\Generator\Manager\MigrationManager $manager
+     *
+     * @return null|false|void
+     */
+    public function postDown(MigrationManager $manager)
+    {
+        // add the post-migration code here
+    }
+
+    /**
+     * Get the SQL statements for the Up migration
+     *
+     * @return array list of the SQL strings to execute for the Up migration
+     *               the keys being the datasources
+     */
+    public function getUpSQL(): array
+    {
+        $connection_default = <<< 'EOT'
+
+# This is a fix for InnoDB in MySQL >= 4.1.x
+# It "suspends judgement" for fkey relationships until are tables are set.
+SET FOREIGN_KEY_CHECKS = 0;
+
+ALTER TABLE `payments`
+
+  ADD `payment_hash` VARCHAR(64) AFTER `payment_original_id`,
+
+  ADD `payment_hash_version` TINYINT DEFAULT 1 AFTER `payment_hash`;
+
+# This restores the fkey checks, after having unset them earlier
+SET FOREIGN_KEY_CHECKS = 1;
+EOT;
+
+        return [
+            'default' => $connection_default,
+        ];
+    }
+
+    /**
+     * Get the SQL statements for the Down migration
+     *
+     * @return array list of the SQL strings to execute for the Down migration
+     *               the keys being the datasources
+     */
+    public function getDownSQL(): array
+    {
+        $connection_default = <<< 'EOT'
+
+# This is a fix for InnoDB in MySQL >= 4.1.x
+# It "suspends judgement" for fkey relationships until are tables are set.
+SET FOREIGN_KEY_CHECKS = 0;
+
+ALTER TABLE `payments`
+
+  DROP `payment_hash`,
+
+  DROP `payment_hash_version`;
+
+# This restores the fkey checks, after having unset them earlier
+SET FOREIGN_KEY_CHECKS = 1;
+EOT;
+
+        return [
+            'default' => $connection_default,
+        ];
+    }
+
+}

--- a/schema.xml
+++ b/schema.xml
@@ -947,6 +947,8 @@
     <column name="payment_updated" phpName="UpdatedAt" type="TIMESTAMP"/>
     <column name="payment_refunded_at" phpName="RefundedAt" type="TIMESTAMP"/>
     <column name="payment_original_id" phpName="OriginalId" type="INTEGER"/>
+    <column name="payment_hash" phpName="Hash" type="VARCHAR" size="64"/>
+    <column name="payment_hash_version" phpName="HashVersion" type="TINYINT" default="1"/>
     <behavior name="timestampable">
       <parameter name="create_column" value="payment_created" />
       <parameter name="update_column" value="payment_updated" />

--- a/src/Model/Base/Payment.php
+++ b/src/Model/Base/Payment.php
@@ -154,6 +154,21 @@ abstract class Payment implements ActiveRecordInterface
     protected $payment_original_id;
 
     /**
+     * The value for the payment_hash field.
+     *
+     * @var        string|null
+     */
+    protected $payment_hash;
+
+    /**
+     * The value for the payment_hash_version field.
+     *
+     * Note: this column has a database default value of: 1
+     * @var        int|null
+     */
+    protected $payment_hash_version;
+
+    /**
      * @var        ChildSite
      */
     protected $aSite;
@@ -191,10 +206,23 @@ abstract class Payment implements ActiveRecordInterface
     protected $paymentsRelatedByIdScheduledForDeletion = null;
 
     /**
+     * Applies default values to this object.
+     * This method should be called from the object's constructor (or
+     * equivalent initialization method).
+     * @see __construct()
+     */
+    public function applyDefaultValues(): void
+    {
+        $this->payment_hash_version = 1;
+    }
+
+    /**
      * Initializes internal state of Model\Base\Payment object.
+     * @see applyDefaults()
      */
     public function __construct()
     {
+        $this->applyDefaultValues();
     }
 
     /**
@@ -499,7 +527,7 @@ abstract class Payment implements ActiveRecordInterface
      *
      * @psalm-return ($format is null ? DateTime|null : string|null)
      */
-    public function getCreatedAt($format = null)
+    public function getCreatedAt(?string $format = null)
     {
         if ($format === null) {
             return $this->payment_created;
@@ -521,7 +549,7 @@ abstract class Payment implements ActiveRecordInterface
      *
      * @psalm-return ($format is null ? DateTime|null : string|null)
      */
-    public function getExecuted($format = null)
+    public function getExecuted(?string $format = null)
     {
         if ($format === null) {
             return $this->payment_executed;
@@ -543,7 +571,7 @@ abstract class Payment implements ActiveRecordInterface
      *
      * @psalm-return ($format is null ? DateTime|null : string|null)
      */
-    public function getUpdatedAt($format = null)
+    public function getUpdatedAt(?string $format = null)
     {
         if ($format === null) {
             return $this->payment_updated;
@@ -565,7 +593,7 @@ abstract class Payment implements ActiveRecordInterface
      *
      * @psalm-return ($format is null ? DateTime|null : string|null)
      */
-    public function getRefundedAt($format = null)
+    public function getRefundedAt(?string $format = null)
     {
         if ($format === null) {
             return $this->payment_refunded_at;
@@ -582,6 +610,26 @@ abstract class Payment implements ActiveRecordInterface
     public function getOriginalId()
     {
         return $this->payment_original_id;
+    }
+
+    /**
+     * Get the [payment_hash] column value.
+     *
+     * @return string|null
+     */
+    public function getHash()
+    {
+        return $this->payment_hash;
+    }
+
+    /**
+     * Get the [payment_hash_version] column value.
+     *
+     * @return int|null
+     */
+    public function getHashVersion()
+    {
+        return $this->payment_hash_version;
     }
 
     /**
@@ -837,6 +885,46 @@ abstract class Payment implements ActiveRecordInterface
     }
 
     /**
+     * Set the value of [payment_hash] column.
+     *
+     * @param string|null $v New value
+     * @return $this The current object (for fluent API support)
+     */
+    public function setHash($v)
+    {
+        if ($v !== null) {
+            $v = (string) $v;
+        }
+
+        if ($this->payment_hash !== $v) {
+            $this->payment_hash = $v;
+            $this->modifiedColumns[PaymentTableMap::COL_PAYMENT_HASH] = true;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Set the value of [payment_hash_version] column.
+     *
+     * @param int|null $v New value
+     * @return $this The current object (for fluent API support)
+     */
+    public function setHashVersion($v)
+    {
+        if ($v !== null) {
+            $v = (int) $v;
+        }
+
+        if ($this->payment_hash_version !== $v) {
+            $this->payment_hash_version = $v;
+            $this->modifiedColumns[PaymentTableMap::COL_PAYMENT_HASH_VERSION] = true;
+        }
+
+        return $this;
+    }
+
+    /**
      * Indicates whether the columns in this object are only set to default values.
      *
      * This method can be used in conjunction with isModified() to indicate whether an object is both
@@ -846,6 +934,10 @@ abstract class Payment implements ActiveRecordInterface
      */
     public function hasOnlyDefaultValues(): bool
     {
+            if ($this->payment_hash_version !== 1) {
+                return false;
+            }
+
         // otherwise, everything was equal, so return TRUE
         return true;
     }
@@ -920,6 +1012,12 @@ abstract class Payment implements ActiveRecordInterface
             $col = $row[TableMap::TYPE_NUM == $indexType ? 11 + $startcol : PaymentTableMap::translateFieldName('OriginalId', TableMap::TYPE_PHPNAME, $indexType)];
             $this->payment_original_id = (null !== $col) ? (int) $col : null;
 
+            $col = $row[TableMap::TYPE_NUM == $indexType ? 12 + $startcol : PaymentTableMap::translateFieldName('Hash', TableMap::TYPE_PHPNAME, $indexType)];
+            $this->payment_hash = (null !== $col) ? (string) $col : null;
+
+            $col = $row[TableMap::TYPE_NUM == $indexType ? 13 + $startcol : PaymentTableMap::translateFieldName('HashVersion', TableMap::TYPE_PHPNAME, $indexType)];
+            $this->payment_hash_version = (null !== $col) ? (int) $col : null;
+
             $this->resetModified();
             $this->setNew(false);
 
@@ -927,7 +1025,7 @@ abstract class Payment implements ActiveRecordInterface
                 $this->ensureConsistency();
             }
 
-            return $startcol + 12; // 12 = PaymentTableMap::NUM_HYDRATE_COLUMNS.
+            return $startcol + 14; // 14 = PaymentTableMap::NUM_HYDRATE_COLUMNS.
 
         } catch (Exception $e) {
             throw new PropelException(sprintf('Error populating %s object', '\\Model\\Payment'), 0, $e);
@@ -1070,19 +1168,18 @@ abstract class Payment implements ActiveRecordInterface
             if ($isInsert) {
                 $ret = $ret && $this->preInsert($con);
                 // timestampable behavior
-                $time = time();
-                $highPrecision = \Propel\Runtime\Util\PropelDateTime::createHighPrecision();
+                $mtime = microtime(true);
                 if (!$this->isColumnModified(PaymentTableMap::COL_PAYMENT_CREATED)) {
-                    $this->setCreatedAt($highPrecision);
+                    $this->setCreatedAt(PropelDateTime::createHighPrecision(PropelDateTime::formatMicrotime($mtime), 'DateTime'));
                 }
                 if (!$this->isColumnModified(PaymentTableMap::COL_PAYMENT_UPDATED)) {
-                    $this->setUpdatedAt($highPrecision);
+                    $this->setUpdatedAt(PropelDateTime::createHighPrecision(PropelDateTime::formatMicrotime($mtime), 'DateTime'));
                 }
             } else {
                 $ret = $ret && $this->preUpdate($con);
                 // timestampable behavior
                 if ($this->isModified() && !$this->isColumnModified(PaymentTableMap::COL_PAYMENT_UPDATED)) {
-                    $this->setUpdatedAt(\Propel\Runtime\Util\PropelDateTime::createHighPrecision());
+                    $this->setUpdatedAt(PropelDateTime::createHighPrecision(null, 'DateTime'));
                 }
             }
             if ($ret) {
@@ -1236,6 +1333,12 @@ abstract class Payment implements ActiveRecordInterface
         if ($this->isColumnModified(PaymentTableMap::COL_PAYMENT_ORIGINAL_ID)) {
             $modifiedColumns[':p' . $index++]  = 'payment_original_id';
         }
+        if ($this->isColumnModified(PaymentTableMap::COL_PAYMENT_HASH)) {
+            $modifiedColumns[':p' . $index++]  = 'payment_hash';
+        }
+        if ($this->isColumnModified(PaymentTableMap::COL_PAYMENT_HASH_VERSION)) {
+            $modifiedColumns[':p' . $index++]  = 'payment_hash_version';
+        }
 
         $sql = sprintf(
             'INSERT INTO payments (%s) VALUES (%s)',
@@ -1293,6 +1396,14 @@ abstract class Payment implements ActiveRecordInterface
                         break;
                     case 'payment_original_id':
                         $stmt->bindValue($identifier, $this->payment_original_id, PDO::PARAM_INT);
+
+                        break;
+                    case 'payment_hash':
+                        $stmt->bindValue($identifier, $this->payment_hash, PDO::PARAM_STR);
+
+                        break;
+                    case 'payment_hash_version':
+                        $stmt->bindValue($identifier, $this->payment_hash_version, PDO::PARAM_INT);
 
                         break;
                 }
@@ -1393,6 +1504,12 @@ abstract class Payment implements ActiveRecordInterface
             case 11:
                 return $this->getOriginalId();
 
+            case 12:
+                return $this->getHash();
+
+            case 13:
+                return $this->getHashVersion();
+
             default:
                 return null;
         } // switch()
@@ -1433,6 +1550,8 @@ abstract class Payment implements ActiveRecordInterface
             $keys[9] => $this->getUpdatedAt(),
             $keys[10] => $this->getRefundedAt(),
             $keys[11] => $this->getOriginalId(),
+            $keys[12] => $this->getHash(),
+            $keys[13] => $this->getHashVersion(),
         ];
         if ($result[$keys[7]] instanceof \DateTimeInterface) {
             $result[$keys[7]] = $result[$keys[7]]->format('Y-m-d H:i:s.u');
@@ -1588,6 +1707,12 @@ abstract class Payment implements ActiveRecordInterface
             case 11:
                 $this->setOriginalId($value);
                 break;
+            case 12:
+                $this->setHash($value);
+                break;
+            case 13:
+                $this->setHashVersion($value);
+                break;
         } // switch()
 
         return $this;
@@ -1649,6 +1774,12 @@ abstract class Payment implements ActiveRecordInterface
         }
         if (array_key_exists($keys[11], $arr)) {
             $this->setOriginalId($arr[$keys[11]]);
+        }
+        if (array_key_exists($keys[12], $arr)) {
+            $this->setHash($arr[$keys[12]]);
+        }
+        if (array_key_exists($keys[13], $arr)) {
+            $this->setHashVersion($arr[$keys[13]]);
         }
 
         return $this;
@@ -1728,6 +1859,12 @@ abstract class Payment implements ActiveRecordInterface
         }
         if ($this->isColumnModified(PaymentTableMap::COL_PAYMENT_ORIGINAL_ID)) {
             $criteria->add(PaymentTableMap::COL_PAYMENT_ORIGINAL_ID, $this->payment_original_id);
+        }
+        if ($this->isColumnModified(PaymentTableMap::COL_PAYMENT_HASH)) {
+            $criteria->add(PaymentTableMap::COL_PAYMENT_HASH, $this->payment_hash);
+        }
+        if ($this->isColumnModified(PaymentTableMap::COL_PAYMENT_HASH_VERSION)) {
+            $criteria->add(PaymentTableMap::COL_PAYMENT_HASH_VERSION, $this->payment_hash_version);
         }
 
         return $criteria;
@@ -1828,6 +1965,8 @@ abstract class Payment implements ActiveRecordInterface
         $copyObj->setUpdatedAt($this->getUpdatedAt());
         $copyObj->setRefundedAt($this->getRefundedAt());
         $copyObj->setOriginalId($this->getOriginalId());
+        $copyObj->setHash($this->getHash());
+        $copyObj->setHashVersion($this->getHashVersion());
 
         if ($deepCopy) {
             // important: temporarily setNew(false) because this affects the behavior of
@@ -1877,7 +2016,7 @@ abstract class Payment implements ActiveRecordInterface
      * @return $this The current object (for fluent API support)
      * @throws \Propel\Runtime\Exception\PropelException
      */
-    public function setSite(ChildSite $v = null)
+    public function setSite(?ChildSite $v = null)
     {
         if ($v === null) {
             $this->setSiteId(NULL);
@@ -1928,7 +2067,7 @@ abstract class Payment implements ActiveRecordInterface
      * @return $this The current object (for fluent API support)
      * @throws \Propel\Runtime\Exception\PropelException
      */
-    public function setOrder(ChildOrder $v = null)
+    public function setOrder(?ChildOrder $v = null)
     {
         if ($v === null) {
             $this->setOrderId(NULL);
@@ -1979,7 +2118,7 @@ abstract class Payment implements ActiveRecordInterface
      * @return $this The current object (for fluent API support)
      * @throws \Propel\Runtime\Exception\PropelException
      */
-    public function setPaymentRelatedByOriginalId(ChildPayment $v = null)
+    public function setPaymentRelatedByOriginalId(?ChildPayment $v = null)
     {
         if ($v === null) {
             $this->setOriginalId(NULL);
@@ -2361,8 +2500,11 @@ abstract class Payment implements ActiveRecordInterface
         $this->payment_updated = null;
         $this->payment_refunded_at = null;
         $this->payment_original_id = null;
+        $this->payment_hash = null;
+        $this->payment_hash_version = null;
         $this->alreadyInSave = false;
         $this->clearAllReferences();
+        $this->applyDefaultValues();
         $this->resetModified();
         $this->setNew(true);
         $this->setDeleted(false);

--- a/src/Model/Base/PaymentQuery.php
+++ b/src/Model/Base/PaymentQuery.php
@@ -31,6 +31,8 @@ use Propel\Runtime\Exception\PropelException;
  * @method     ChildPaymentQuery orderByUpdatedAt($order = Criteria::ASC) Order by the payment_updated column
  * @method     ChildPaymentQuery orderByRefundedAt($order = Criteria::ASC) Order by the payment_refunded_at column
  * @method     ChildPaymentQuery orderByOriginalId($order = Criteria::ASC) Order by the payment_original_id column
+ * @method     ChildPaymentQuery orderByHash($order = Criteria::ASC) Order by the payment_hash column
+ * @method     ChildPaymentQuery orderByHashVersion($order = Criteria::ASC) Order by the payment_hash_version column
  *
  * @method     ChildPaymentQuery groupById() Group by the payment_id column
  * @method     ChildPaymentQuery groupBySiteId() Group by the site_id column
@@ -44,6 +46,8 @@ use Propel\Runtime\Exception\PropelException;
  * @method     ChildPaymentQuery groupByUpdatedAt() Group by the payment_updated column
  * @method     ChildPaymentQuery groupByRefundedAt() Group by the payment_refunded_at column
  * @method     ChildPaymentQuery groupByOriginalId() Group by the payment_original_id column
+ * @method     ChildPaymentQuery groupByHash() Group by the payment_hash column
+ * @method     ChildPaymentQuery groupByHashVersion() Group by the payment_hash_version column
  *
  * @method     ChildPaymentQuery leftJoin($relation) Adds a LEFT JOIN clause to the query
  * @method     ChildPaymentQuery rightJoin($relation) Adds a RIGHT JOIN clause to the query
@@ -110,6 +114,8 @@ use Propel\Runtime\Exception\PropelException;
  * @method     ChildPayment|null findOneByUpdatedAt(string $payment_updated) Return the first ChildPayment filtered by the payment_updated column
  * @method     ChildPayment|null findOneByRefundedAt(string $payment_refunded_at) Return the first ChildPayment filtered by the payment_refunded_at column
  * @method     ChildPayment|null findOneByOriginalId(int $payment_original_id) Return the first ChildPayment filtered by the payment_original_id column
+ * @method     ChildPayment|null findOneByHash(string $payment_hash) Return the first ChildPayment filtered by the payment_hash column
+ * @method     ChildPayment|null findOneByHashVersion(int $payment_hash_version) Return the first ChildPayment filtered by the payment_hash_version column
  *
  * @method     ChildPayment requirePk($key, ?ConnectionInterface $con = null) Return the ChildPayment by primary key and throws \Propel\Runtime\Exception\EntityNotFoundException when not found
  * @method     ChildPayment requireOne(?ConnectionInterface $con = null) Return the first ChildPayment matching the query and throws \Propel\Runtime\Exception\EntityNotFoundException when not found
@@ -126,6 +132,8 @@ use Propel\Runtime\Exception\PropelException;
  * @method     ChildPayment requireOneByUpdatedAt(string $payment_updated) Return the first ChildPayment filtered by the payment_updated column and throws \Propel\Runtime\Exception\EntityNotFoundException when not found
  * @method     ChildPayment requireOneByRefundedAt(string $payment_refunded_at) Return the first ChildPayment filtered by the payment_refunded_at column and throws \Propel\Runtime\Exception\EntityNotFoundException when not found
  * @method     ChildPayment requireOneByOriginalId(int $payment_original_id) Return the first ChildPayment filtered by the payment_original_id column and throws \Propel\Runtime\Exception\EntityNotFoundException when not found
+ * @method     ChildPayment requireOneByHash(string $payment_hash) Return the first ChildPayment filtered by the payment_hash column and throws \Propel\Runtime\Exception\EntityNotFoundException when not found
+ * @method     ChildPayment requireOneByHashVersion(int $payment_hash_version) Return the first ChildPayment filtered by the payment_hash_version column and throws \Propel\Runtime\Exception\EntityNotFoundException when not found
  *
  * @method     ChildPayment[]|Collection find(?ConnectionInterface $con = null) Return ChildPayment objects based on current ModelCriteria
  * @psalm-method Collection&\Traversable<ChildPayment> find(?ConnectionInterface $con = null) Return ChildPayment objects based on current ModelCriteria
@@ -154,6 +162,10 @@ use Propel\Runtime\Exception\PropelException;
  * @psalm-method Collection&\Traversable<ChildPayment> findByRefundedAt(string|array<string> $payment_refunded_at) Return ChildPayment objects filtered by the payment_refunded_at column
  * @method     ChildPayment[]|Collection findByOriginalId(int|array<int> $payment_original_id) Return ChildPayment objects filtered by the payment_original_id column
  * @psalm-method Collection&\Traversable<ChildPayment> findByOriginalId(int|array<int> $payment_original_id) Return ChildPayment objects filtered by the payment_original_id column
+ * @method     ChildPayment[]|Collection findByHash(string|array<string> $payment_hash) Return ChildPayment objects filtered by the payment_hash column
+ * @psalm-method Collection&\Traversable<ChildPayment> findByHash(string|array<string> $payment_hash) Return ChildPayment objects filtered by the payment_hash column
+ * @method     ChildPayment[]|Collection findByHashVersion(int|array<int> $payment_hash_version) Return ChildPayment objects filtered by the payment_hash_version column
+ * @psalm-method Collection&\Traversable<ChildPayment> findByHashVersion(int|array<int> $payment_hash_version) Return ChildPayment objects filtered by the payment_hash_version column
  *
  * @method     ChildPayment[]|\Propel\Runtime\Util\PropelModelPager paginate($page = 1, $maxPerPage = 10, ?ConnectionInterface $con = null) Issue a SELECT query based on the current ModelCriteria and uses a page and a maximum number of results per page to compute an offset and a limit
  * @psalm-method \Propel\Runtime\Util\PropelModelPager&\Traversable<ChildPayment> paginate($page = 1, $maxPerPage = 10, ?ConnectionInterface $con = null) Issue a SELECT query based on the current ModelCriteria and uses a page and a maximum number of results per page to compute an offset and a limit
@@ -169,7 +181,7 @@ abstract class PaymentQuery extends ModelCriteria
      * @param string $modelName The phpName of a model, e.g. 'Book'
      * @param string $modelAlias The alias for the model in this query, e.g. 'b'
      */
-    public function __construct($dbName = 'default', $modelName = '\\Model\\Payment', $modelAlias = null)
+    public function __construct($dbName = 'default', $modelName = '\\Model\\Payment', ?string $modelAlias = null)
     {
         parent::__construct($dbName, $modelName, $modelAlias);
     }
@@ -253,7 +265,7 @@ abstract class PaymentQuery extends ModelCriteria
      */
     protected function findPkSimple($key, ConnectionInterface $con)
     {
-        $sql = 'SELECT payment_id, site_id, order_id, payment_amount, payment_mode, payment_provider_id, payment_url, payment_created, payment_executed, payment_updated, payment_refunded_at, payment_original_id FROM payments WHERE payment_id = :p0';
+        $sql = 'SELECT payment_id, site_id, order_id, payment_amount, payment_mode, payment_provider_id, payment_url, payment_created, payment_executed, payment_updated, payment_refunded_at, payment_original_id, payment_hash, payment_hash_version FROM payments WHERE payment_id = :p0';
         try {
             $stmt = $con->prepare($sql);
             $stmt->bindValue(':p0', $key, PDO::PARAM_INT);
@@ -833,6 +845,77 @@ abstract class PaymentQuery extends ModelCriteria
     }
 
     /**
+     * Filter the query on the payment_hash column
+     *
+     * Example usage:
+     * <code>
+     * $query->filterByHash('fooValue');   // WHERE payment_hash = 'fooValue'
+     * $query->filterByHash('%fooValue%', Criteria::LIKE); // WHERE payment_hash LIKE '%fooValue%'
+     * $query->filterByHash(['foo', 'bar']); // WHERE payment_hash IN ('foo', 'bar')
+     * </code>
+     *
+     * @param string|string[] $hash The value to use as filter.
+     * @param string|null $comparison Operator to use for the column comparison, defaults to Criteria::EQUAL
+     *
+     * @return $this The current query, for fluid interface
+     */
+    public function filterByHash($hash = null, ?string $comparison = null)
+    {
+        if (null === $comparison) {
+            if (is_array($hash)) {
+                $comparison = Criteria::IN;
+            }
+        }
+
+        $this->addUsingAlias(PaymentTableMap::COL_PAYMENT_HASH, $hash, $comparison);
+
+        return $this;
+    }
+
+    /**
+     * Filter the query on the payment_hash_version column
+     *
+     * Example usage:
+     * <code>
+     * $query->filterByHashVersion(1234); // WHERE payment_hash_version = 1234
+     * $query->filterByHashVersion(array(12, 34)); // WHERE payment_hash_version IN (12, 34)
+     * $query->filterByHashVersion(array('min' => 12)); // WHERE payment_hash_version > 12
+     * </code>
+     *
+     * @param mixed $hashVersion The value to use as filter.
+     *              Use scalar values for equality.
+     *              Use array values for in_array() equivalent.
+     *              Use associative array('min' => $minValue, 'max' => $maxValue) for intervals.
+     * @param string|null $comparison Operator to use for the column comparison, defaults to Criteria::EQUAL
+     *
+     * @return $this The current query, for fluid interface
+     */
+    public function filterByHashVersion($hashVersion = null, ?string $comparison = null)
+    {
+        if (is_array($hashVersion)) {
+            $useMinMax = false;
+            if (isset($hashVersion['min'])) {
+                $this->addUsingAlias(PaymentTableMap::COL_PAYMENT_HASH_VERSION, $hashVersion['min'], Criteria::GREATER_EQUAL);
+                $useMinMax = true;
+            }
+            if (isset($hashVersion['max'])) {
+                $this->addUsingAlias(PaymentTableMap::COL_PAYMENT_HASH_VERSION, $hashVersion['max'], Criteria::LESS_EQUAL);
+                $useMinMax = true;
+            }
+            if ($useMinMax) {
+                return $this;
+            }
+            if (null === $comparison) {
+                $comparison = Criteria::IN;
+            }
+        }
+
+        $this->addUsingAlias(PaymentTableMap::COL_PAYMENT_HASH_VERSION, $hashVersion, $comparison);
+
+        return $this;
+    }
+
+    /**
      * Filter the query by a related \Model\Site object
      *
      * @param \Model\Site|ObjectCollection $site The related object(s) to use as filter
@@ -904,7 +987,7 @@ abstract class PaymentQuery extends ModelCriteria
      *
      * @return \Model\SiteQuery A secondary query class using the current class as primary query
      */
-    public function useSiteQuery($relationAlias = null, $joinType = Criteria::LEFT_JOIN)
+    public function useSiteQuery(?string $relationAlias = null, string $joinType = Criteria::LEFT_JOIN)
     {
         return $this
             ->joinSite($relationAlias, $joinType)
@@ -924,7 +1007,7 @@ abstract class PaymentQuery extends ModelCriteria
      */
     public function withSiteQuery(
         callable $callable,
-        string $relationAlias = null,
+        ?string $relationAlias = null,
         ?string $joinType = Criteria::LEFT_JOIN
     ) {
         $relatedQuery = $this->useSiteQuery(
@@ -948,7 +1031,7 @@ abstract class PaymentQuery extends ModelCriteria
      *
      * @return \Model\SiteQuery The inner query object of the EXISTS statement
      */
-    public function useSiteExistsQuery($modelAlias = null, $queryClass = null, $typeOfExists = 'EXISTS')
+    public function useSiteExistsQuery(?string $modelAlias = null, ?string $queryClass = null, string $typeOfExists = 'EXISTS')
     {
         /** @var $q \Model\SiteQuery */
         $q = $this->useExistsQuery('Site', $modelAlias, $queryClass, $typeOfExists);
@@ -965,7 +1048,7 @@ abstract class PaymentQuery extends ModelCriteria
      *
      * @return \Model\SiteQuery The inner query object of the NOT EXISTS statement
      */
-    public function useSiteNotExistsQuery($modelAlias = null, $queryClass = null)
+    public function useSiteNotExistsQuery(?string $modelAlias = null, ?string $queryClass = null)
     {
         /** @var $q \Model\SiteQuery */
         $q = $this->useExistsQuery('Site', $modelAlias, $queryClass, 'NOT EXISTS');
@@ -983,7 +1066,7 @@ abstract class PaymentQuery extends ModelCriteria
      *
      * @return \Model\SiteQuery The inner query object of the IN statement
      */
-    public function useInSiteQuery($modelAlias = null, $queryClass = null, $typeOfIn = 'IN')
+    public function useInSiteQuery(?string $modelAlias = null, ?string $queryClass = null, string $typeOfIn = 'IN')
     {
         /** @var $q \Model\SiteQuery */
         $q = $this->useInQuery('Site', $modelAlias, $queryClass, $typeOfIn);
@@ -1000,7 +1083,7 @@ abstract class PaymentQuery extends ModelCriteria
      *
      * @return \Model\SiteQuery The inner query object of the NOT IN statement
      */
-    public function useNotInSiteQuery($modelAlias = null, $queryClass = null)
+    public function useNotInSiteQuery(?string $modelAlias = null, ?string $queryClass = null)
     {
         /** @var $q \Model\SiteQuery */
         $q = $this->useInQuery('Site', $modelAlias, $queryClass, 'NOT IN');
@@ -1079,7 +1162,7 @@ abstract class PaymentQuery extends ModelCriteria
      *
      * @return \Model\OrderQuery A secondary query class using the current class as primary query
      */
-    public function useOrderQuery($relationAlias = null, $joinType = Criteria::LEFT_JOIN)
+    public function useOrderQuery(?string $relationAlias = null, string $joinType = Criteria::LEFT_JOIN)
     {
         return $this
             ->joinOrder($relationAlias, $joinType)
@@ -1099,7 +1182,7 @@ abstract class PaymentQuery extends ModelCriteria
      */
     public function withOrderQuery(
         callable $callable,
-        string $relationAlias = null,
+        ?string $relationAlias = null,
         ?string $joinType = Criteria::LEFT_JOIN
     ) {
         $relatedQuery = $this->useOrderQuery(
@@ -1123,7 +1206,7 @@ abstract class PaymentQuery extends ModelCriteria
      *
      * @return \Model\OrderQuery The inner query object of the EXISTS statement
      */
-    public function useOrderExistsQuery($modelAlias = null, $queryClass = null, $typeOfExists = 'EXISTS')
+    public function useOrderExistsQuery(?string $modelAlias = null, ?string $queryClass = null, string $typeOfExists = 'EXISTS')
     {
         /** @var $q \Model\OrderQuery */
         $q = $this->useExistsQuery('Order', $modelAlias, $queryClass, $typeOfExists);
@@ -1140,7 +1223,7 @@ abstract class PaymentQuery extends ModelCriteria
      *
      * @return \Model\OrderQuery The inner query object of the NOT EXISTS statement
      */
-    public function useOrderNotExistsQuery($modelAlias = null, $queryClass = null)
+    public function useOrderNotExistsQuery(?string $modelAlias = null, ?string $queryClass = null)
     {
         /** @var $q \Model\OrderQuery */
         $q = $this->useExistsQuery('Order', $modelAlias, $queryClass, 'NOT EXISTS');
@@ -1158,7 +1241,7 @@ abstract class PaymentQuery extends ModelCriteria
      *
      * @return \Model\OrderQuery The inner query object of the IN statement
      */
-    public function useInOrderQuery($modelAlias = null, $queryClass = null, $typeOfIn = 'IN')
+    public function useInOrderQuery(?string $modelAlias = null, ?string $queryClass = null, string $typeOfIn = 'IN')
     {
         /** @var $q \Model\OrderQuery */
         $q = $this->useInQuery('Order', $modelAlias, $queryClass, $typeOfIn);
@@ -1175,7 +1258,7 @@ abstract class PaymentQuery extends ModelCriteria
      *
      * @return \Model\OrderQuery The inner query object of the NOT IN statement
      */
-    public function useNotInOrderQuery($modelAlias = null, $queryClass = null)
+    public function useNotInOrderQuery(?string $modelAlias = null, ?string $queryClass = null)
     {
         /** @var $q \Model\OrderQuery */
         $q = $this->useInQuery('Order', $modelAlias, $queryClass, 'NOT IN');
@@ -1254,7 +1337,7 @@ abstract class PaymentQuery extends ModelCriteria
      *
      * @return \Model\PaymentQuery A secondary query class using the current class as primary query
      */
-    public function usePaymentRelatedByOriginalIdQuery($relationAlias = null, $joinType = Criteria::LEFT_JOIN)
+    public function usePaymentRelatedByOriginalIdQuery(?string $relationAlias = null, string $joinType = Criteria::LEFT_JOIN)
     {
         return $this
             ->joinPaymentRelatedByOriginalId($relationAlias, $joinType)
@@ -1274,7 +1357,7 @@ abstract class PaymentQuery extends ModelCriteria
      */
     public function withPaymentRelatedByOriginalIdQuery(
         callable $callable,
-        string $relationAlias = null,
+        ?string $relationAlias = null,
         ?string $joinType = Criteria::LEFT_JOIN
     ) {
         $relatedQuery = $this->usePaymentRelatedByOriginalIdQuery(
@@ -1298,7 +1381,7 @@ abstract class PaymentQuery extends ModelCriteria
      *
      * @return \Model\PaymentQuery The inner query object of the EXISTS statement
      */
-    public function usePaymentRelatedByOriginalIdExistsQuery($modelAlias = null, $queryClass = null, $typeOfExists = 'EXISTS')
+    public function usePaymentRelatedByOriginalIdExistsQuery(?string $modelAlias = null, ?string $queryClass = null, string $typeOfExists = 'EXISTS')
     {
         /** @var $q \Model\PaymentQuery */
         $q = $this->useExistsQuery('PaymentRelatedByOriginalId', $modelAlias, $queryClass, $typeOfExists);
@@ -1315,7 +1398,7 @@ abstract class PaymentQuery extends ModelCriteria
      *
      * @return \Model\PaymentQuery The inner query object of the NOT EXISTS statement
      */
-    public function usePaymentRelatedByOriginalIdNotExistsQuery($modelAlias = null, $queryClass = null)
+    public function usePaymentRelatedByOriginalIdNotExistsQuery(?string $modelAlias = null, ?string $queryClass = null)
     {
         /** @var $q \Model\PaymentQuery */
         $q = $this->useExistsQuery('PaymentRelatedByOriginalId', $modelAlias, $queryClass, 'NOT EXISTS');
@@ -1333,7 +1416,7 @@ abstract class PaymentQuery extends ModelCriteria
      *
      * @return \Model\PaymentQuery The inner query object of the IN statement
      */
-    public function useInPaymentRelatedByOriginalIdQuery($modelAlias = null, $queryClass = null, $typeOfIn = 'IN')
+    public function useInPaymentRelatedByOriginalIdQuery(?string $modelAlias = null, ?string $queryClass = null, string $typeOfIn = 'IN')
     {
         /** @var $q \Model\PaymentQuery */
         $q = $this->useInQuery('PaymentRelatedByOriginalId', $modelAlias, $queryClass, $typeOfIn);
@@ -1350,7 +1433,7 @@ abstract class PaymentQuery extends ModelCriteria
      *
      * @return \Model\PaymentQuery The inner query object of the NOT IN statement
      */
-    public function useNotInPaymentRelatedByOriginalIdQuery($modelAlias = null, $queryClass = null)
+    public function useNotInPaymentRelatedByOriginalIdQuery(?string $modelAlias = null, ?string $queryClass = null)
     {
         /** @var $q \Model\PaymentQuery */
         $q = $this->useInQuery('PaymentRelatedByOriginalId', $modelAlias, $queryClass, 'NOT IN');
@@ -1427,7 +1510,7 @@ abstract class PaymentQuery extends ModelCriteria
      *
      * @return \Model\PaymentQuery A secondary query class using the current class as primary query
      */
-    public function usePaymentRelatedByIdQuery($relationAlias = null, $joinType = Criteria::LEFT_JOIN)
+    public function usePaymentRelatedByIdQuery(?string $relationAlias = null, string $joinType = Criteria::LEFT_JOIN)
     {
         return $this
             ->joinPaymentRelatedById($relationAlias, $joinType)
@@ -1447,7 +1530,7 @@ abstract class PaymentQuery extends ModelCriteria
      */
     public function withPaymentRelatedByIdQuery(
         callable $callable,
-        string $relationAlias = null,
+        ?string $relationAlias = null,
         ?string $joinType = Criteria::LEFT_JOIN
     ) {
         $relatedQuery = $this->usePaymentRelatedByIdQuery(
@@ -1471,7 +1554,7 @@ abstract class PaymentQuery extends ModelCriteria
      *
      * @return \Model\PaymentQuery The inner query object of the EXISTS statement
      */
-    public function usePaymentRelatedByIdExistsQuery($modelAlias = null, $queryClass = null, $typeOfExists = 'EXISTS')
+    public function usePaymentRelatedByIdExistsQuery(?string $modelAlias = null, ?string $queryClass = null, string $typeOfExists = 'EXISTS')
     {
         /** @var $q \Model\PaymentQuery */
         $q = $this->useExistsQuery('PaymentRelatedById', $modelAlias, $queryClass, $typeOfExists);
@@ -1488,7 +1571,7 @@ abstract class PaymentQuery extends ModelCriteria
      *
      * @return \Model\PaymentQuery The inner query object of the NOT EXISTS statement
      */
-    public function usePaymentRelatedByIdNotExistsQuery($modelAlias = null, $queryClass = null)
+    public function usePaymentRelatedByIdNotExistsQuery(?string $modelAlias = null, ?string $queryClass = null)
     {
         /** @var $q \Model\PaymentQuery */
         $q = $this->useExistsQuery('PaymentRelatedById', $modelAlias, $queryClass, 'NOT EXISTS');
@@ -1506,7 +1589,7 @@ abstract class PaymentQuery extends ModelCriteria
      *
      * @return \Model\PaymentQuery The inner query object of the IN statement
      */
-    public function useInPaymentRelatedByIdQuery($modelAlias = null, $queryClass = null, $typeOfIn = 'IN')
+    public function useInPaymentRelatedByIdQuery(?string $modelAlias = null, ?string $queryClass = null, string $typeOfIn = 'IN')
     {
         /** @var $q \Model\PaymentQuery */
         $q = $this->useInQuery('PaymentRelatedById', $modelAlias, $queryClass, $typeOfIn);
@@ -1523,7 +1606,7 @@ abstract class PaymentQuery extends ModelCriteria
      *
      * @return \Model\PaymentQuery The inner query object of the NOT IN statement
      */
-    public function useNotInPaymentRelatedByIdQuery($modelAlias = null, $queryClass = null)
+    public function useNotInPaymentRelatedByIdQuery(?string $modelAlias = null, ?string $queryClass = null)
     {
         /** @var $q \Model\PaymentQuery */
         $q = $this->useInQuery('PaymentRelatedById', $modelAlias, $queryClass, 'NOT IN');

--- a/src/Model/Map/PaymentTableMap.php
+++ b/src/Model/Map/PaymentTableMap.php
@@ -63,7 +63,7 @@ class PaymentTableMap extends TableMap
     /**
      * The total number of columns
      */
-    public const NUM_COLUMNS = 12;
+    public const NUM_COLUMNS = 14;
 
     /**
      * The number of lazy-loaded columns
@@ -73,7 +73,7 @@ class PaymentTableMap extends TableMap
     /**
      * The number of columns to hydrate (NUM_COLUMNS - NUM_LAZY_LOAD_COLUMNS)
      */
-    public const NUM_HYDRATE_COLUMNS = 12;
+    public const NUM_HYDRATE_COLUMNS = 14;
 
     /**
      * the column name for the payment_id field
@@ -136,6 +136,16 @@ class PaymentTableMap extends TableMap
     public const COL_PAYMENT_ORIGINAL_ID = 'payments.payment_original_id';
 
     /**
+     * the column name for the payment_hash field
+     */
+    public const COL_PAYMENT_HASH = 'payments.payment_hash';
+
+    /**
+     * the column name for the payment_hash_version field
+     */
+    public const COL_PAYMENT_HASH_VERSION = 'payments.payment_hash_version';
+
+    /**
      * The default string format for model objects of the related table
      */
     public const DEFAULT_STRING_FORMAT = 'YAML';
@@ -149,11 +159,11 @@ class PaymentTableMap extends TableMap
      * @var array<string, mixed>
      */
     protected static $fieldNames = [
-        self::TYPE_PHPNAME       => ['Id', 'SiteId', 'OrderId', 'Amount', 'Mode', 'ProviderId', 'Url', 'CreatedAt', 'Executed', 'UpdatedAt', 'RefundedAt', 'OriginalId', ],
-        self::TYPE_CAMELNAME     => ['id', 'siteId', 'orderId', 'amount', 'mode', 'providerId', 'url', 'createdAt', 'executed', 'updatedAt', 'refundedAt', 'originalId', ],
-        self::TYPE_COLNAME       => [PaymentTableMap::COL_PAYMENT_ID, PaymentTableMap::COL_SITE_ID, PaymentTableMap::COL_ORDER_ID, PaymentTableMap::COL_PAYMENT_AMOUNT, PaymentTableMap::COL_PAYMENT_MODE, PaymentTableMap::COL_PAYMENT_PROVIDER_ID, PaymentTableMap::COL_PAYMENT_URL, PaymentTableMap::COL_PAYMENT_CREATED, PaymentTableMap::COL_PAYMENT_EXECUTED, PaymentTableMap::COL_PAYMENT_UPDATED, PaymentTableMap::COL_PAYMENT_REFUNDED_AT, PaymentTableMap::COL_PAYMENT_ORIGINAL_ID, ],
-        self::TYPE_FIELDNAME     => ['payment_id', 'site_id', 'order_id', 'payment_amount', 'payment_mode', 'payment_provider_id', 'payment_url', 'payment_created', 'payment_executed', 'payment_updated', 'payment_refunded_at', 'payment_original_id', ],
-        self::TYPE_NUM           => [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, ]
+        self::TYPE_PHPNAME       => ['Id', 'SiteId', 'OrderId', 'Amount', 'Mode', 'ProviderId', 'Url', 'CreatedAt', 'Executed', 'UpdatedAt', 'RefundedAt', 'OriginalId', 'Hash', 'HashVersion', ],
+        self::TYPE_CAMELNAME     => ['id', 'siteId', 'orderId', 'amount', 'mode', 'providerId', 'url', 'createdAt', 'executed', 'updatedAt', 'refundedAt', 'originalId', 'hash', 'hashVersion', ],
+        self::TYPE_COLNAME       => [PaymentTableMap::COL_PAYMENT_ID, PaymentTableMap::COL_SITE_ID, PaymentTableMap::COL_ORDER_ID, PaymentTableMap::COL_PAYMENT_AMOUNT, PaymentTableMap::COL_PAYMENT_MODE, PaymentTableMap::COL_PAYMENT_PROVIDER_ID, PaymentTableMap::COL_PAYMENT_URL, PaymentTableMap::COL_PAYMENT_CREATED, PaymentTableMap::COL_PAYMENT_EXECUTED, PaymentTableMap::COL_PAYMENT_UPDATED, PaymentTableMap::COL_PAYMENT_REFUNDED_AT, PaymentTableMap::COL_PAYMENT_ORIGINAL_ID, PaymentTableMap::COL_PAYMENT_HASH, PaymentTableMap::COL_PAYMENT_HASH_VERSION, ],
+        self::TYPE_FIELDNAME     => ['payment_id', 'site_id', 'order_id', 'payment_amount', 'payment_mode', 'payment_provider_id', 'payment_url', 'payment_created', 'payment_executed', 'payment_updated', 'payment_refunded_at', 'payment_original_id', 'payment_hash', 'payment_hash_version', ],
+        self::TYPE_NUM           => [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, ]
     ];
 
     /**
@@ -165,11 +175,11 @@ class PaymentTableMap extends TableMap
      * @var array<string, mixed>
      */
     protected static $fieldKeys = [
-        self::TYPE_PHPNAME       => ['Id' => 0, 'SiteId' => 1, 'OrderId' => 2, 'Amount' => 3, 'Mode' => 4, 'ProviderId' => 5, 'Url' => 6, 'CreatedAt' => 7, 'Executed' => 8, 'UpdatedAt' => 9, 'RefundedAt' => 10, 'OriginalId' => 11, ],
-        self::TYPE_CAMELNAME     => ['id' => 0, 'siteId' => 1, 'orderId' => 2, 'amount' => 3, 'mode' => 4, 'providerId' => 5, 'url' => 6, 'createdAt' => 7, 'executed' => 8, 'updatedAt' => 9, 'refundedAt' => 10, 'originalId' => 11, ],
-        self::TYPE_COLNAME       => [PaymentTableMap::COL_PAYMENT_ID => 0, PaymentTableMap::COL_SITE_ID => 1, PaymentTableMap::COL_ORDER_ID => 2, PaymentTableMap::COL_PAYMENT_AMOUNT => 3, PaymentTableMap::COL_PAYMENT_MODE => 4, PaymentTableMap::COL_PAYMENT_PROVIDER_ID => 5, PaymentTableMap::COL_PAYMENT_URL => 6, PaymentTableMap::COL_PAYMENT_CREATED => 7, PaymentTableMap::COL_PAYMENT_EXECUTED => 8, PaymentTableMap::COL_PAYMENT_UPDATED => 9, PaymentTableMap::COL_PAYMENT_REFUNDED_AT => 10, PaymentTableMap::COL_PAYMENT_ORIGINAL_ID => 11, ],
-        self::TYPE_FIELDNAME     => ['payment_id' => 0, 'site_id' => 1, 'order_id' => 2, 'payment_amount' => 3, 'payment_mode' => 4, 'payment_provider_id' => 5, 'payment_url' => 6, 'payment_created' => 7, 'payment_executed' => 8, 'payment_updated' => 9, 'payment_refunded_at' => 10, 'payment_original_id' => 11, ],
-        self::TYPE_NUM           => [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, ]
+        self::TYPE_PHPNAME       => ['Id' => 0, 'SiteId' => 1, 'OrderId' => 2, 'Amount' => 3, 'Mode' => 4, 'ProviderId' => 5, 'Url' => 6, 'CreatedAt' => 7, 'Executed' => 8, 'UpdatedAt' => 9, 'RefundedAt' => 10, 'OriginalId' => 11, 'Hash' => 12, 'HashVersion' => 13, ],
+        self::TYPE_CAMELNAME     => ['id' => 0, 'siteId' => 1, 'orderId' => 2, 'amount' => 3, 'mode' => 4, 'providerId' => 5, 'url' => 6, 'createdAt' => 7, 'executed' => 8, 'updatedAt' => 9, 'refundedAt' => 10, 'originalId' => 11, 'hash' => 12, 'hashVersion' => 13, ],
+        self::TYPE_COLNAME       => [PaymentTableMap::COL_PAYMENT_ID => 0, PaymentTableMap::COL_SITE_ID => 1, PaymentTableMap::COL_ORDER_ID => 2, PaymentTableMap::COL_PAYMENT_AMOUNT => 3, PaymentTableMap::COL_PAYMENT_MODE => 4, PaymentTableMap::COL_PAYMENT_PROVIDER_ID => 5, PaymentTableMap::COL_PAYMENT_URL => 6, PaymentTableMap::COL_PAYMENT_CREATED => 7, PaymentTableMap::COL_PAYMENT_EXECUTED => 8, PaymentTableMap::COL_PAYMENT_UPDATED => 9, PaymentTableMap::COL_PAYMENT_REFUNDED_AT => 10, PaymentTableMap::COL_PAYMENT_ORIGINAL_ID => 11, PaymentTableMap::COL_PAYMENT_HASH => 12, PaymentTableMap::COL_PAYMENT_HASH_VERSION => 13, ],
+        self::TYPE_FIELDNAME     => ['payment_id' => 0, 'site_id' => 1, 'order_id' => 2, 'payment_amount' => 3, 'payment_mode' => 4, 'payment_provider_id' => 5, 'payment_url' => 6, 'payment_created' => 7, 'payment_executed' => 8, 'payment_updated' => 9, 'payment_refunded_at' => 10, 'payment_original_id' => 11, 'payment_hash' => 12, 'payment_hash_version' => 13, ],
+        self::TYPE_NUM           => [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, ]
     ];
 
     /**
@@ -274,6 +284,22 @@ class PaymentTableMap extends TableMap
         'COL_PAYMENT_ORIGINAL_ID' => 'PAYMENT_ORIGINAL_ID',
         'payment_original_id' => 'PAYMENT_ORIGINAL_ID',
         'payments.payment_original_id' => 'PAYMENT_ORIGINAL_ID',
+        'Hash' => 'PAYMENT_HASH',
+        'Payment.Hash' => 'PAYMENT_HASH',
+        'hash' => 'PAYMENT_HASH',
+        'payment.hash' => 'PAYMENT_HASH',
+        'PaymentTableMap::COL_PAYMENT_HASH' => 'PAYMENT_HASH',
+        'COL_PAYMENT_HASH' => 'PAYMENT_HASH',
+        'payment_hash' => 'PAYMENT_HASH',
+        'payments.payment_hash' => 'PAYMENT_HASH',
+        'HashVersion' => 'PAYMENT_HASH_VERSION',
+        'Payment.HashVersion' => 'PAYMENT_HASH_VERSION',
+        'hashVersion' => 'PAYMENT_HASH_VERSION',
+        'payment.hashVersion' => 'PAYMENT_HASH_VERSION',
+        'PaymentTableMap::COL_PAYMENT_HASH_VERSION' => 'PAYMENT_HASH_VERSION',
+        'COL_PAYMENT_HASH_VERSION' => 'PAYMENT_HASH_VERSION',
+        'payment_hash_version' => 'PAYMENT_HASH_VERSION',
+        'payments.payment_hash_version' => 'PAYMENT_HASH_VERSION',
     ];
 
     /**
@@ -305,6 +331,8 @@ class PaymentTableMap extends TableMap
         $this->addColumn('payment_updated', 'UpdatedAt', 'TIMESTAMP', false, null, null);
         $this->addColumn('payment_refunded_at', 'RefundedAt', 'TIMESTAMP', false, null, null);
         $this->addForeignKey('payment_original_id', 'OriginalId', 'INTEGER', 'payments', 'payment_id', false, null, null);
+        $this->addColumn('payment_hash', 'Hash', 'VARCHAR', false, 64, null);
+        $this->addColumn('payment_hash_version', 'HashVersion', 'TINYINT', false, null, 1);
     }
 
     /**
@@ -511,6 +539,8 @@ class PaymentTableMap extends TableMap
             $criteria->addSelectColumn(PaymentTableMap::COL_PAYMENT_UPDATED);
             $criteria->addSelectColumn(PaymentTableMap::COL_PAYMENT_REFUNDED_AT);
             $criteria->addSelectColumn(PaymentTableMap::COL_PAYMENT_ORIGINAL_ID);
+            $criteria->addSelectColumn(PaymentTableMap::COL_PAYMENT_HASH);
+            $criteria->addSelectColumn(PaymentTableMap::COL_PAYMENT_HASH_VERSION);
         } else {
             $criteria->addSelectColumn($alias . '.payment_id');
             $criteria->addSelectColumn($alias . '.site_id');
@@ -524,6 +554,8 @@ class PaymentTableMap extends TableMap
             $criteria->addSelectColumn($alias . '.payment_updated');
             $criteria->addSelectColumn($alias . '.payment_refunded_at');
             $criteria->addSelectColumn($alias . '.payment_original_id');
+            $criteria->addSelectColumn($alias . '.payment_hash');
+            $criteria->addSelectColumn($alias . '.payment_hash_version');
         }
     }
 
@@ -554,6 +586,8 @@ class PaymentTableMap extends TableMap
             $criteria->removeSelectColumn(PaymentTableMap::COL_PAYMENT_UPDATED);
             $criteria->removeSelectColumn(PaymentTableMap::COL_PAYMENT_REFUNDED_AT);
             $criteria->removeSelectColumn(PaymentTableMap::COL_PAYMENT_ORIGINAL_ID);
+            $criteria->removeSelectColumn(PaymentTableMap::COL_PAYMENT_HASH);
+            $criteria->removeSelectColumn(PaymentTableMap::COL_PAYMENT_HASH_VERSION);
         } else {
             $criteria->removeSelectColumn($alias . '.payment_id');
             $criteria->removeSelectColumn($alias . '.site_id');
@@ -567,6 +601,8 @@ class PaymentTableMap extends TableMap
             $criteria->removeSelectColumn($alias . '.payment_updated');
             $criteria->removeSelectColumn($alias . '.payment_refunded_at');
             $criteria->removeSelectColumn($alias . '.payment_original_id');
+            $criteria->removeSelectColumn($alias . '.payment_hash');
+            $criteria->removeSelectColumn($alias . '.payment_hash_version');
         }
     }
 

--- a/src/Model/Payment.php
+++ b/src/Model/Payment.php
@@ -84,6 +84,23 @@ class Payment extends BasePayment
             $this->setCreatedAt(new DateTime());
         }
 
+        // La colonne payment_created est un TIMESTAMP sans précision fractionnaire :
+        // seule la seconde entière est stockée. Or l'arrondi des sous-secondes au
+        // stockage dépend du moteur (MariaDB tronque, MySQL 8 arrondit à la seconde
+        // supérieure dès .5). Si on hachait la date brute (avec microsecondes), le
+        // hash porterait sur une valeur différente de celle réellement persistée sur
+        // MySQL 8, faisant échouer toute vérification d'intégrité future. On fige
+        // donc ici la date à la seconde entière, AVANT le calcul du hash, afin que la
+        // valeur hachée soit strictement identique à la valeur stockée quel que soit
+        // le moteur. On reconstruit la date dans le même fuseau horaire pour ne pas
+        // décaler l'heure murale.
+        $createdAt = $this->getCreatedAt();
+        $this->setCreatedAt(DateTime::createFromFormat(
+            "Y-m-d H:i:s",
+            $createdAt->format("Y-m-d H:i:s"),
+            $createdAt->getTimezone()
+        ));
+
         $previous = PaymentQuery::create()
             ->orderById(Criteria::DESC)
             ->findOne($con);

--- a/src/Model/Payment.php
+++ b/src/Model/Payment.php
@@ -15,7 +15,6 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-
 namespace Model;
 
 use DateTime;

--- a/src/Model/Payment.php
+++ b/src/Model/Payment.php
@@ -18,7 +18,10 @@
 
 namespace Model;
 
+use DateTime;
 use Model\Base\Payment as BasePayment;
+use Propel\Runtime\ActiveQuery\Criteria;
+use Propel\Runtime\Connection\ConnectionInterface;
 use Propel\Runtime\Exception\PropelException;
 
 /**
@@ -62,5 +65,39 @@ class Payment extends BasePayment
     public function isExecuted(): bool
     {
         return $this->getExecuted() !== null;
+    }
+
+    /**
+     * @throws PropelException
+     */
+    public function preInsert(?ConnectionInterface $con = null): bool
+    {
+        if (!parent::preInsert($con)) {
+            return false;
+        }
+
+        // Le comportement timestampable renseigne payment_created APRÈS preInsert.
+        // On fige donc la date ici si elle n'est pas déjà fixée, pour que le hash
+        // porte sur la valeur réellement stockée (timestampable respectera ensuite
+        // cette valeur via son test !isColumnModified).
+        if ($this->getCreatedAt() === null) {
+            $this->setCreatedAt(new DateTime());
+        }
+
+        $previous = PaymentQuery::create()
+            ->orderById(Criteria::DESC)
+            ->findOne($con);
+        $previousHash = $previous?->getHash() ?? "";
+
+        $this->setHashVersion(PaymentHash::CURRENT_VERSION);
+        $this->setHash(PaymentHash::compute(
+            PaymentHash::CURRENT_VERSION,
+            $this->getAmount(),
+            $this->getCreatedAt(),
+            $this->getOrderId(),
+            $previousHash
+        ));
+
+        return true;
     }
 }

--- a/src/Model/PaymentHash.php
+++ b/src/Model/PaymentHash.php
@@ -15,7 +15,6 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-
 namespace Model;
 
 use DateTimeInterface;

--- a/src/Model/PaymentHash.php
+++ b/src/Model/PaymentHash.php
@@ -1,0 +1,56 @@
+<?php
+/*
+ * Copyright (C) 2026 Clément Latzarus
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+
+namespace Model;
+
+use DateTimeInterface;
+use InvalidArgumentException;
+
+final class PaymentHash
+{
+    public const CURRENT_VERSION = 1;
+
+    public static function compute(
+        int $version,
+        ?int $amount,
+        ?DateTimeInterface $createdAt,
+        ?int $orderId,
+        string $previousHash
+    ): string {
+        return match ($version) {
+            1 => self::computeV1($amount, $createdAt, $orderId, $previousHash),
+            default => throw new InvalidArgumentException("Unknown hash version: $version"),
+        };
+    }
+
+    // APPEND-ONLY : ne jamais modifier ni supprimer.
+    private static function computeV1(
+        ?int $amount,
+        ?DateTimeInterface $createdAt,
+        ?int $orderId,
+        string $previousHash
+    ): string {
+        $parts = [
+            $amount ?? "",
+            $createdAt?->format("Y-m-d H:i:s") ?? "",
+            $orderId ?? "",
+            $previousHash,
+        ];
+        return hash("sha256", implode("|", $parts));
+    }
+}

--- a/tests/Model/PaymentHashTest.php
+++ b/tests/Model/PaymentHashTest.php
@@ -15,7 +15,6 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-
 namespace Model;
 
 use DateTime;

--- a/tests/Model/PaymentHashTest.php
+++ b/tests/Model/PaymentHashTest.php
@@ -1,0 +1,64 @@
+<?php
+/*
+ * Copyright (C) 2026 Clément Latzarus
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+
+namespace Model;
+
+use DateTime;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+class PaymentHashTest extends TestCase
+{
+    /** Golden vector — genesis (previousHash vide). Fige la v1. */
+    public function testVersion1GenesisIsFrozen(): void
+    {
+        $hash = PaymentHash::compute(1, 1500, new DateTime("2026-01-01 12:00:00"), 42, "");
+        $this->assertSame(
+            "c9cc9f071d5e4553561f1c82ba04ee6dae4e75148d5550c0d247b4d7c7e8bff3",
+            $hash
+        );
+    }
+
+    /** Golden vector — maillon chaîné sur le genesis. */
+    public function testVersion1ChainsOnPreviousHash(): void
+    {
+        $previous = "c9cc9f071d5e4553561f1c82ba04ee6dae4e75148d5550c0d247b4d7c7e8bff3";
+        $hash = PaymentHash::compute(1, 900, new DateTime("2026-01-02 09:30:00"), 43, $previous);
+        $this->assertSame(
+            "6a902e886212458b3697a76503f48c625cc4ed89380ad3613b05d93a5fa218c7",
+            $hash
+        );
+    }
+
+    /** amount null et orderId null sont sérialisés en chaîne vide. */
+    public function testVersion1SerializesNullFieldsAsEmptyString(): void
+    {
+        $previous = "c9cc9f071d5e4553561f1c82ba04ee6dae4e75148d5550c0d247b4d7c7e8bff3";
+        $hash = PaymentHash::compute(1, null, new DateTime("2026-01-03 08:00:00"), null, $previous);
+        $this->assertSame(
+            "2e94c203350e13789172fccb3fb30a2120d7d222576c7073670a575c802f81ce",
+            $hash
+        );
+    }
+
+    public function testUnknownVersionThrows(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        PaymentHash::compute(99, 1500, new DateTime("2026-01-01 12:00:00"), 42, "");
+    }
+}

--- a/tests/Model/PaymentTest.php
+++ b/tests/Model/PaymentTest.php
@@ -20,6 +20,7 @@ namespace Model;
 
 use Biblys\Test\ModelFactory;
 use DateTime;
+use Model\Map\PaymentTableMap;
 use PHPUnit\Framework\TestCase;
 use Propel\Runtime\ActiveQuery\Criteria;
 use Propel\Runtime\Exception\PropelException;
@@ -97,5 +98,95 @@ class PaymentTest extends TestCase
             ),
             $third->getHash()
         );
+    }
+
+    /**
+     * @throws PropelException
+     */
+    public function testPreInsertFloorsCreatedDateToWholeSecondsForHashPortability(): void
+    {
+        // given — un paiement précédent (pour alimenter le chaînage des hashs)
+        $order = ModelFactory::createOrder();
+        $first = ModelFactory::createPayment($order, 1500);
+
+        // and — un second paiement dont la date de création porte une sous-seconde
+        // >= 0.5 : sur MySQL 8 (arrondi), la valeur stockée serait alors une seconde
+        // de plus que la valeur brute ; le hook doit la figer à la seconde entière
+        // AVANT le calcul du hash pour rester cohérent avec la valeur stockée quel
+        // que soit le moteur.
+        $createdAtWithSubSecond = DateTime::createFromFormat(
+            "Y-m-d H:i:s.u",
+            "2026-03-01 10:00:00.700"
+        );
+
+        $second = new Payment();
+        $second->setOrder($order);
+        $second->setAmount(900);
+        $second->setMode(Payment::MODE_STRIPE);
+        $second->setProviderId("stripe-5678");
+        $second->setCreatedAt($createdAtWithSubSecond);
+        $second->save();
+        $secondId = $second->getId();
+
+        // when — on relit le paiement depuis la base, en vidant le pool d'instances
+        // Propel pour être certain de lire la ligne réellement persistée.
+        PaymentTableMap::clearInstancePool();
+        $reloaded = PaymentQuery::create()->findPk($secondId);
+
+        // then — la date rechargée est bien à la seconde entière (0 microseconde).
+        // Note : sur cette machine de dev (MariaDB, qui tronque au stockage), cette
+        // assertion passe même sans le correctif, puisque la colonne ne peut de toute
+        // façon pas conserver de fraction de seconde. Elle documente le contrat de
+        // stockage et sert de garde-fou si la colonne gagnait un jour une précision
+        // fractionnaire. La régression réelle (portabilité MySQL 8) est couverte par
+        // le test unitaire testPreInsertFloorsCreatedDateInMemoryBeforeHashing
+        // ci-dessous, qui échoue bien sur MariaDB sans le correctif.
+        $this->assertSame(0, (int)$reloaded->getCreatedAt()->format("u"));
+
+        // and — le hash stocké est recalculable à partir de la date rechargée,
+        // garantissant qu'une vérification d'intégrité future ne signalera pas de
+        // falsification à tort.
+        $this->assertSame(
+            PaymentHash::compute(
+                PaymentHash::CURRENT_VERSION,
+                $reloaded->getAmount(),
+                $reloaded->getCreatedAt(),
+                $reloaded->getOrderId(),
+                $first->getHash()
+            ),
+            $reloaded->getHash()
+        );
+    }
+
+    /**
+     * @throws PropelException
+     */
+    public function testPreInsertFloorsCreatedDateInMemoryBeforeHashing(): void
+    {
+        // given — un paiement dont la date de création porte une sous-seconde,
+        // fixée AVANT l'appel du hook (simule le cas d'un appelant fournissant
+        // explicitement une date, ou celui où timestampable a déjà renseigné une
+        // valeur avec microsecondes).
+        $order = ModelFactory::createOrder();
+        $payment = new Payment();
+        $payment->setOrder($order);
+        $payment->setAmount(500);
+        $payment->setMode(Payment::MODE_STRIPE);
+        $payment->setProviderId("stripe-floor-test");
+        $payment->setCreatedAt(DateTime::createFromFormat(
+            "Y-m-d H:i:s.u",
+            "2026-03-01 10:00:00.700"
+        ));
+
+        // when — on invoque directement le hook, sans passer par save(), afin
+        // d'observer l'objet en mémoire indépendamment de tout arrondi/troncature
+        // fait par le moteur de base de données au stockage.
+        $payment->preInsert();
+
+        // then — la date en mémoire a été figée à la seconde entière : c'est cette
+        // assertion qui échoue réellement sur ce poste (MariaDB) sans le correctif,
+        // puisqu'avant le correctif l'objet conserve ses microsecondes (.700000)
+        // jusqu'au moment du stockage.
+        $this->assertSame("000000", $payment->getCreatedAt()->format("u"));
     }
 }

--- a/tests/Model/PaymentTest.php
+++ b/tests/Model/PaymentTest.php
@@ -15,14 +15,12 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-
 namespace Model;
 
 use Biblys\Test\ModelFactory;
 use DateTime;
 use Model\Map\PaymentTableMap;
 use PHPUnit\Framework\TestCase;
-use Propel\Runtime\ActiveQuery\Criteria;
 use Propel\Runtime\Exception\PropelException;
 
 class PaymentTest extends TestCase

--- a/tests/Model/PaymentTest.php
+++ b/tests/Model/PaymentTest.php
@@ -18,8 +18,10 @@
 
 namespace Model;
 
+use Biblys\Test\ModelFactory;
 use DateTime;
 use PHPUnit\Framework\TestCase;
+use Propel\Runtime\ActiveQuery\Criteria;
 use Propel\Runtime\Exception\PropelException;
 
 class PaymentTest extends TestCase
@@ -56,5 +58,44 @@ class PaymentTest extends TestCase
 
         // then
         $this->assertTrue($result);
+    }
+
+    /** preInsert */
+
+    /**
+     * @throws PropelException
+     */
+    public function testPreInsertBuildsSignatureChain(): void
+    {
+        // given
+        $order = ModelFactory::createOrder();
+
+        // when — trois paiements créés successivement
+        $first = ModelFactory::createPayment($order, 1500);
+        $second = ModelFactory::createPayment($order, 900);
+        $third = ModelFactory::createPayment($order, 300);
+
+        // then — chaque hash est calculable à partir du précédent
+        $this->assertSame(PaymentHash::CURRENT_VERSION, $third->getHashVersion());
+        $this->assertSame(
+            PaymentHash::compute(
+                PaymentHash::CURRENT_VERSION,
+                $second->getAmount(),
+                $second->getCreatedAt(),
+                $second->getOrderId(),
+                $first->getHash()
+            ),
+            $second->getHash()
+        );
+        $this->assertSame(
+            PaymentHash::compute(
+                PaymentHash::CURRENT_VERSION,
+                $third->getAmount(),
+                $third->getCreatedAt(),
+                $third->getOrderId(),
+                $second->getHash()
+            ),
+            $third->getHash()
+        );
     }
 }


### PR DESCRIPTION
## Problème

Contexte : https://github.com/biblys/biblys/issues/407

Dans le cadre de la conformité NF525, il doit être impossible de modifier a posteriori un paiement enregistré en base de données. Empêcher la modification est impossible, mais implémenter une chaine de signature permet de prouver que les données n'ont pas été altérées.

## Solution

Implémenter une chaîne de signatures sur la table des paiements pour rendre l'historique **inaltérable et vérifiable**. Chaque paiement reçoit un hash SHA-256 chaîné au précédent :

```
hash_n = SHA256(montant | date | commande_id | hash_{n-1})
```

Toute modification rétroactive d'un paiement casse son hash et celui de tous les paiements suivants, rendant l'altération détectable.

## Ce que contient la PR

- **`PaymentHash`** — classe versionnée (`compute($version, …)`), source unique de vérité de la formule. La v1 est *append-only* et gelée par un **golden test** à valeurs SHA-256 codées en dur : toute modification ou suppression de la v1 fait échouer la CI.
- **Colonnes** `payment_hash` (VARCHAR 64) et `payment_hash_version` (TINYINT, défaut 1) + **migration** dont le `postUp` backfill tout l'historique existant (version **pinée à 1** — un artefact de migration reste gelé, ne suit jamais `CURRENT_VERSION`).
- **Hook `Payment::preInsert()`** — calcule et stocke le hash + sa version à chaque insertion, quel que soit le point d'appel (un seul branchement couvre les 7+ sites de création). Utilise `CURRENT_VERSION`.

## Points de conception

- **Versionnement** : faire évoluer la formule plus tard est *additif* (`computeV2` + bump `CURRENT_VERSION`), sans jamais réécrire l'historique — cohérent avec l'esprit d'une chaîne de signatures.
- **Portabilité MySQL/MariaDB** : `payment_created` est stocké sans précision fractionnaire ; MySQL 8 arrondit les sous-secondes là où MariaDB tronque. Le hook tronque donc la date à la seconde avant de hasher **et** de stocker, pour que le hash reproduise exactement la valeur stockée sur n'importe quel moteur.

## Comment tester

Vérification manuelle bout en bout sur une base réelle (aucune commande de vérification n'étant fournie) :

**1. Créer deux paiements** via un parcours normal (finalisation d'une commande, encaissement en caisse, etc.).

**2. Inspecter les deux dernières lignes :**

```sql
SELECT payment_id, payment_amount, payment_created, order_id, payment_hash, payment_hash_version
FROM payments ORDER BY payment_id DESC LIMIT 2;
```

Attendu : `payment_hash` renseigné (64 caractères hexadécimaux), `payment_hash_version = 1`.

**3. Reproduire le hash du plus récent** avec la formule v1 — `montant | date | commande_id | hash_précédent` (champs null → chaîne vide, date au format `Y-m-d H:i:s`), où `hash_précédent` est le `payment_hash` de la ligne d'`payment_id` juste inférieur :

```bash
php -r 'echo hash("sha256", "1500|2026-07-06 14:30:00|4321|<hash_du_paiement_precedent>") . "\n";'
```

Attendu : la valeur imprimée est **identique** au `payment_hash` stocké → le hash est reproductible et la date stockée == date hashée (pas de dérive sous-seconde).

**4. Démontrer la détection d'altération** — modifier directement un paiement en base :

```sql
UPDATE payments SET payment_amount = payment_amount + 100 WHERE payment_id = <id>;
```

En recalculant le hash de ce paiement (étape 3) avec le nouveau montant, la valeur ne correspond plus au `payment_hash` stocké, **et** tous les paiements suivants (qui chaînent sur l'ancien hash) deviennent eux aussi irréconciliables : l'altération est détectable. *(Pensez à restaurer la valeur d'origine après la démonstration.)*

Closes #510
