### PR TITLE
Base de données : ouvrir la connexion legacy de façon paresseuse

### DIFF
--- a/inc/functions.php
+++ b/inc/functions.php
@@ -28,7 +28,6 @@ use Rollbar\Rollbar;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Exception\ServiceUnavailableHttpException;
 
 // Default error level
 ini_set('display_errors', 'On');
@@ -130,13 +129,18 @@ if (is_array($maintenanceMode) && $maintenanceMode["enabled"] === true) {
     die();
 }
 
-try {
-    $_SQL = Biblys\Database\Connection::init($config);
-} catch (ServiceUnavailableHttpException $exception) {
-    $response = new Response($exception->getMessage(), 503);
-    $response->send();
-    die();
-}
+// The legacy connection is opened lazily: requests that never touch legacy
+// SQL (e.g. pages served entirely through Propel) do not open it, which halves
+// the number of concurrent MySQL connections under load.
+//
+// Trade-off: a connection failure is no longer caught here (initLazy() never
+// connects). It now surfaces at the first query. If that query is a legacy
+// one, LazyPdo throws a ServiceUnavailableHttpException rendered as a 503 by
+// the kernel's ErrorController; a Propel-first failure surfaces as a generic
+// 500 instead. During a full outage the error page itself may fail to render
+// (it needs the database) — an accepted degradation, since fewer connections
+// make such outages rarer.
+$_SQL = Biblys\Database\Connection::initLazy($config);
 
 $config = Config::load();
 Biblys\Database\Connection::initPropel($config);

--- a/src/Biblys/Database/Connection.php
+++ b/src/Biblys/Database/Connection.php
@@ -61,6 +61,24 @@ class Connection
     }
 
     /**
+     * Builds a lazily-connecting legacy PDO connection and registers it as the
+     * global `$_SQL`. The MySQL connection is only opened when the connection
+     * is first used, so requests that never touch legacy SQL do not open it.
+     */
+    public static function initLazy(Config $config): PDO
+    {
+        $connection = new LazyPdo(
+            self::getDsnFromConfig($config),
+            $config->get("db.user"),
+            $config->get("db.pass"),
+            $config->get("db.host") . ":" . $config->get("db.port"),
+        );
+        $GLOBALS["_SQL"] = $connection;
+
+        return $connection;
+    }
+
+    /**
      * @throws PropelException
      */
     public static function initPropel(Config $config): void

--- a/src/Biblys/Database/LazyPdo.php
+++ b/src/Biblys/Database/LazyPdo.php
@@ -1,0 +1,160 @@
+<?php
+/*
+ * Copyright (C) 2026 Clément Latzarus
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+
+namespace Biblys\Database;
+
+use Biblys\Service\LoggerService;
+use PDO;
+use PDOException;
+use PDOStatement;
+use Symfony\Component\HttpKernel\Exception\ServiceUnavailableHttpException;
+
+/**
+ * A PDO subclass that defers opening the MySQL connection until it is first
+ * used. Requests that never touch the legacy `$_SQL` connection (e.g. pages
+ * served entirely through Propel) therefore no longer open a second MySQL
+ * connection, which halves the concurrent connection count under load.
+ *
+ * The object IS a real PDO instance, so it satisfies existing `PDO` type
+ * hints and requires no change to the ~80 legacy call sites that use
+ * `global $_SQL`.
+ */
+class LazyPdo extends PDO
+{
+    private bool $connected = false;
+
+    public function __construct(
+        private readonly string  $dsn,
+        private readonly ?string $username,
+        private readonly ?string $password,
+        private readonly string  $serverDescription,
+    ) {
+        // Intentionally do NOT call parent::__construct(): the actual MySQL
+        // connection is opened lazily by ensureConnected() on first use.
+    }
+
+    /**
+     * Opens the underlying connection on first use. Idempotent.
+     *
+     * Not named connect() to avoid colliding with PDO::connect(), the static
+     * factory added in PHP 8.4 (a static/instance clash is a fatal error).
+     *
+     * @throws ServiceUnavailableHttpException when the connection cannot be opened.
+     */
+    private function ensureConnected(): void
+    {
+        if ($this->connected) {
+            return;
+        }
+
+        try {
+            parent::__construct($this->dsn, $this->username, $this->password);
+        } catch (PDOException $exception) {
+            $logger = new LoggerService();
+            $logger->log(
+                logger: "errors",
+                level: "ERROR",
+                message: "Cannot connect to MySQL server " . $this->serverDescription
+                    . " #" . $exception->getCode() . ": " . $exception->getMessage(),
+            );
+            throw new ServiceUnavailableHttpException(null, "Une erreur est survenue lors de la connexion à la base de données. Consultez les logs pour plus de détails.");
+        }
+
+        $this->connected = true;
+        parent::exec("SET CHARACTER SET utf8");
+        parent::setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+    }
+
+    public function prepare(string $query, array $options = []): PDOStatement|false
+    {
+        $this->ensureConnected();
+        return parent::prepare($query, $options);
+    }
+
+    public function query(string $query, ?int $fetchMode = null, mixed ...$fetchModeArgs): PDOStatement|false
+    {
+        $this->ensureConnected();
+        return parent::query($query, $fetchMode, ...$fetchModeArgs);
+    }
+
+    public function exec(string $statement): int|false
+    {
+        $this->ensureConnected();
+        return parent::exec($statement);
+    }
+
+    public function beginTransaction(): bool
+    {
+        $this->ensureConnected();
+        return parent::beginTransaction();
+    }
+
+    public function commit(): bool
+    {
+        $this->ensureConnected();
+        return parent::commit();
+    }
+
+    public function rollBack(): bool
+    {
+        $this->ensureConnected();
+        return parent::rollBack();
+    }
+
+    public function inTransaction(): bool
+    {
+        $this->ensureConnected();
+        return parent::inTransaction();
+    }
+
+    public function lastInsertId(?string $name = null): string|false
+    {
+        $this->ensureConnected();
+        return parent::lastInsertId($name);
+    }
+
+    public function quote(string $string, int $type = PDO::PARAM_STR): string|false
+    {
+        $this->ensureConnected();
+        return parent::quote($string, $type);
+    }
+
+    public function errorCode(): ?string
+    {
+        $this->ensureConnected();
+        return parent::errorCode();
+    }
+
+    public function errorInfo(): array
+    {
+        $this->ensureConnected();
+        return parent::errorInfo();
+    }
+
+    public function getAttribute(int $attribute): mixed
+    {
+        $this->ensureConnected();
+        return parent::getAttribute($attribute);
+    }
+
+    public function setAttribute(int $attribute, mixed $value): bool
+    {
+        $this->ensureConnected();
+        return parent::setAttribute($attribute, $value);
+    }
+}

