### PR TITLE
Correctif 3.14.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 - La page d'édition d'un article provoquait une erreur fatale lorsque le type
   de l'article était introuvable (`type_id` invalide ou orphelin). C'est corrigé.
+- Dans la caisse, choisir "=> Créer un nouveau client" dans les résultats de
+  recherche du champ Client ouvrait une popup vide. Ce lien ouvre désormais
+  la page de création d'un nouveau client dans un nouvel onglet.
 
 ## 3.14.2 (18 juillet 2026)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 - Dans la caisse, choisir "=> Créer un nouveau client" dans les résultats de
   recherche du champ Client ouvrait une popup vide. Ce lien ouvre désormais
   la page de création d'un nouveau client dans un nouvel onglet.
+- La case "Abonné à la newsletter" affichée dans la caisse et sur les pages
+  de gestion des clients ne pouvait jamais s'afficher cochée. Elle a été
+  retirée, ainsi que le code lié.
 
 ## 3.14.2 (18 juillet 2026)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Historique des modifications
 
+## 3.14.3 (20 juillet 2026)
+
+### Corrections
+
+- La page d'édition d'un article provoquait une erreur fatale lorsque le type
+  de l'article était introuvable (`type_id` invalide ou orphelin). C'est corrigé.
+
 ## 3.14.2 (18 juillet 2026)
 
 ### Corrections

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Historique des modifications
 
-## 3.14.3 (20 juillet 2026)
+## 3.14.3 (24 juillet 2026)
 
 ### Corrections
 

--- a/controllers/common/php/adm_customer.php
+++ b/controllers/common/php/adm_customer.php
@@ -38,9 +38,6 @@ if ($request->getMethod() === "POST") {
 
     // Update object
     foreach ($request->request->all() as $key => $val) {
-        if ($key === "customer_newsletter") {
-            continue;
-        }
         $customer->set($key, $val);
     }
 
@@ -73,12 +70,6 @@ if ($customer) {
 } else {
     $pageTitle = "Créer un nouveau client";
     $customer = new Customer([]);
-}
-
-if ($customer->get("customer_newsletter") == 1) {
-    $newsletterChecked = " checked";
-} else {
-    $newsletterChecked = NULL;
 }
 
 $message = NULL;
@@ -133,11 +124,6 @@ $content = '
             <p>
                 <label for="customer_privatization">Privatisation :</label>
                 <input type="date" name="customer_privatization" id="customer_privatization" value="'.$customer->get('customer_privatization').'" placeholder="AAAA-MM-JJ">
-            </p>
-
-            <p class="center">
-                <input type="checkbox" name="customer_newsletter" id="customer_newsletter" value="1" '.$newsletterChecked.' disabled>
-                <label for="customer_newsletter" class="after">Abonné à la newsletter</label>
             </p>
 
             <br>

--- a/controllers/common/xhr/adm_customers.php
+++ b/controllers/common/xhr/adm_customers.php
@@ -29,7 +29,6 @@
 			$ci['label'] = $c->get('customer_last_name').', '.$c->get('customer_first_name').' ('.$c->get('customer_email').')';
 			$ci['value'] = '';
 			$ci['id'] = $c->get('customer_id');
-			$ci['newsletter'] = $c->get('customer_newsletter');
 			$j[] = $ci;
 		}
 		

