### PR TITLE
Ventilation de la TVA sur les frais de port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 - La facture affiche désormais le détail de la TVA : taux, prix HT et TVA pour
   chaque article, ainsi qu'un tableau de synthèse ventilant base HT, montant de
   TVA et total TTC par taux appliqué sur la commande.
+- Les frais de port sont désormais ventilés par taux de TVA sur la facture,
+  au prorata du montant HT de chaque taux présent sur la commande.
 
 ## 3.14.1 (11 juillet 2026)
 

--- a/src/AppBundle/Controller/OrderController.php
+++ b/src/AppBundle/Controller/OrderController.php
@@ -24,6 +24,7 @@ use Biblys\Service\CurrentSite;
 use Biblys\Service\CurrentUser;
 use Biblys\Service\InvalidSiteIdException;
 use Biblys\Service\Mailer;
+use Biblys\Service\ShippingVatAllocationService;
 use Biblys\Service\TemplateService;
 use Exception;
 use Framework\Controller;
@@ -321,6 +322,15 @@ class OrderController extends Controller
             ];
         }
 
+        $shippingParts = [];
+        if ($order->getShippingCost() > 0) {
+            $htByRate = array_map(fn($group) => $group["ht"], $vatBreakdown);
+            $shippingParts = ShippingVatAllocationService::allocate($htByRate, (int) $order->getShippingCost());
+            $vatBreakdown = ShippingVatAllocationService::mergeIntoBreakdown($vatBreakdown, $shippingParts);
+            $totalHt += array_sum(array_column($shippingParts, "ht"));
+            $totalVat += array_sum(array_column($shippingParts, "vat"));
+        }
+
         uasort($vatBreakdown, function ($a, $b) {
             if ($a["rate"] === null) {
                 return 1;
@@ -330,6 +340,8 @@ class OrderController extends Controller
             }
             return $a["rate"] <=> $b["rate"];
         });
+
+        $shippingVat = ShippingVatAllocationService::summarizeForDisplay($shippingParts, $vatBreakdown);
 
         $payment = null;
         if ($order->getPaymentDate()) {
@@ -346,6 +358,7 @@ class OrderController extends Controller
             "total_ht" => $totalHt,
             "total_vat" => $totalVat,
             "vat_breakdown" => $vatBreakdown,
+            "shipping_vat" => $shippingVat,
             "is_shop" => (bool) $currentSite->getSite()->getShop(),
             "has_vat" => (bool) $currentSite->getSite()->getTva(),
             "payment" => $payment,

--- a/src/AppBundle/Resources/views/Order/invoice.html.twig
+++ b/src/AppBundle/Resources/views/Order/invoice.html.twig
@@ -46,6 +46,10 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
             font-size: 18pt;
         }
 
+        .invoice-document .article-list thead th {
+            font-weight: normal;
+        }
+
         .invoice-document .total {
           background: rgba(0, 0, 0, 0.03);
           display: flex;
@@ -54,15 +58,39 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
           padding: 10pt 20pt;
         }
 
-        /* Alignements (print.css supprimé) : valables à l'écran et à l'impression. */
-        .invoice-document .text-right { text-align: right; }
-        .invoice-document .text-center { text-align: center; }
-        .invoice-document .align { vertical-align: middle; }
+        .invoice-document .vat-breakdown {
+            margin-left: auto;
+            margin-right: 0;
+            width: auto;
+        }
+
+        .invoice-document .vat-breakdown th,
+        .invoice-document .vat-breakdown td {
+            background: rgba(0, 0, 0, 0.03);
+            border-color: rgba(0, 0, 0, 0.08);
+            padding: 8pt 12pt;
+        }
+
+        .invoice-document .vat-breakdown th {
+            font-weight: bold;
+        }
+
+        .invoice-document .text-right { 
+            text-align: right; 
+        }
+
+        .invoice-document .text-center { 
+            text-align: center; 
+        }
+
+        .invoice-document .align { 
+            vertical-align: middle; 
+        }
     </style>
 {% endblock %}
 
 {% block main %}
-    {% set colspan = is_shop ? 3 : 2 %}
+    {% set vatBreakdownColspan = 3 %}
 
     <a href="javascript:history.back()" class="btn btn-secondary d-print-none mb-3">← Retour</a>
 