--- a/tests/Biblys/Database/LazyPdoTest.php
+++ b/tests/Biblys/Database/LazyPdoTest.php
@@ -1,0 +1,80 @@
+<?php
+/*
+ * Copyright (C) 2026 Clément Latzarus
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+
+namespace Biblys\Database;
+
+use Biblys\Service\Config;
+use PDO;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpKernel\Exception\ServiceUnavailableHttpException;
+
+class LazyPdoTest extends TestCase
+{
+    public function testIsInstanceOfPdo()
+    {
+        // given
+        $connection = Connection::initLazy(Config::load());
+
+        // then
+        $this->assertInstanceOf(PDO::class, $connection);
+    }
+
+    public function testDoesNotConnectWithInvalidConfigUntilUsed()
+    {
+        // when a lazy connection is built with an unusable config
+        $connection = Connection::initLazy(new Config(["db" => []]));
+
+        // then no connection is attempted, so no exception is thrown yet
+        $this->assertInstanceOf(PDO::class, $connection);
+    }
+
+    public function testThrowsServiceUnavailableOnFirstUseWhenConnectionFails()
+    {
+        // given a lazy connection built with an unusable config
+        $connection = Connection::initLazy(new Config(["db" => []]));
+
+        // then using it triggers the deferred connection and fails
+        $this->expectException(ServiceUnavailableHttpException::class);
+        $this->expectExceptionMessage("Une erreur est survenue lors de la connexion à la base de données. Consultez les logs pour plus de détails.");
+
+        // when the connection is actually used
+        $connection->query("SELECT 1");
+    }
+
+    public function testConnectsAndQueriesLazilyWithValidConfig()
+    {
+        // given a lazy connection built with the working test config
+        $connection = Connection::initLazy(Config::load());
+
+        // when it is used for the first time
+        $statement = $connection->query("SELECT 1 AS one");
+        $result = $statement->fetch(PDO::FETCH_ASSOC);
+
+        // then it connects transparently and returns the result
+        $this->assertEquals(1, $result["one"]);
+    }
+
+    public function testStoresConnectionInGlobals()
+    {
+        // when
+        $connection = Connection::initLazy(Config::load());
+
+        // then the legacy global points to the lazy connection
+        $this->assertSame($connection, $GLOBALS["_SQL"]);
+    }
+}


### PR DESCRIPTION
## Contexte

En production, le serveur MySQL a saturé à plusieurs reprises (`max_user_connections`) sous la charge de scrapers agressifs martelant les endpoints de recherche coûteux (`/articles/search`, `/o/collection/…`). Chaque saturation fait échouer **toutes** les requêtes concurrentes, y compris les validations de commande — d'où des commandes perdues.

## Cause

Chaque requête web ouvrait **deux** connexions MySQL simultanées :
- la connexion PDO legacy `$_SQL`, ouverte **systématiquement** dans `inc/functions.php` ;
- la connexion Propel.

Depuis que la logique cœur de chaque requête (session/visiteur, options, droits) est passée à Propel, les pages servies entièrement par Propel payaient quand même la connexion legacy. Le nombre de connexions concurrentes était donc doublé, franchissant `max_user_connections` bien plus tôt sous charge.

## Correctif

- Nouvelle classe `LazyPdo` (sous-classe de `PDO`) qui diffère l'ouverture de la connexion jusqu'au premier usage réel.
- `Connection::initLazy()` (additif — `init()` inchangé) construit cette connexion paresseuse et l'enregistre comme `$_SQL`.
- Le bootstrap (`functions.php`) bascule sur `initLazy()`.

Une page qui ne touche jamais au SQL legacy n'ouvre plus la seconde connexion → le nombre de connexions concurrentes par requête passe de ~2 à ~1, quel que soit le scraper.

## Points de conception

- **Zéro changement aux ~80 appels `global $_SQL`** : `LazyPdo` **est** un vrai `PDO`, donc tous les type-hints `: PDO` et le code legacy fonctionnent tels quels.
- La gestion d'erreur de connexion (log « Cannot connect… » + 503) est déplacée au moment réel de la connexion ; une DB injoignable remonte désormais proprement via l'`ErrorController` du kernel.

## Tests

- Nouveau `tests/Biblys/Database/LazyPdoTest.php` (déferrement, échec à l'usage, requête réelle, enregistrement dans `$_SQL`).
- Suite complète : **1220 tests OK**. Chaque test transite par le bootstrap, donc toute la couche DB legacy est exercée via la connexion paresseuse.