--- a/inc/Article.class.php
+++ b/inc/Article.class.php
@@ -772,7 +772,8 @@ class Article extends Entity
      */
     public function isPhysical(): bool
     {
-        return $this->getType()->isPhysical();
+        $type = $this->getType();
+        return $type ? $type->isPhysical() : true;
     }
 
     /**
@@ -782,7 +783,8 @@ class Article extends Entity
      */
     public function isDownloadable(): bool
     {
-        return $this->getType()->isDownloadable();
+        $type = $this->getType();
+        return $type ? $type->isDownloadable() : false;
     }
 
     /**

--- a/inc/Customer.class.php
+++ b/inc/Customer.class.php
@@ -58,8 +58,6 @@
 			$list = array();
 			while ($d = $q->fetch(PDO::FETCH_ASSOC))
 			{
-				$d['customer_newsletter'] = 0;
-				
 				$list[] = new Customer($d);
 			}
 			$q->closeCursor();

--- a/inc/constants.php
+++ b/inc/constants.php
@@ -15,4 +15,4 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-const BIBLYS_VERSION = "3.14.3-dev";
+const BIBLYS_VERSION = "3.14.3";

--- a/inc/constants.php
+++ b/inc/constants.php
@@ -15,4 +15,4 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-const BIBLYS_VERSION = "3.14.2";
+const BIBLYS_VERSION = "3.14.3-dev";

--- a/public/common/js/biblys-admin.js
+++ b/public/common/js/biblys-admin.js
@@ -613,14 +613,7 @@ function reloadAdminEvents() {
       select: function(event, ui) {
         if (ui.item.create == '1') {
           // Creer un nouveau client
-          $('#customer_first_name')
-            .val(ui.item.value)
-            .focus();
-          $('#createCustomer').dialog({
-            title: 'Créer un nouveau client',
-            modal: true,
-            width: 500
-          });
+          window.open('/pages/adm_customer', '_blank');
         } else {
           // Selectionner un client existant
           selectCustomer(ui.item.id, ui.item.label, ui.item.newsletter);
@@ -674,29 +667,6 @@ function reloadAdminEvents() {
       }
     );
   }
-
-  // Créer un client
-  $('#createCustomer').submit(function(e) {
-    e.preventDefault();
-    $.post(
-      '/pages/adm_customer',
-      {
-        customer_last_name: '' + $('#customer_last_name').val() + '',
-        customer_first_name: '' + $('#customer_first_name').val() + '',
-        customer_email: '' + $('#customer_email').val() + '',
-        customer_phone: '' + $('#customer_phone').val() + '',
-        customer_newsletter: '' + $('#new_customer_newsletter:checked').val() + ''
-      },
-      function(res) {
-        if (res.error) _alert(res.error);
-        else {
-          $('#createCustomer').dialog('close');
-          selectCustomer(res.id, res.name, 0);
-          notify('Le client ' + res.name + ' a bien été créé.');
-        }
-      }
-    );
-  });
 
   document.addEventListener('keyup', function(event) {
     const { ctrlKey, shiftKey, key } = event;

--- a/public/common/js/biblys-admin.js
+++ b/public/common/js/biblys-admin.js
@@ -616,7 +616,7 @@ function reloadAdminEvents() {
           window.open('/pages/adm_customer', '_blank');
         } else {
           // Selectionner un client existant
-          selectCustomer(ui.item.id, ui.item.label, ui.item.newsletter);
+          selectCustomer(ui.item.id, ui.item.label);
         }
       }
       // Annuler la sélection du client
@@ -634,8 +634,6 @@ function reloadAdminEvents() {
               .removeClass('pointer')
               .removeAttr('readonly')
               .val('');
-            $('#customer_mailing').removeAttr('checked');
-            $('#newsletter').hide();
             $('#customer_id').val('');
             //notify(res.success);
           }
@@ -645,8 +643,7 @@ function reloadAdminEvents() {
     .removeClass('event');
 
   // Sélectionner un client
-  function selectCustomer(id, name, newsletter) {
-    if (newsletter == 1) $('#customer_mailing').attr('checked', 'checked');
+  function selectCustomer(id, name) {
     $.post(
       '/pages/adm_checkout?cart_id=' + $('#cart_id').val(),
       {
@@ -660,7 +657,6 @@ function reloadAdminEvents() {
             .attr('readonly', 'readonly')
             .val(name);
           $('#customer_id').val(id);
-          $('#newsletter').show();
           $('#article').focus();
           notify(res.success);
         }

--- a/src/AppBundle/Resources/views/PointOfSale/index.html.twig
+++ b/src/AppBundle/Resources/views/PointOfSale/index.html.twig
@@ -76,32 +76,6 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
       Caisse
     </h1>
 
-    <form id="createCustomer" hidden>
-      <fieldset>
-        <p>
-          <label for="customer_last_name">Nom :</label>
-          <input type="text" id="customer_last_name" name="customer_last_name" required>
-        </p>
-        <p>
-          <label for="customer_first_name">Prénom :</label>
-          <input type="text" id="customer_first_name" name="customer_first_name">
-        </p>
-        <p>
-          <label for="customer_email">Adresse e-mail :</label>
-          <input type="email" id="customer_email" name="customer_email" class="long">
-        </p>
-        <p>
-          <label for="customer_phone">Téléphone :</label>
-          <input type="number" id="customer_phone" name="customer_phone">
-        </p>
-        <p class="center">
-          <input type="checkbox" name="customer_newsletter" id="customer_newsletter" value="1" checked>
-          <label for="customer_newsletter" class="after">Abonner à la newsletter</label>
-        </p>
-        <div class="right"><input type="submit" value="Valider"/></div>
-      </fieldset>
-    </form>
-
     <h3>
       <span id="cart_title" class="event pointer" contenteditable>{{ cart.get('cart_title')|raw }}</span>
     </h3>

--- a/src/AppBundle/Resources/views/PointOfSale/index.html.twig
+++ b/src/AppBundle/Resources/views/PointOfSale/index.html.twig
@@ -101,18 +101,9 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
                    value="{{ customer.get('customer_last_name') }}, {{ customer.get('customer_first_name') }} ({{ customer.get('customer_email') }})"
                    readonly class="pointer event verylong">
             <input type="hidden" name="customer_id" id="customer_id" value="{{ customer.get('customer_id') }}" required>
-            <span id="newsletter">
-              <input type="checkbox" name="customer_mailing" id="customer_mailing" value="1" disabled
-                  {% if customer.get('customer_newsletter') == 1 %}checked{% endif %}>
-              <label for="customer_mailing" class="after">Abonné à la newsletter</label>
-            </span>
           {% else %}
             <input type="text" name="customer" id="customer" placeholder="Rechercher un client..." class="event verylong">
             <input type="hidden" name="customer_id" id="customer_id" required>
-            <span id="newsletter2" class="hidden">
-              <input type="checkbox" name="customer_mailing" id="customer_mailing" value="1" disabled>
-              <label for="customer_mailing" class="after">Abonné à la newsletter</label>
-            </span>
           {% endif %}
         </p>
 

--- a/tests/ArticleTest.php
+++ b/tests/ArticleTest.php
@@ -424,6 +424,9 @@ class ArticleTest extends PHPUnit\Framework\TestCase
 
         $article->set('type_id', 1);
         $this->assertTrue($article->isPhysical());
+
+        $article->set('type_id', 999999);
+        $this->assertTrue($article->isPhysical());
     }
 
     /**
@@ -440,6 +443,9 @@ class ArticleTest extends PHPUnit\Framework\TestCase
 
         $article->set('type_id', 2);
         $this->assertTrue($article->isDownloadable());
+
+        $article->set('type_id', 999999);
+        $this->assertFalse($article->isDownloadable());
     }
 
     /**


### PR DESCRIPTION
## Corrections

- L'édition d'un article dont le type était inconnu provoquait une erreur fatale (`Call to a member function isDownloadable() on bool`). C'est corrigé.
- Dans la caisse, choisir "=> Créer un nouveau client" dans les résultats de recherche du champ Client ouvrait une popup vide (formulaire invisible). Ce lien ouvre désormais la page de création d'un nouveau client dans un nouvel onglet. (#583)
- La case "Abonné à la newsletter" affichée dans la caisse et sur les pages de gestion des clients ne pouvait jamais s'afficher cochée (la colonne `customer_newsletter` n'existe pas en base). Elle a été retirée, ainsi que le code lié. (#582)