### PR TITLE
Correctif 3.14.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Historique des modifications
 
+## 3.14.2 (15 juillet 2026)
+
+### Corrections
+
+- La section "Abonnements" du panier affichait par erreur les articles
+  numériques à télécharger au lieu des abonnements. C'est corrigé.
+
 ## 3.14.1 (11 juillet 2026)
 
 ### Corrections

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - La section "Abonnements" du panier affichait par erreur les articles
   numériques à télécharger au lieu des abonnements. C'est corrigé.
+- Un article de type Abonnement était aussi affiché à tort dans la section
+  "Articles numériques à télécharger" du panier. C'est corrigé.
 
 ## 3.14.1 (11 juillet 2026)
 

--- a/controllers/common/php/cart.php
+++ b/controllers/common/php/cart.php
@@ -266,7 +266,7 @@ return function (
                 </tr>
             </thead>
             <tbody>
-                ' . implode($cartDownloadableItems) . '
+                ' . implode($cartServiceItems) . '
             </tbody>
         ';
     }

--- a/inc/Article.class.php
+++ b/inc/Article.class.php
@@ -772,21 +772,17 @@ class Article extends Entity
      */
     public function isPhysical(): bool
     {
-        $type = $this->get('type_id');
-        if ($type == 2 || $type == 10 || $type == 11) {
-            return false;
-        }
-        return true;
+        return $this->getType()->isPhysical();
     }
 
     /**
-     * Returns true if article is downloadable (not physical type)
+     * Returns true if article has a downloadable type
      * @return bool
      * @throws Exception
      */
     public function isDownloadable(): bool
     {
-        return !$this->isPhysical();
+        return $this->getType()->isDownloadable();
     }
 
     /**

--- a/inc/constants.php
+++ b/inc/constants.php
@@ -15,4 +15,4 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-const BIBLYS_VERSION = "3.14.1";
+const BIBLYS_VERSION = "3.14.2";

--- a/tests/AppBundle/Controller/Legacy/CartTest.php
+++ b/tests/AppBundle/Controller/Legacy/CartTest.php
@@ -18,6 +18,7 @@
 
 namespace AppBundle\Controller\Legacy;
 
+use Biblys\Data\ArticleType;
 use Biblys\Service\Config;
 use Biblys\Service\CurrentSite;
 use Biblys\Service\CurrentUser;
@@ -107,6 +108,94 @@ class CartTest extends TestCase
             "it should display the finalize order button"
         );
     }
+    /**
+     * @throws PropelException
+     * @throws Exception
+     */
+    public function testCartDisplayWithServiceAndDownloadableItems()
+    {
+        // given
+        $controller = require __DIR__ . "/../../../../controllers/common/php/cart.php";
+
+        ModelFactory::createCountry();
+        $flashBag = $this
+            ->getMockBuilder("Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface")
+            ->getMock();
+        $flashBag->method("get")->willReturn([]);
+        $session = $this
+            ->getMockBuilder("Symfony\Component\HttpFoundation\Session\Session")
+            ->getMock();
+        $session->method("getFlashBag")->willReturn($flashBag);
+        $request = new Request();
+
+        $site = ModelFactory::createSite();
+        $cart = ModelFactory::createCart();
+        $downloadableArticle = ModelFactory::createArticle(
+            title: "Le livre téléchargeable",
+            typeId: ArticleType::EBOOK,
+        );
+        ModelFactory::createStockItem(article: $downloadableArticle, cart: $cart);
+        $serviceArticle = ModelFactory::createArticle(
+            title: "L'abonnement",
+            typeId: ArticleType::SUBSCRIPTION,
+        );
+        ModelFactory::createStockItem(article: $serviceArticle, cart: $cart);
+
+        $config = new Config();
+        $currentSite = Mockery::mock(CurrentSite::class);
+        $currentSite->shouldReceive("getSite")->andReturn($site);
+        $currentSite->shouldReceive("getOption")->andReturn(null);
+        $urlGenerator = $this->createMock(UrlGenerator::class);
+        $currentUser = Mockery::mock(CurrentUser::class);
+        $currentUser->shouldReceive("getOrCreateCart")->andReturn($cart);
+        $currentUser->shouldReceive("isAuthenticated")->andReturn(false);
+        $currentUser->shouldReceive("isAdmin")->andReturn(false);
+        $currentUser->shouldReceive("hasPurchasedArticle")->andReturn(false);
+        $imagesService = Mockery::mock(ImagesService::class);
+        $imagesService->expects("imageExistsFor")->andReturn(true);
+        $templateService = Mockery::mock(TemplateService::class);
+        $templateService->expects("render");
+        $metaTagsService = Mockery::mock(MetaTagsService::class);
+        $metaTagsService->shouldReceive("disallowSeoIndexing");
+
+        // when
+        $response = $controller(
+            $request,
+            $config,
+            $currentSite,
+            $currentUser,
+            $urlGenerator,
+            $imagesService,
+            $templateService,
+            $metaTagsService,
+        );
+
+        // then
+        $content = $response->getContent();
+        $subscriptionsSectionStart = mb_strpos($content, '<th colspan="100">Abonnements</th>');
+        $this->assertNotFalse(
+            $subscriptionsSectionStart,
+            "it should display the Abonnements section"
+        );
+        $subscriptionsSectionEnd = mb_strpos($content, "</tbody>", $subscriptionsSectionStart);
+        $subscriptionsSection = mb_substr(
+            $content,
+            $subscriptionsSectionStart,
+            $subscriptionsSectionEnd - $subscriptionsSectionStart,
+        );
+
+        $this->assertStringContainsString(
+            "L'abonnement",
+            $subscriptionsSection,
+            "it should display the subscription line under the Abonnements section"
+        );
+        $this->assertStringNotContainsString(
+            "Le livre téléchargeable",
+            $subscriptionsSection,
+            "it should not repeat the downloadable article under the Abonnements section"
+        );
+    }
+
     /**
      * @throws PropelException
      * @throws Exception

--- a/tests/AppBundle/Controller/Legacy/CartTest.php
+++ b/tests/AppBundle/Controller/Legacy/CartTest.php
@@ -194,6 +194,11 @@ class CartTest extends TestCase
             $subscriptionsSection,
             "it should not repeat the downloadable article under the Abonnements section"
         );
+        $this->assertEquals(
+            1,
+            substr_count($content, "L'abonnement"),
+            "it should not also list the subscription article under the downloadable section"
+        );
     }
 
     /**


### PR DESCRIPTION
## Corrections

- La section "Abonnements" du panier affichait par erreur les articles
  numériques à télécharger au lieu des abonnements. C'est corrigé.
- Un article de type Abonnement était aussi affiché à tort dans la section
  "Articles numériques à télécharger" du panier. C'est corrigé.