### PR TITLE
Afficher les informations détaillées de TVA sur la facture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
 - La page de facture d'une commande a été refondue : elle s'affiche désormais
   dans une présentation épurée dédiée à l'impression (sans le menu ni l'habillage
   du site), plus lisible, avec un bouton de retour. 
+- La facture affiche désormais le détail de la TVA : taux, prix HT et TVA pour
+  chaque article, ainsi qu'un tableau de synthèse ventilant base HT, montant de
+  TVA et total TTC par taux appliqué sur la commande.
 
 ## 3.14.0 (4 juillet 2026)
 

--- a/src/AppBundle/Controller/OrderController.php
+++ b/src/AppBundle/Controller/OrderController.php
@@ -282,11 +282,23 @@ class OrderController extends Controller
 
         $lines = [];
         $totalHt = 0;
-        $totalTva = 0;
+        $totalVat = 0;
+        $vatBreakdown = [];
         foreach ($stocks as $stock) {
             $article = $stock->getArticle();
-            $totalHt += (int) $stock->getSellingPriceHt();
-            $totalTva += (int) $stock->getSellingPriceTva();
+            $priceHt = (int) $stock->getSellingPriceHt();
+            $priceVat = (int) $stock->getSellingPriceTva();
+            $vatRate = $stock->getTvaRate();
+            $totalHt += $priceHt;
+            $totalVat += $priceVat;
+
+            $breakdownKey = $vatRate !== null ? (string) $vatRate : "unknown";
+            if (!isset($vatBreakdown[$breakdownKey])) {
+                $vatBreakdown[$breakdownKey] = ["rate" => $vatRate, "ht" => 0, "vat" => 0, "ttc" => 0];
+            }
+            $vatBreakdown[$breakdownKey]["ht"] += $priceHt;
+            $vatBreakdown[$breakdownKey]["vat"] += $priceVat;
+            $vatBreakdown[$breakdownKey]["ttc"] += $priceHt + $priceVat;
 
             $notices = [];
             if ($article->getTypeId() == 2) {
@@ -303,8 +315,21 @@ class OrderController extends Controller
                 "number" => $article->getNumber(),
                 "condition" => $stock->getCondition(),
                 "price" => (int) $stock->getSellingPrice(),
+                "priceHt" => $priceHt,
+                "priceVat" => $priceVat,
+                "vatRate" => $vatRate,
             ];
         }