@@ -79,7 +107,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
                     {{ order.address1 }}<br>
                     {% if order.address2 %}{{ order.address2 }}<br>{% endif %}
                     {{ order.postalcode }} {{ order.city }}<br>
-                    {{ order.countryName }}
+                    {{ order.country.name }}
                 </p>
                 <p>{{ order.email }}</p>
             </div>
@@ -92,9 +120,11 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
                 <tr>
                     <th>Article</th>
                     {% if is_shop %}<th>État</th>{% endif %}
-                    <th class="text-right">Taux</th>
-                    <th class="text-right">Prix HT</th>
-                    <th class="text-right">TVA</th>
+                    {% if has_vat %}
+                        <th class="text-right">Taux</th>
+                        <th class="text-right">Prix HT</th>
+                        <th class="text-right">TVA</th>
+                    {% endif %}
                     <th class="text-right">Prix TTC</th>
                 </tr>
             </thead>
@@ -113,9 +143,11 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
                             </p>
                         </td>
                         {% if is_shop %}<td class="text-center align">{{ line.condition }}</td>{% endif %}
-                        <td class="text-right align">{{ line.vatRate is not null ? (line.vatRate|replace({'.': ','}) ~ ' %') : '—' }}</td>
-                        <td class="text-right align">{{ line.vatRate is not null ? line.priceHt|currency(true)|raw : '—' }}</td>
-                        <td class="text-right align">{{ line.vatRate is not null ? line.priceVat|currency(true)|raw : '—' }}</td>
+                        {% if has_vat %}
+                            <td class="text-right align">{{ line.vatRate is not null ? (line.vatRate|replace({'.': ','}) ~ ' %') : '—' }}</td>
+                            <td class="text-right align">{{ line.vatRate is not null ? line.priceHt|currency(true)|raw : '—' }}</td>
+                            <td class="text-right align">{{ line.vatRate is not null ? line.priceVat|currency(true)|raw : '—' }}</td>
+                        {% endif %}
                         <td class="text-right align">{{ line.price|currency(true)|raw }}</td>
                     </tr>
                 {% endfor %}
@@ -129,42 +161,51 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
                             </p>
                         </td>
                         {% if is_shop %}<td></td>{% endif %}
-                        <td class="text-right align">—</td>
-                        <td class="text-right align">—</td>
-                        <td class="text-right align">—</td>
+                        {% if has_vat %}
+                            <td class="text-right align">
+                                {{ shipping_vat is not null and shipping_vat.rate is not null ? (shipping_vat.rate|replace({'.': ','}) ~ ' %') : (shipping_vat is not null ? 'Taux inconnu' : '—') }}{% if shipping_vat is not null and shipping_vat.recalculated %}*{% endif %}
+                            </td>
+                            <td class="text-right align">{{ shipping_vat is not null ? shipping_vat.ht|currency(true)|raw : '—' }}</td>
+                            <td class="text-right align">{{ shipping_vat is not null ? shipping_vat.vat|currency(true)|raw : '—' }}</td>
+                        {% endif %}
                         <td class="text-right align">
                             {{ order.shippingCost|currency(true)|raw }}
                         </td>
                     </tr>
                 {% endif %}
             </tbody>
-            <tfoot>
-                {% if total_vat %}
+        </table>
+
+        {% if total_vat %}
+            <table class="table vat-breakdown mt-4">
+                <thead>
                     <tr>
-                        <th colspan="{{ colspan }}" class="text-right">Taux</th>
+                        <th colspan="{{ vatBreakdownColspan }}" class="text-right">Taux</th>
                         <th class="text-right">Base HT</th>
                         <th class="text-right">TVA</th>
                         <th class="text-right">Total TTC</th>
                     </tr>
+                </thead>
+                <tbody>
                     {% for group in vat_breakdown %}
                         <tr>
-                            <th colspan="{{ colspan }}" class="text-right">
+                            <td colspan="{{ vatBreakdownColspan }}" class="text-right">
                                 {{ group.rate is not null ? (group.rate|replace({'.': ','}) ~ ' %') : 'Taux inconnu' }}
-                            </th>
-                            <th class="text-right">{{ group.ht|currency(true)|raw }}</th>
-                            <th class="text-right">{{ group.vat|currency(true)|raw }}</th>
-                            <th class="text-right">{{ group.ttc|currency(true)|raw }}</th>
+                            </td>
+                            <td class="text-right">{{ group.ht|currency(true)|raw }}</td>
+                            <td class="text-right">{{ group.vat|currency(true)|raw }}</td>
+                            <td class="text-right">{{ group.ttc|currency(true)|raw }}</td>
                         </tr>
                     {% endfor %}
                     <tr>
