### PR TITLE
Ajouter un type d'article Abonnement (CPPAP) avec un taux de TVA à 2,1 %

### DIFF
--- a/controllers/common/php/article_edit.php
+++ b/controllers/common/php/article_edit.php
@@ -162,6 +162,9 @@ return function (
             if (in_array($_POST['type_id'], array(1, 2, 7, 8, 9, 12))) {
                 $_POST['article_tva'] = 1;
             }
+            if ($_POST['type_id'] == ArticleType::SUBSCRIPTION_CPPAP) {
+                $_POST['article_tva'] = 2;
+            }
         }
 
         // FICHIERS //

--- a/inc/Article.class.php
+++ b/inc/Article.class.php
@@ -777,7 +777,7 @@ class Article extends Entity
     }
 
     /**
-     * Returns true if article is downloadable (not physical type)
+     * Returns true if article is downloadable (per ArticleType::isDownloadable())
      * @return bool
      * @throws Exception
      */

--- a/inc/Article.class.php
+++ b/inc/Article.class.php
@@ -772,11 +772,8 @@ class Article extends Entity
      */
     public function isPhysical(): bool
     {
-        $type = $this->get('type_id');
-        if ($type == 2 || $type == 10 || $type == 11 || $type == 16) {
-            return false;
-        }
-        return true;
+        $type = $this->getType();
+        return $type ? $type->isPhysical() : true;
     }
 
     /**
@@ -786,7 +783,8 @@ class Article extends Entity
      */
     public function isDownloadable(): bool
     {
-        return !$this->isPhysical();
+        $type = $this->getType();
+        return $type ? $type->isDownloadable() : false;
     }
 
     /**

--- a/inc/Article.class.php
+++ b/inc/Article.class.php
@@ -773,7 +773,7 @@ class Article extends Entity
     public function isPhysical(): bool
     {
         $type = $this->get('type_id');
-        if ($type == 2 || $type == 10 || $type == 11) {
+        if ($type == 2 || $type == 10 || $type == 11 || $type == 16) {
             return false;
         }
         return true;

--- a/inc/CFReward.class.php
+++ b/inc/CFReward.class.php
@@ -140,8 +140,9 @@ class CFReward extends Entity
                     throw new Exception("L'article n° $articleId n'existe pas.");
                 }
 
-                // if article is downloadable, quantity is unlimited
-                if ($article->get('type_id') == 2 || $article->get('type_id') == 10 || $article->get('type_id') == 11 || $article->get('type_id') == 16) {
+                // if article is downloadable or a service, quantity is unlimited
+                $type = $article->getType();
+                if ($type && ($type->isDownloadable() || $type->isService())) {
                     continue;
                 }
 

--- a/inc/CFReward.class.php
+++ b/inc/CFReward.class.php
@@ -141,7 +141,7 @@ class CFReward extends Entity
                 }
 
                 // if article is downloadable, quantity is unlimited
-                if ($article->get('type_id') == 2 || $article->get('type_id') == 10 || $article->get('type_id') == 11) {
+                if ($article->get('type_id') == 2 || $article->get('type_id') == 10 || $article->get('type_id') == 11 || $article->get('type_id') == 16) {
                     continue;
                 }
 

--- a/src/AppBundle/Resources/views/Order/invoice.html.twig
+++ b/src/AppBundle/Resources/views/Order/invoice.html.twig
@@ -237,7 +237,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
             {% endif %}
 
             {% if shipping_vat is not null and shipping_vat.recalculated %}
-                <p class="text-center text-muted">
+                <p class="small text-center text-muted">
                     * Cette commande comporte plusieurs taux de TVA ; les frais de port ont été
                     répartis entre eux au prorata du montant HT de chaque taux. Le taux affiché
                     ici est recalculé à partir du total de TVA et de la base HT ainsi obtenus

--- a/src/Biblys/Data/ArticleType.php
+++ b/src/Biblys/Data/ArticleType.php
@@ -46,6 +46,7 @@ class ArticleType
     public const PERIODICAL = 13;
     public const ROLEPLAY = 14;
     public const CARDS = 15;
+    public const SUBSCRIPTION_CPPAP = 16;
 
 
 
@@ -250,6 +251,15 @@ class ArticleType
         $type->setTax('STANDARD');
         $type->setPhysical(true);
         $type->setDownloadable(false);
+        $types[] = $type;
+
+        $type = new ArticleType();
+        $type->setId(self::SUBSCRIPTION_CPPAP);
+        $type->setName('Abonnement (CPPAP)');
+        $type->setTax('PERIODICAL');
+        $type->setPhysical(false);
+        $type->setDownloadable(false);
+        $type->setIsService(true);
         $types[] = $type;
 
         return $types;

--- a/src/Biblys/Legacy/OrderDeliveryHelpers.php
+++ b/src/Biblys/Legacy/OrderDeliveryHelpers.php
@@ -292,7 +292,7 @@ class OrderDeliveryHelpers
         $orderContainsDownloadable = false;
         foreach ($order->getStockItems() as $stockItem) {
             $article = $stockItem->getArticle();
-            $articleIsDownloadable = $article->getTypeId() === 2 || $article->getTypeId() === 10 || $article->getTypeId() === 11;
+            $articleIsDownloadable = $article->getTypeId() === 2 || $article->getTypeId() === 10 || $article->getTypeId() === 11 || $article->getTypeId() === 16;
             if ($articleIsDownloadable) {
                 $orderContainsDownloadable = true;
             }

--- a/src/Biblys/Legacy/OrderDeliveryHelpers.php
+++ b/src/Biblys/Legacy/OrderDeliveryHelpers.php
@@ -292,7 +292,7 @@ class OrderDeliveryHelpers
         $orderContainsDownloadable = false;
         foreach ($order->getStockItems() as $stockItem) {
             $article = $stockItem->getArticle();
-            $articleIsDownloadable = $article->getTypeId() === 2 || $article->getTypeId() === 10 || $article->getTypeId() === 11 || $article->getTypeId() === 16;
+            $articleIsDownloadable = $article->getType()->isDownloadable() || $article->isService();
             if ($articleIsDownloadable) {
                 $orderContainsDownloadable = true;
             }

--- a/src/Biblys/Legacy/OrderDeliveryHelpers.php
+++ b/src/Biblys/Legacy/OrderDeliveryHelpers.php
@@ -292,7 +292,7 @@ class OrderDeliveryHelpers
         $orderContainsDownloadable = false;
         foreach ($order->getStockItems() as $stockItem) {
             $article = $stockItem->getArticle();
-            $articleIsDownloadable = $article->getType()->isDownloadable() || $article->isService();
+            $articleIsDownloadable = $article->getType()->isDownloadable();
             if ($articleIsDownloadable) {
                 $orderContainsDownloadable = true;
             }

--- a/tests/AppBundle/Controller/PaymentControllerTest.php
+++ b/tests/AppBundle/Controller/PaymentControllerTest.php
@@ -473,10 +473,26 @@ class PaymentControllerTest extends TestCase
         // then
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertStringContainsString("Comment souhaitez-vous régler votre commande ?", $response->getContent());
-        $this->assertStringNotContainsString("Stripe", $response->getContent());
-        $this->assertStringNotContainsString("PayPlug", $response->getContent());
-        $this->assertStringNotContainsString("PayPal", $response->getContent());
-        $this->assertStringNotContainsString("Virement", $response->getContent());
+        $paymentMethodsSection = $this->extractPaymentMethodsSection($response->getContent());
+        $this->assertStringNotContainsString("Stripe", $paymentMethodsSection);
+        $this->assertStringNotContainsString("PayPlug", $paymentMethodsSection);
+        $this->assertStringNotContainsString("PayPal", $paymentMethodsSection);
+        $this->assertStringNotContainsString("Virement", $paymentMethodsSection);
+    }
+
+    /**
+     * The response includes the full page, which extends the site's theme layout — a
+     * separate, environment-specific template that may render its own payment-brand
+     * trust badges (e.g. a PayPlug badge in a sidebar) regardless of this controller's
+     * own logic. Scope assertions to the payment-methods-accordion block this controller
+     * actually renders, so the test doesn't depend on what the local theme includes.
+     */
+    private function extractPaymentMethodsSection(string $content): string
+    {
+        $start = strpos($content, 'id="payment-methods-accordion"');
+        $end = strpos($content, "payment-methods.js", $start);
+
+        return substr($content, $start, $end - $start);
     }
 
     /**

--- a/tests/ArticleTest.php
+++ b/tests/ArticleTest.php
@@ -424,6 +424,9 @@ class ArticleTest extends PHPUnit\Framework\TestCase
 
         $article->set('type_id', 1);
         $this->assertTrue($article->isPhysical());
+
+        $article->set('type_id', ArticleType::SUBSCRIPTION_CPPAP);
+        $this->assertFalse($article->isPhysical());
     }
 
     /**
@@ -439,6 +442,9 @@ class ArticleTest extends PHPUnit\Framework\TestCase
         $this->assertFalse($article->isDownloadable());
 
         $article->set('type_id', 2);
+        $this->assertTrue($article->isDownloadable());
+
+        $article->set('type_id', ArticleType::SUBSCRIPTION_CPPAP);
         $this->assertTrue($article->isDownloadable());
     }
 

--- a/tests/ArticleTest.php
+++ b/tests/ArticleTest.php
@@ -410,12 +410,6 @@ class ArticleTest extends PHPUnit\Framework\TestCase
         $this->assertTrue($article->isPreorderable());
     }
 
-    /**
-     * Test if article is of a physical type
-     * @throws Exception
-     * @throws Exception
-     * @throws PropelException
-     */
     public function testIsPhysical()
     {
         $article = EntityFactory::createArticle();
@@ -425,12 +419,15 @@ class ArticleTest extends PHPUnit\Framework\TestCase
         $article->set('type_id', 1);
         $this->assertTrue($article->isPhysical());
 
+        $article->set('type_id', ArticleType::SUBSCRIPTION);
+        $this->assertFalse($article->isPhysical());
+
         $article->set('type_id', ArticleType::SUBSCRIPTION_CPPAP);
         $this->assertFalse($article->isPhysical());
     }
 
     /**
-     * Test if article is downloadable (non-physical)
+     * Test if article is downloadable (per ArticleType::isDownloadable(), not merely non-physical)
      * @throws Exception
      * @throws Exception
      * @throws PropelException
@@ -444,8 +441,11 @@ class ArticleTest extends PHPUnit\Framework\TestCase
         $article->set('type_id', 2);
         $this->assertTrue($article->isDownloadable());
 
+        $article->set('type_id', ArticleType::SUBSCRIPTION);
+        $this->assertFalse($article->isDownloadable());
+
         $article->set('type_id', ArticleType::SUBSCRIPTION_CPPAP);
-        $this->assertTrue($article->isDownloadable());
+        $this->assertFalse($article->isDownloadable());
     }
 
     /**

--- a/tests/ArticleTypeTest.php
+++ b/tests/ArticleTypeTest.php
@@ -143,4 +143,15 @@ class ArticleTypeTest extends PHPUnit\Framework\TestCase
 
         $this->assertEquals($options[2], '<option value="3" selected>CD</option>');
     }
+
+    public function testSubscriptionCppapType()
+    {
+        $type = ArticleType::getById(ArticleType::SUBSCRIPTION_CPPAP);
+
+        $this->assertEquals('Abonnement (CPPAP)', $type->getName());
+        $this->assertEquals('PERIODICAL', $type->getTax());
+        $this->assertFalse($type->isPhysical());
+        $this->assertFalse($type->isDownloadable());
+        $this->assertTrue($type->isService());
+    }
 }

--- a/tests/Biblys/Legacy/OrderDeliveryHelpersTest.php
+++ b/tests/Biblys/Legacy/OrderDeliveryHelpersTest.php
@@ -20,6 +20,7 @@
 
 namespace Biblys\Legacy;
 
+use Biblys\Data\ArticleType;
 use Biblys\Exception\InvalidEmailAddressException;
 use Biblys\Exception\OrderDetailsValidationException;
 use Biblys\Service\CurrentSite;
@@ -374,6 +375,54 @@ class OrderDeliveryHelpersTest extends TestCase
                 ['contact@paronymie.fr' => 'Marie Golade'],
                 ['reply-to' => 'customer@paronymie.fr'],
             )
+            ->andReturn(true);
+
+        // when
+        OrderDeliveryHelpers::sendOrderConfirmationMail(
+            OrderQuery::create()->findPk($order->get("id")),
+            $shipping,
+            $mailer,
+            $currentSite,
+            false,
+            $termsPage,
+        );
+
+        // then
+        $this->expectNotToPerformAssertions();
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testSendOrderConfirmationMailIncludesDownloadMessageForServiceType()
+    {
+        // given
+        $site = ModelFactory::createSite();
+        $currentSite = Mockery::mock(CurrentSite::class);
+        $currentSite->shouldReceive("getSite")->andReturn($site);
+        $currentSite->shouldReceive("getOption")->andReturn(null);
+        $cm = new CartManager();
+        $om = new OrderManager();
+        $cart = EntityFactory::createCart();
+        $article = EntityFactory::createArticle([
+            "type_id" => ArticleType::SUBSCRIPTION_CPPAP,
+            "article_title" => "Abonnement CPPAP dans la commande",
+            "article_url" => "abonnement-cppap-dans-la-commande",
+        ]);
+        $copy = EntityFactory::createStock(["article_id" => $article->get("id")]);
+        $cm->addStock($cart, $copy);
+        $shipping = EntityFactory::createShipping(mode: "Colissimo", fee: 560);
+        $order = EntityFactory::createOrder(shippingId: $shipping->get("id"));
+        $om->hydrateFromCart($order, $cart);
+        $termsPage = ModelFactory::createPage();
+
+        $mailer = Mockery::mock(Mailer::class);
+        $mailer->shouldReceive("send")
+            ->withArgs(fn ($to, $subject, $body) => str_contains(
+                $body,
+                "vous pourrez télécharger les articles numériques de votre commande"
+            ))
+            ->twice()
             ->andReturn(true);
 
         // when

--- a/tests/Biblys/Legacy/OrderDeliveryHelpersTest.php
+++ b/tests/Biblys/Legacy/OrderDeliveryHelpersTest.php
@@ -394,7 +394,7 @@ class OrderDeliveryHelpersTest extends TestCase
     /**
      * @throws Exception
      */