+
+        uasort($vatBreakdown, function ($a, $b) {
+            if ($a["rate"] === null) {
+                return 1;
+            }
+            if ($b["rate"] === null) {
+                return -1;
+            }
+            return $a["rate"] <=> $b["rate"];
+        });
 
         $payment = null;
         if ($order->getPaymentDate()) {
@@ -319,7 +344,8 @@ class OrderController extends Controller
             "order" => $order,
             "lines" => $lines,
             "total_ht" => $totalHt,
-            "total_tva" => $totalTva,
+            "total_vat" => $totalVat,
+            "vat_breakdown" => $vatBreakdown,
             "is_shop" => (bool) $currentSite->getSite()->getShop(),
             "has_tva" => (bool) $currentSite->getSite()->getTva(),
             "payment" => $payment,

--- a/src/AppBundle/Controller/OrderController.php
+++ b/src/AppBundle/Controller/OrderController.php
@@ -347,7 +347,7 @@ class OrderController extends Controller
             "total_vat" => $totalVat,
             "vat_breakdown" => $vatBreakdown,
             "is_shop" => (bool) $currentSite->getSite()->getShop(),
-            "has_tva" => (bool) $currentSite->getSite()->getTva(),
+            "has_vat" => (bool) $currentSite->getSite()->getTva(),
             "payment" => $payment,
             "invoice_notice" => $currentSite->getOption("invoice_notice"),
             "site_title" => $currentSite->getTitle(),

--- a/src/AppBundle/Resources/views/Order/invoice.html.twig
+++ b/src/AppBundle/Resources/views/Order/invoice.html.twig
@@ -62,7 +62,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 {% endblock %}
 
 {% block main %}
-    {% set colspan = is_shop ? 2 : 1 %}
+    {% set colspan = is_shop ? 3 : 2 %}
 
     <a href="javascript:history.back()" class="btn btn-secondary d-print-none mb-3">← Retour</a>
 
@@ -92,7 +92,10 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
                 <tr>
                     <th>Article</th>
                     {% if is_shop %}<th>État</th>{% endif %}
-                    <th class="text-right">Prix</th>
+                    <th class="text-right">Taux</th>
+                    <th class="text-right">Prix HT</th>
+                    <th class="text-right">TVA</th>
+                    <th class="text-right">Prix TTC</th>
                 </tr>
             </thead>
             <tbody>
@@ -110,6 +113,9 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
                             </p>
                         </td>
                         {% if is_shop %}<td class="text-center align">{{ line.condition }}</td>{% endif %}
+                        <td class="text-right align">{{ line.vatRate is not null ? (line.vatRate|replace({'.': ','}) ~ ' %') : '—' }}</td>
+                        <td class="text-right align">{{ line.vatRate is not null ? line.priceHt|currency(true)|raw : '—' }}</td>
+                        <td class="text-right align">{{ line.vatRate is not null ? line.priceVat|currency(true)|raw : '—' }}</td>
                         <td class="text-right align">{{ line.price|currency(true)|raw }}</td>
                     </tr>
                 {% endfor %}
@@ -122,6 +128,10 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
                                 <small class="text-muted">({{ order.shippingMode }})</small>
                             </p>
                         </td>
+                        {% if is_shop %}<td></td>{% endif %}
+                        <td class="text-right align">—</td>
+                        <td class="text-right align">—</td>
+                        <td class="text-right align">—</td>
                         <td class="text-right align">
                             {{ order.shippingCost|currency(true)|raw }}
                         </td>
@@ -131,12 +141,26 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
             <tfoot>
                 {% if total_tva %}
                     <tr>
-                        <th colspan="{{ colspan }}" class="text-right">Total H.T. :</th>
-                        <th class="text-right">{{ total_ht|currency(true)|raw }}</th>
+                        <th colspan="{{ colspan }}" class="text-right">Taux</th>
+                        <th class="text-right">Base HT</th>
+                        <th class="text-right">TVA</th>
+                        <th class="text-right">Total TTC</th>
                     </tr>
+                    {% for group in vat_breakdown %}
+                        <tr>
+                            <th colspan="{{ colspan }}" class="text-right">
+                                {{ group.rate is not null ? (group.rate|replace({'.': ','}) ~ ' %') : 'Taux inconnu' }}
+                            </th>
+                            <th class="text-right">{{ group.ht|currency(true)|raw }}</th>
+                            <th class="text-right">{{ group.vat|currency(true)|raw }}</th>
+                            <th class="text-right">{{ group.ttc|currency(true)|raw }}</th>
+                        </tr>
+                    {% endfor %}
                     <tr>
-                        <th colspan="{{ colspan }}" class="text-right">T.V.A. :</th>
-                        <th class="text-right">{{ total_tva|currency(true)|raw }}</th>
+                        <th colspan="{{ colspan }}" class="text-right">Total</th>
+                        <th class="text-right">{{ total_ht|currency(true)|raw }}</th>
+                        <th class="text-right">{{ total_vat|currency(true)|raw }}</th>
+                        <th class="text-right">{{ (total_ht + total_vat)|currency(true)|raw }}</th>
                     </tr>
                 {% endif %}
             </tfoot>

--- a/src/AppBundle/Resources/views/Order/invoice.html.twig
+++ b/src/AppBundle/Resources/views/Order/invoice.html.twig
@@ -139,7 +139,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
                 {% endif %}
             </tbody>
             <tfoot>
-                {% if total_tva %}
+                {% if total_vat %}
                     <tr>
                         <th colspan="{{ colspan }}" class="text-right">Taux</th>
                         <th class="text-right">Base HT</th>
@@ -177,7 +177,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
         </div>
 
         <footer class="mt-4">
-            {% if not has_tva %}
+            {% if not has_vat %}
                 <p class="text-center">
                     TVA non applicable en application de l'article 293 B du CGI.
                 </p>

--- a/tests/AppBundle/Controller/OrderControllerTest.php
+++ b/tests/AppBundle/Controller/OrderControllerTest.php
@@ -450,6 +450,67 @@ class OrderControllerTest extends TestCase
         $this->assertStringContainsString("Le Livre Test", $response->getContent());
     }
 