-                        <th colspan="{{ colspan }}" class="text-right">Total</th>
-                        <th class="text-right">{{ total_ht|currency(true)|raw }}</th>
-                        <th class="text-right">{{ total_vat|currency(true)|raw }}</th>
-                        <th class="text-right">{{ (total_ht + total_vat)|currency(true)|raw }}</th>
+                        <td colspan="{{ vatBreakdownColspan }}" class="text-right">Total</td>
+                        <td class="text-right">{{ total_ht|currency(true)|raw }}</td>
+                        <td class="text-right">{{ total_vat|currency(true)|raw }}</td>
+                        <td class="text-right">{{ (total_ht + total_vat)|currency(true)|raw }}</td>
                     </tr>
-                {% endif %}
-            </tfoot>
-        </table>
+                </tbody>
+            </table>
+        {% endif %}
 
 
         <div class="total">
@@ -192,6 +233,15 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
             {% if invoice_notice %}
                 <p class="text-center">
                     {{ invoice_notice|replace({'\\n': '<br>'})|raw }}
+                </p>
+            {% endif %}
+
+            {% if shipping_vat is not null and shipping_vat.recalculated %}
+                <p class="text-center text-muted">
+                    * Cette commande comporte plusieurs taux de TVA ; les frais de port ont été
+                    répartis entre eux au prorata du montant HT de chaque taux. Le taux affiché
+                    ici est recalculé à partir du total de TVA et de la base HT ainsi obtenus
+                    pour le port (TVA ÷ HT).
                 </p>
             {% endif %}
         </footer>

--- a/src/Biblys/Service/ShippingVatAllocationService.php
+++ b/src/Biblys/Service/ShippingVatAllocationService.php
@@ -1,0 +1,130 @@
+<?php
+/*
+ * Copyright (C) 2026 Clément Latzarus
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+
+namespace Biblys\Service;
+
+class ShippingVatAllocationService
+{
+    /**
+     * Ventile les frais de port (TTC) au prorata du total HT de chaque taux
+     * de TVA présent sur la commande, puis décompose chaque part en HT/TVA
+     * avec le taux de son groupe.
+     *
+     * @param array<string, int> $htByRate Total HT en centimes par taux ("5.5", "20", "unknown"...)
+     * @param int $shippingCostTtc Frais de port en centimes, TTC
+     * @return array<string, array{ht: int, vat: int, ttc: int}>
+     */
+    public static function allocate(array $htByRate, int $shippingCostTtc): array
+    {
+        if ($shippingCostTtc === 0 || empty($htByRate)) {
+            return [];
+        }
+
+        if (count($htByRate) === 1) {
+            $rateKey = array_key_first($htByRate);
+            return [$rateKey => self::decompose($shippingCostTtc, self::rateFromKey($rateKey))];
+        }
+
+        $totalHt = array_sum($htByRate);
+        $lastKey = array_key_last($htByRate);
+        $allocatedTtc = 0;
+        $parts = [];
+
+        foreach ($htByRate as $rateKey => $rateHt) {
+            if ($rateKey === $lastKey) {
+                $ttcPart = $shippingCostTtc - $allocatedTtc;
+            } else {
+                $weight = $totalHt > 0 ? $rateHt / $totalHt : 0;
+                $ttcPart = (int) round($shippingCostTtc * $weight);
+                $allocatedTtc += $ttcPart;
+            }
+
+            $parts[$rateKey] = self::decompose($ttcPart, self::rateFromKey($rateKey));
+        }
+
+        return $parts;
+    }
+
+    /**
+     * Ajoute les parts de port ventilées à un récapitulatif de TVA par taux
+     * déjà constitué (ex. celui des lignes d'une commande), en cumulant
+     * HT/TVA/TTC pour chaque taux concerné.
+     *
+     * @param array<string, array{rate: ?float, ht: int, vat: int, ttc: int}> $vatBreakdown
+     * @param array<string, array{ht: int, vat: int, ttc: int}> $shippingParts
+     * @return array<string, array{rate: ?float, ht: int, vat: int, ttc: int}>
+     */
+    public static function mergeIntoBreakdown(array $vatBreakdown, array $shippingParts): array
+    {
+        foreach ($shippingParts as $rateKey => $part) {
+            $vatBreakdown[$rateKey]["ht"] += $part["ht"];
+            $vatBreakdown[$rateKey]["vat"] += $part["vat"];
+            $vatBreakdown[$rateKey]["ttc"] += $part["ttc"];
+        }
+
+        return $vatBreakdown;
+    }
+
+    /**
+     * Construit le résumé à afficher sur la ligne de port d'une facture : le
+     * taux réel si un seul taux s'applique, ou un taux recalculé (TVA ÷ HT)
+     * agrégeant toutes les parts si plusieurs taux ont été ventilés.
+     *
+     * @param array<string, array{ht: int, vat: int, ttc: int}> $shippingParts
+     * @param array<string, array{rate: ?float, ht: int, vat: int, ttc: int}> $vatBreakdown
+     * @return array{rate: ?float, ht: int, vat: int, recalculated: bool}|null
+     */
+    public static function summarizeForDisplay(array $shippingParts, array $vatBreakdown): ?array
+    {
+        if (empty($shippingParts)) {
+            return null;
+        }
+
+        $ht = array_sum(array_column($shippingParts, "ht"));
+        $vat = array_sum(array_column($shippingParts, "vat"));
+
+        if (count($shippingParts) === 1) {
+            $rateKey = array_key_first($shippingParts);
+
+            return ["rate" => $vatBreakdown[$rateKey]["rate"], "ht" => $ht, "vat" => $vat, "recalculated" => false];
+        }
+
+        return [
+            "rate" => $ht > 0 ? round($vat / $ht * 100, 1) : null,
+            "ht" => $ht,
+            "vat" => $vat,
+            "recalculated" => true,
+        ];
+    }
+
+    private static function rateFromKey(string $rateKey): ?float
+    {
+        return $rateKey === "unknown" ? null : (float) $rateKey;
+    }
+
+    private static function decompose(int $ttc, ?float $rate): array
+    {
+        if ($rate === null || $rate === 0.0) {
+            return ["ht" => $ttc, "vat" => 0, "ttc" => $ttc];
+        }
+
+        $ht = (int) round($ttc / (1 + $rate / 100));
+
+        return ["ht" => $ht, "vat" => $ttc - $ht, "ttc" => $ttc];
+    }
+}