-    public function testSendOrderConfirmationMailIncludesDownloadMessageForServiceType()
+    public function testSendOrderConfirmationMailExcludesDownloadMessageForServiceType()
     {
         // given
         $site = ModelFactory::createSite();
@@ -418,7 +418,7 @@ class OrderDeliveryHelpersTest extends TestCase
 
         $mailer = Mockery::mock(Mailer::class);
         $mailer->shouldReceive("send")
-            ->withArgs(fn ($to, $subject, $body) => str_contains(
+            ->withArgs(fn ($to, $subject, $body) => !str_contains(
                 $body,
                 "vous pourrez télécharger les articles numériques de votre commande"
             ))

--- a/tests/Biblys/Legacy/OrderDeliveryHelpersTest.php
+++ b/tests/Biblys/Legacy/OrderDeliveryHelpersTest.php
@@ -439,6 +439,53 @@ class OrderDeliveryHelpersTest extends TestCase
         $this->expectNotToPerformAssertions();
     }
 
+    /**
+     * @throws Exception
+     */
+    public function testSendOrderConfirmationMailIncludesDownloadMessageForDownloadableType()
+    {
+        // given
+        $site = ModelFactory::createSite();
+        $currentSite = Mockery::mock(CurrentSite::class);
+        $currentSite->shouldReceive("getSite")->andReturn($site);
+        $currentSite->shouldReceive("getOption")->andReturn(null);
+        $cm = new CartManager();
+        $om = new OrderManager();
+        $cart = EntityFactory::createCart();
+        $article = EntityFactory::createArticle([
+            "type_id" => ArticleType::EBOOK,
+            "article_title" => "Ebook dans la commande",
+            "article_url" => "ebook-dans-la-commande",
+        ]);
+        $copy = EntityFactory::createStock(["article_id" => $article->get("id")]);
+        $cm->addStock($cart, $copy);
+        $shipping = EntityFactory::createShipping(mode: "Colissimo", fee: 560);
+        $order = EntityFactory::createOrder(shippingId: $shipping->get("id"));
+        $om->hydrateFromCart($order, $cart);
+        $termsPage = ModelFactory::createPage();
+
+        $mailer = Mockery::mock(Mailer::class);
+        $mailer->shouldReceive("send")
+            ->withArgs(fn ($to, $subject, $body) => str_contains(
+                $body,
+                "vous pourrez télécharger les articles numériques de votre commande"
+            ))
+            ->twice()
+            ->andReturn(true);
+
+        // when
+        OrderDeliveryHelpers::sendOrderConfirmationMail(
+            OrderQuery::create()->findPk($order->get("id")),
+            $shipping,
+            $mailer,
+            $currentSite,
+            false,
+            $termsPage,
+        );
+
+        // then
+        $this->expectNotToPerformAssertions();
+    }
 
     /**
      * @throws InvalidEmailAddressException

--- a/tests/CFRewardTest.php
+++ b/tests/CFRewardTest.php
@@ -159,6 +159,30 @@ class CFRewardTest extends PHPUnit\Framework\TestCase
     /**
      * @throws Exception
      */
+    public function testUpdateQuantityIsUnlimitedForDownloadableType()
+    {
+        // given
+        $GLOBALS["LEGACY_CURRENT_SITE"] = EntityFactory::createSite();
+        $article = EntityFactory::createArticle(["type_id" => ArticleType::EBOOK]);
+        EntityFactory::createStock(["article_id" => $article->get('id')]);
+        EntityFactory::createStock(["article_id" => $article->get('id')]);
+        EntityFactory::createStock(["article_id" => $article->get('id')]);
+        $reward = EntityFactory::createCrowdfundingReward();
+        $reward->set("reward_quantity", 0);
+        $reward->set("reward_limited", 1);
+        $reward->set("reward_articles", "[{$article->get("id")}]");
+        $rm = new CFRewardManager();
+
+        // when
+        $updatedReward = $rm->updateQuantity($reward);
+
+        // then
+        $this->assertEquals(0, $updatedReward->get("reward_quantity"));
+    }
+
+    /**
+     * @throws Exception
+     */
     public function testUpdateQuantityWithUnexistingArticle()
     {
         // given

--- a/tests/CFRewardTest.php
+++ b/tests/CFRewardTest.php
@@ -16,6 +16,7 @@
  */
 
 
+use Biblys\Data\ArticleType;
 use Biblys\Legacy\LegacyCodeHelper;
 use Biblys\Test\EntityFactory;
 use Biblys\Test\ModelFactory;
@@ -129,6 +130,30 @@ class CFRewardTest extends PHPUnit\Framework\TestCase
 
         // then
         $this->assertEquals(2, $updatedReward->get("reward_quantity"));
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testUpdateQuantityIsUnlimitedForServiceType()
+    {
+        // given
+        $GLOBALS["LEGACY_CURRENT_SITE"] = EntityFactory::createSite();
+        $article = EntityFactory::createArticle(["type_id" => ArticleType::SUBSCRIPTION_CPPAP]);
+        EntityFactory::createStock(["article_id" => $article->get('id')]);
+        EntityFactory::createStock(["article_id" => $article->get('id')]);
+        EntityFactory::createStock(["article_id" => $article->get('id')]);
+        $reward = EntityFactory::createCrowdfundingReward();
+        $reward->set("reward_quantity", 0);
+        $reward->set("reward_limited", 1);
+        $reward->set("reward_articles", "[{$article->get("id")}]");
+        $rm = new CFRewardManager();
+
+        // when
+        $updatedReward = $rm->updateQuantity($reward);
+
+        // then
+        $this->assertEquals(0, $updatedReward->get("reward_quantity"));
     }
 
     /**


### PR DESCRIPTION
## Résumé

- Ajoute un nouveau type d'article `Abonnement (CPPAP)` (id 16), identique au type `Abonnement` existant sur tous les plans, sauf le taux de TVA : 2,1 % (taux presse, réservé aux abonnements à des publications inscrites à la CPPAP) au lieu de 20 %
- Réutilise la catégorie fiscale `PERIODICAL` déjà mappée à 2,1 % pour la France dans `EuroTax` — aucune modification de la librairie de calcul de TVA
- Corrige le mapping legacy de `article_tva` dans `article_edit.php` pour ce nouveau type, afin que les rapports admin restent cohérents avec le taux appliqué sur les factures
- Fait déléguer trois méthodes legacy (`inc/Article.class.php`, `inc/CFReward.class.php`, `src/Biblys/Legacy/OrderDeliveryHelpers.php`) à `ArticleType` — la source de vérité déjà utilisée par le reste du code moderne — au lieu de dupliquer la classification via des listes `type_id` codées en dur. Corrige au passage deux bugs latents révélés par cette délégation : un abonnement était affiché à tort sous "Articles numériques à télécharger" dans un panier mixte, et le champ admin "LemonInk" (gestion de fichier numérique) apparaissait à tort en édition d'un abonnement

## Hors scope

- Un bug préexistant sur le mapping TVA legacy du type "Périodique" (id 13, absent de la même liste, indépendamment de ce type) est traité séparément dans #569, qui couvre aussi la suppression complète de la duplication `article_tva`/`EuroTax`
- Un bug préexistant sans rapport avec ce refactor a été repéré au passage : la section "Abonnements" du panier (`controllers/common/php/cart.php:261-272`) affiche par erreur `$cartDownloadableItems` au lieu de `$cartServiceItems` (copier-coller). Non corrigé ici.

## Test plan

- [x] `composer test:path tests/ArticleTypeTest.php` — nouveau type vérifié (nom, taux, flags)
- [x] `composer test:path tests/ArticleTest.php` — délégation isPhysical/isDownloadable à ArticleType vérifiée, y compris le changement de comportement assumé pour Abonnement/Abonnement (CPPAP)
- [x] `composer test:path tests/CFRewardTest.php`, `tests/Biblys/Legacy/OrderDeliveryHelpersTest.php` — délégation vérifiée pour les types service et téléchargeable, non-régression sur les types physiques
- [x] Suite complète (`composer test`) : aucune régression liée à cette branche (1 échec pré-existant, lié à la config locale `app/config.yml`, sans rapport avec ce changement)
- [ ] Vérification manuelle en admin : créer/éditer un article de type "Abonnement (CPPAP)", enregistrer, confirmer `article_tva = 2` en base (non exécutable en environnement sandbox, à faire sur un stack de dev)

Closes #562