+    public function testInvoiceActionShowsVatBreakdownByRate(): void
+    {
+        // given : une commande mélangeant un livre (5,5 %) et un article standard (20 %)
+        $controller = new OrderController();
+        $request = new Request();
+        $order = ModelFactory::createOrder(slug: "invoice-vat-mix", amount: 3000, shippingCost: 0);
+        $book = ModelFactory::createArticle(title: "Le Livre Test");
+        $standardItem = ModelFactory::createArticle(title: "Un Objet Dérivé");
+
+        $bookStock = ModelFactory::createStockItem(article: $book, order: $order, sellingPrice: 2000);
+        $bookStock->setSellingPriceHt(1896)->setSellingPriceTva(104)->setTvaRate(5.5)->save();
+
+        $standardStock = ModelFactory::createStockItem(article: $standardItem, order: $order, sellingPrice: 1000);
+        $standardStock->setSellingPriceHt(833)->setSellingPriceTva(167)->setTvaRate(20)->save();
+
+        $currentUser = Mockery::mock(CurrentUser::class);
+        $currentUser->shouldReceive("isAuthenticated")->andReturn(false);
+        $currentUser->shouldReceive("isAdmin")->andReturn(false);
+        $currentSite = $this->_mockCurrentSiteForInvoice();
+        $templateService = Helpers::getTemplateService();
+
+        // when
+        $response = $controller->invoiceAction($request, $currentUser, $currentSite, $templateService, "invoice-vat-mix");
+        $content = $response->getContent();
+
+        // then
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertStringContainsString("5,5 %", $content, "Le taux de TVA du livre doit apparaître dans la ventilation");
+        $this->assertStringContainsString("20 %", $content, "Le taux de TVA de l'article standard doit apparaître dans la ventilation");
+    }
+
+    public function testInvoiceActionGroupsUnknownVatRate(): void
+    {
+        // given : un exemplaire vendu sans taux de TVA renseigné (cas legacy),
+        // accompagné d'un article à taux connu pour que le bloc de ventilation s'affiche
+        $controller = new OrderController();
+        $request = new Request();
+        $order = ModelFactory::createOrder(slug: "invoice-vat-unk", amount: 4000, shippingCost: 0);
+        $article = ModelFactory::createArticle(title: "Le Livre Test");
+        $stock = ModelFactory::createStockItem(article: $article, order: $order, sellingPrice: 2000);
+        $stock->setSellingPriceHt(0)->setSellingPriceTva(0)->setTvaRate(null)->save();
+
+        $knownRateArticle = ModelFactory::createArticle(title: "Un Objet Dérivé");
+        $knownRateStock = ModelFactory::createStockItem(article: $knownRateArticle, order: $order, sellingPrice: 2000);
+        $knownRateStock->setSellingPriceHt(1667)->setSellingPriceTva(333)->setTvaRate(20)->save();
+
+        $currentUser = Mockery::mock(CurrentUser::class);
+        $currentUser->shouldReceive("isAuthenticated")->andReturn(false);
+        $currentUser->shouldReceive("isAdmin")->andReturn(false);
+        $currentSite = $this->_mockCurrentSiteForInvoice();
+        $templateService = Helpers::getTemplateService();
+
+        // when
+        $response = $controller->invoiceAction($request, $currentUser, $currentSite, $templateService, "invoice-vat-unk");
+        $content = $response->getContent();
+
+        // then
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertStringContainsString("Taux inconnu", $content, "Un taux de TVA non renseigné doit être regroupé sous « Taux inconnu »");
+    }
+
     public function testInvoiceActionRendersPaidOrderWithoutPaymentMode(): void
     {
         // given : commande réglée (date de paiement) mais sans mode de paiement


### PR DESCRIPTION
## Problème

Le détail de la TVA n'est pas affiché sur la facture.

## Solution

- Ajout des colonnes Taux TVA / Prix HT / TVA / Prix TTC sur chaque ligne d'article de la facture (`OrderController::invoiceAction`, `Order/invoice.html.twig`)
- Ajout d'un tableau de synthèse en pied de facture, ventilant base HT / montant TVA / total TTC par taux de TVA appliqué sur la commande
- Les exemplaires vendus sans taux de TVA renseigné (cas legacy) sont regroupés sous une ligne « Taux inconnu »
- Les frais de port restent hors calcul de TVA, comme aujourd'hui (pas de changement de comportement sur ce point)

## Test plan

- [x] `composer test:path tests/AppBundle/Controller/OrderControllerTest.php` (17/17 tests passent)
- [x] Suite complète (`composer test`) sans régression introduite (un échec préexistant sur `PaymentControllerTest` lié à PayPlug, indépendant de ce changement)
- [x] Rendu HTML de la facture vérifié manuellement avec une commande multi-taux (livre 5,5 %, ebook 5,5 %, article standard 20 %, port) : ventilation et totaux corrects
- [ ] Vérification visuelle de la mise en page à l'impression (nouveau tableau à 5-6 colonnes) sur un environnement local avec navigateur