--- a/tests/AppBundle/Controller/OrderControllerTest.php
+++ b/tests/AppBundle/Controller/OrderControllerTest.php
@@ -511,6 +511,113 @@ class OrderControllerTest extends TestCase
         $this->assertStringContainsString("Taux inconnu", $content, "Un taux de TVA non renseigné doit être regroupé sous « Taux inconnu »");
     }
 
+    public function testInvoiceActionAllocatesShippingVatForSingleRate(): void
+    {
+        // given : une commande mono-taux (20 %) avec des frais de port
+        $controller = new OrderController();
+        $request = new Request();
+        $order = ModelFactory::createOrder(slug: "inv-ship-single", amount: 2000, shippingCost: 600);
+        $article = ModelFactory::createArticle(title: "Un Objet Dérivé");
+        $stock = ModelFactory::createStockItem(article: $article, order: $order, sellingPrice: 2000);
+        $stock->setSellingPriceHt(1667)->setSellingPriceTva(333)->setTvaRate(20)->save();
+
+        $currentUser = Mockery::mock(CurrentUser::class);
+        $currentUser->shouldReceive("isAuthenticated")->andReturn(false);
+        $currentUser->shouldReceive("isAdmin")->andReturn(false);
+        $currentSite = $this->_mockCurrentSiteForInvoice();
+        $templateService = Helpers::getTemplateService();
+
+        // when
+        $response = $controller->invoiceAction($request, $currentUser, $currentSite, $templateService, "inv-ship-single");
+        $content = $response->getContent();
+
+        // then : le port apparaît décomposé sous son propre taux, plus de tirets sur sa ligne,
+        // et le total TVA global inclut désormais la TVA du port (333 articles + 100 port = 433 c)
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertStringNotContainsString('<td class="text-right align">—</td>', $content);
+        // currency() rend l'entité HTML &euro;, pas le glyphe € directement
+        $this->assertStringContainsString("4,33&nbsp;&euro;", $content, "La TVA totale (article + port) doit apparaître dans le pied de facture");
+    }
+
+    public function testInvoiceActionAllocatesShippingVatAcrossMultipleRates(): void
+    {
+        // given : livre (5,5 %) + article standard (20 %), port 600 c
+        $controller = new OrderController();
+        $request = new Request();
+        $order = ModelFactory::createOrder(slug: "inv-ship-multi", amount: 3000, shippingCost: 600);
+        $book = ModelFactory::createArticle(title: "Le Livre Test");
+        $standardItem = ModelFactory::createArticle(title: "Un Objet Dérivé");
+
+        $bookStock = ModelFactory::createStockItem(article: $book, order: $order, sellingPrice: 2000);
+        $bookStock->setSellingPriceHt(1896)->setSellingPriceTva(104)->setTvaRate(5.5)->save();
+
+        $standardStock = ModelFactory::createStockItem(article: $standardItem, order: $order, sellingPrice: 1000);
+        $standardStock->setSellingPriceHt(833)->setSellingPriceTva(167)->setTvaRate(20)->save();
+
+        $currentUser = Mockery::mock(CurrentUser::class);
+        $currentUser->shouldReceive("isAuthenticated")->andReturn(false);
+        $currentUser->shouldReceive("isAdmin")->andReturn(false);
+        $currentSite = $this->_mockCurrentSiteForInvoice();
+        $templateService = Helpers::getTemplateService();
+
+        // when
+        $response = $controller->invoiceAction($request, $currentUser, $currentSite, $templateService, "inv-ship-multi");
+        $content = $response->getContent();
+
+        // then : la ligne de port affiche un taux recalculé (marqué d'une étoile), obtenu
+        // en agrégeant les parts HT/TVA du port réparties au prorata (395+153 c HT,
+        // 22+30 c TVA sur 600 c TTC) puis TVA ÷ HT = 52/548 ≈ 9,5 %, plus une notice
+        // explicative en pied de page
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertStringContainsString("9,5 %*", $content, "Le taux recalculé du port doit être marqué d'une étoile");
+        $this->assertStringContainsString("5,48&nbsp;&euro;", $content, "HT agrégé du port (395 + 153 c)");
+        $this->assertStringContainsString("0,52&nbsp;&euro;", $content, "TVA agrégée du port (22 + 30 c)");
+        $this->assertStringContainsString(
+            "les frais de port ont été",
+            $content,
+            "La notice explicative du taux recalculé doit apparaître en pied de page"
+        );
+    }
+
+    public function testInvoiceActionHidesVatColumnsWhenSiteHasNoVat(): void
+    {
+        // given : un site non soumis à la TVA (art. 293 B du CGI), commande avec port
+        $controller = new OrderController();
+        $request = new Request();
+        $order = ModelFactory::createOrder(slug: "invoice-no-vat", amount: 2000, shippingCost: 600);
+        $article = ModelFactory::createArticle(title: "Un Objet Dérivé");
+        $stock = ModelFactory::createStockItem(article: $article, order: $order, sellingPrice: 2000);
+        $stock->setSellingPriceHt(2000)->setSellingPriceTva(0)->setTvaRate(null)->save();
+
+        $site = Mockery::mock(Site::class);
+        $site->shouldReceive("getShop")->andReturn(false);
+        $site->shouldReceive("getTva")->andReturn(null);
+        $site->shouldReceive("getAddress")->andReturn("1 rue du Livre|33000 Bordeaux");
+        $currentSite = Mockery::mock(CurrentSite::class);
+        $currentSite->shouldReceive("getSite")->andReturn($site);
+        $currentSite->shouldReceive("getTitle")->andReturn("Ma librairie");
+        $currentSite->shouldReceive("getOption")->with("invoice_notice")->andReturn(null);
+
+        $currentUser = Mockery::mock(CurrentUser::class);
+        $currentUser->shouldReceive("isAuthenticated")->andReturn(false);
+        $currentUser->shouldReceive("isAdmin")->andReturn(false);
+        $templateService = Helpers::getTemplateService();
+
+        // when
+        $response = $controller->invoiceAction($request, $currentUser, $currentSite, $templateService, "invoice-no-vat");
+        $content = $response->getContent();
+
+        // then : les colonnes Taux/Prix HT/TVA sont masquées, seul le prix reste affiché
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertStringNotContainsString('<th class="text-right">Taux</th>', $content);
+        $this->assertStringNotContainsString('<th class="text-right">Prix HT</th>', $content);
+        $this->assertStringContainsString('<th class="text-right">Prix TTC</th>', $content);
+        $this->assertStringContainsString(
+            "TVA non applicable en application de l'article 293 B du CGI.",
+            $content
+        );
+    }
+
     public function testInvoiceActionRendersPaidOrderWithoutPaymentMode(): void
     {
         // given : commande réglée (date de paiement) mais sans mode de paiement

--- a/tests/Biblys/Service/ShippingVatAllocationServiceTest.php
+++ b/tests/Biblys/Service/ShippingVatAllocationServiceTest.php
@@ -1,0 +1,209 @@
+<?php
+/*
+ * Copyright (C) 2026 Clément Latzarus
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+
+namespace Biblys\Service;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__."/../../setUp.php";
+
+class ShippingVatAllocationServiceTest extends TestCase
+{
+    public function testAllocatesWholeAmountWhenSingleRate(): void
+    {
+        // given : un seul taux (5,5 %) sur la commande, port TTC 600 c (6 €)
+        $htByRate = ["5.5" => 4000];
+
+        // when
+        $result = ShippingVatAllocationService::allocate($htByRate, 600);
+
+        // then : tout le port est affecté à ce taux, sans calcul de prorata
+        // (600 / 1,055 = 568,72... arrondi à 569)
+        $this->assertSame(["5.5" => ["ht" => 569, "vat" => 31, "ttc" => 600]], $result);
+    }
+
+    public function testAllocatesProportionallyForTwoBalancedRates(): void
+    {
+        // given : 40 € HT à 5,5 % + 20 € HT à 2,1 %, port 6 € TTC (exemple métier de la spec)
+        $htByRate = ["5.5" => 4000, "2.1" => 2000];
+
+        // when
+        $result = ShippingVatAllocationService::allocate($htByRate, 600);
+
+        // then : 66,7 % du port au taux 5,5 %, 33,3 % au taux 2,1 %, somme exacte
+        $this->assertSame(400, $result["5.5"]["ht"] + $result["5.5"]["vat"]);
+        $this->assertSame(200, $result["2.1"]["ht"] + $result["2.1"]["vat"]);
+        $this->assertSame(600, array_sum(array_column($result, "ttc")));
+    }
+
+    public function testHandlesTinyShippingAmountWithZeroPart(): void
+    {
+        // given : port à 1 centime, deux taux
+        $htByRate = ["5.5" => 4000, "2.1" => 2000];
+
+        // when
+        $result = ShippingVatAllocationService::allocate($htByRate, 1);
+
+        // then : une part peut légitimement tomber à 0, la somme reste exacte
+        $this->assertSame(1, array_sum(array_column($result, "ttc")));
+        $this->assertTrue($result["5.5"]["ttc"] === 0 || $result["2.1"]["ttc"] === 0);
+    }
+
+    public function testRoundingRemainderIsAbsorbedByLastRate(): void
+    {
+        // given : 3 taux, montants qui produisent un écart d'arrondi classique
+        $htByRate = ["2.1" => 1000, "5.5" => 1000, "20" => 1000];
+
+        // when
+        $result = ShippingVatAllocationService::allocate($htByRate, 100);
+
+        // then : la somme des parts TTC arrondies reste strictement égale au port
+        $this->assertSame(100, array_sum(array_column($result, "ttc")));
+    }
+
+    public function testZeroHtGroupGetsNoDivisionByZero(): void
+    {
+        // given : un taux à 0 € HT (article gratuit) parmi d'autres
+        $htByRate = ["5.5" => 0, "20" => 4000];
+
+        // when
+        $result = ShippingVatAllocationService::allocate($htByRate, 600);
+
+        // then : pas d'exception, le groupe à 0 € HT ne reçoit rien via le poids
+        // (il peut néanmoins recevoir le reliquat d'arrondi s'il est traité en dernier)
+        $this->assertSame(600, array_sum(array_column($result, "ttc")));
+    }
+
+    public function testReturnsEmptyArrayWhenShippingIsZero(): void
+    {
+        // given
+        $htByRate = ["5.5" => 4000, "20" => 2000];
+
+        // when
+        $result = ShippingVatAllocationService::allocate($htByRate, 0);
+
+        // then
+        $this->assertSame([], $result);
+    }
+
+    public function testUnknownRateGroupIsTreatedAsRegularGroup(): void
+    {
+        // given : un groupe "unknown" (taux de TVA non renseigné, cas legacy) et un taux connu
+        $htByRate = ["unknown" => 2000, "20" => 2000];
+
+        // when
+        $result = ShippingVatAllocationService::allocate($htByRate, 600);
+
+        // then : pas de crash, le groupe "unknown" reçoit sa part TTC intégralement en HT (pas de TVA)
+        $this->assertSame(300, $result["unknown"]["ttc"]);
+        $this->assertSame(300, $result["unknown"]["ht"]);
+        $this->assertSame(0, $result["unknown"]["vat"]);
+    }
+
+    public function testMergeIntoBreakdownAddsPartsToExistingGroups(): void
+    {
+        // given : un récapitulatif de commande à deux taux, et des parts de port pour ces mêmes taux
+        $vatBreakdown = [
+            "5.5" => ["rate" => 5.5, "ht" => 1896, "vat" => 104, "ttc" => 2000],
+            "20" => ["rate" => 20.0, "ht" => 833, "vat" => 167, "ttc" => 1000],
+        ];
+        $shippingParts = [
+            "5.5" => ["ht" => 395, "vat" => 22, "ttc" => 417],
+            "20" => ["ht" => 153, "vat" => 30, "ttc" => 183],
+        ];
+
+        // when
+        $result = ShippingVatAllocationService::mergeIntoBreakdown($vatBreakdown, $shippingParts);
+
+        // then : les montants du port s'ajoutent à ceux des articles, sans toucher au taux
+        $this->assertSame(["rate" => 5.5, "ht" => 2291, "vat" => 126, "ttc" => 2417], $result["5.5"]);
+        $this->assertSame(["rate" => 20.0, "ht" => 986, "vat" => 197, "ttc" => 1183], $result["20"]);
+    }
+
+    public function testMergeIntoBreakdownIsANoOpWhenNoShippingParts(): void
+    {
+        // given
+        $vatBreakdown = ["5.5" => ["rate" => 5.5, "ht" => 1896, "vat" => 104, "ttc" => 2000]];
+
+        // when
+        $result = ShippingVatAllocationService::mergeIntoBreakdown($vatBreakdown, []);
+
+        // then
+        $this->assertSame($vatBreakdown, $result);
+    }
+
+    public function testSummarizeForDisplayReturnsNullWhenNoShipping(): void
+    {
+        // when
+        $result = ShippingVatAllocationService::summarizeForDisplay([], []);
+
+        // then
+        $this->assertNull($result);
+    }
+
+    public function testSummarizeForDisplayReturnsRealRateForSingleGroup(): void
+    {
+        // given : un seul taux concerné par le port, aucun recalcul nécessaire
+        $shippingParts = ["20" => ["ht" => 500, "vat" => 100, "ttc" => 600]];
+        $vatBreakdown = ["20" => ["rate" => 20.0, "ht" => 2500, "vat" => 500, "ttc" => 3000]];
+
+        // when
+        $result = ShippingVatAllocationService::summarizeForDisplay($shippingParts, $vatBreakdown);
+
+        // then
+        $this->assertSame(["rate" => 20.0, "ht" => 500, "vat" => 100, "recalculated" => false], $result);
+    }
+
+    public function testSummarizeForDisplayDerivesRecalculatedRateForMultipleGroups(): void
+    {
+        // given : deux taux concernés par le port (mêmes parts que le test de fusion ci-dessus)
+        $shippingParts = [
+            "5.5" => ["ht" => 395, "vat" => 22, "ttc" => 417],
+            "20" => ["ht" => 153, "vat" => 30, "ttc" => 183],
+        ];
+        $vatBreakdown = [
+            "5.5" => ["rate" => 5.5, "ht" => 2291, "vat" => 126, "ttc" => 2417],
+            "20" => ["rate" => 20.0, "ht" => 986, "vat" => 197, "ttc" => 1183],
+        ];
+
+        // when
+        $result = ShippingVatAllocationService::summarizeForDisplay($shippingParts, $vatBreakdown);
+
+        // then : taux recalculé = TVA totale du port / HT total du port = 52 / 548 ≈ 9,5 %
+        $this->assertSame(["rate" => 9.5, "ht" => 548, "vat" => 52, "recalculated" => true], $result);
+    }
+
+    public function testSummarizeForDisplayReturnsNullRateWhenAggregatedHtIsZero(): void
+    {
+        // given : cas dégénéré, HT total nul (ne devrait pas arriver en pratique)
+        $shippingParts = [
+            "unknown" => ["ht" => 0, "vat" => 0, "ttc" => 0],
+            "20" => ["ht" => 0, "vat" => 0, "ttc" => 0],
+        ];
+        $vatBreakdown = [
+            "unknown" => ["rate" => null, "ht" => 0, "vat" => 0, "ttc" => 0],
+            "20" => ["rate" => 20.0, "ht" => 0, "vat" => 0, "ttc" => 0],
+        ];
+
+        // when
+        $result = ShippingVatAllocationService::summarizeForDisplay($shippingParts, $vatBreakdown);
+
+        // then : pas de division par zéro, le taux recalculé est simplement inconnu
+        $this->assertSame(["rate" => null, "ht" => 0, "vat" => 0, "recalculated" => true], $result);
+    }
+}

--- a/tests/setUp.php
+++ b/tests/setUp.php
@@ -35,6 +35,18 @@ $_SERVER["SCRIPT_NAME"] = "index.php";
 $_SERVER["REMOTE_ADDR"] = "127.0.0.1";
 
 $config = Config::load();
+
+// Prevent tests being executed using any other table than the test database
+$testDbName = $config->get("db.base");
+if (!str_contains((string) $testDbName, "test")) {
+    fwrite(STDERR,
+        "Refusing to run tests: resolved database \"{$testDbName}\" does not look like a test database.\n" .
+        "Run tests via `composer test` or `composer test:path`, which set PHP_ENV=test, " .
+        "instead of calling vendor/bin/phpunit directly.\n"
+    );
+    exit(1);
+}
+
 Connection::initPropel($config);
 
 require_once __DIR__."/../inc/functions.php";


### PR DESCRIPTION
## Résumé

- Les frais de port (stockés en TTC) sont désormais ventilés par taux de TVA sur la facture, au prorata du montant HT de chaque taux présent sur la commande, via un nouveau service pur `ShippingVatAllocationService`.
- Ce service décompose chaque part de port en HT/TVA avec la méthode du coefficient inverse déjà utilisée pour les articles (`StockManager::calculateTax`), et réajuste la dernière part par différence pour garantir une somme exacte.
- La facture (`invoiceAction` / `invoice.html.twig`) affiche le taux/HT/TVA réels sur la ligne "Port" pour une commande mono-taux. Pour une commande multi-taux, elle affiche un taux recalculé (TVA totale ÷ HT total du port), marqué d'un `*`, avec les HT/TVA agrégés — une notice en pied de page explique ce calcul.
- Le tableau de synthèse TVA (taux/HT/TVA/TTC par taux) est désormais un bloc visuellement distinct de la liste d'articles (table séparée, fond gris, aligné à droite), plutôt qu'un pied de tableau collé à celle-ci.
- Hors périmètre (confirmé) : la règle "vente départ" (taux 20 % forcé) n'existe pas dans le modèle Biblys.

Design et plan détaillés : `docs/superpowers/specs/2026-07-12-shipping-vat-allocation-design.md` et `docs/superpowers/plans/2026-07-12-shipping-vat-allocation.md`.

## Test plan

- [x] `tests/Biblys/Service/ShippingVatAllocationServiceTest.php` — tests unitaires sur `allocate`, `mergeIntoBreakdown` et `summarizeForDisplay` (mono-taux, prorata 2 taux, montant infime, écart d'arrondi 3 taux, taux à 0 € HT, port à 0, taux inconnu, agrégation, taux recalculé)
- [x] `tests/AppBundle/Controller/OrderControllerTest.php` — tests d'intégration (ventilation mono-taux affichée, taux recalculé affiché pour une commande multi-taux)
- [x] Suite complète (`composer test`) : aucune régression sur les fichiers touchés ; échecs préexistants et instables sans lien avec ce diff (CFRewardControllerTest, PaymentControllerTest, ArticleCategoryTest)
- [x] Revue de branche complète (spec + qualité) — points mineurs relevés (description de PR obsolète, couplage `colspan`/`is_shop` sur le tableau TVA) corrigés