### PR TITLE
Caisse : retrait d'un article via la nouvelle route

### DIFF
--- a/public/common/js/biblys-admin.js
+++ b/public/common/js/biblys-admin.js
@@ -468,22 +468,36 @@ function reloadAdminEvents() {
   }
 
   // Supprimer un article
+  async function remove_from_cart(cartId, stockId) {
+    const response = await fetch(`/admin/pos/carts/${cartId}/items/${stockId}`, {
+      method: 'DELETE',
+      headers: {
+        'Accept': 'application/json',
+      },
+    });
+
+    if (!response.ok) {
+      let message = "L'exemplaire n'a pas pu être retiré du panier.";
+      try {
+        const error = await response.json();
+        if (error && error.message) message = error.message;
+      } catch (e) {
+        // réponse d'erreur non-JSON : on conserve le message générique
+      }
+      window._alert(message);
+      return;
+    }
+
+    const json = await response.json();
+    $('#stock_' + stockId).remove();
+    notify(json.success);
+    update_cart();
+  }
+
   $('[data-remove_from_cart].event')
     .click(function() {
       var stock_id = $(this).attr('data-remove_from_cart');
-      $.get(
-        '/pages/adm_checkout?cart_id=' + $('#cart_id').val() + '&remove_stock=' + stock_id,
-        {},
-        function(r) {
-          if (r.error) _alert('Erreur : ' + r.error);
-          else {
-            $('#stock_' + stock_id).remove();
-            notify(r.success);
-            update_cart();
-          }
-        },
-        'json'
-      );
+      remove_from_cart($('#cart_id').val(), stock_id);
     })
     .removeClass('event');
 

--- a/src/AppBundle/Controller/PointOfSaleController.php
+++ b/src/AppBundle/Controller/PointOfSaleController.php
@@ -19,6 +19,7 @@
 namespace AppBundle\Controller;
 
 use Biblys\Exception\CannotAddStockItemToCartException;
+use Biblys\Exception\CannotRemoveStockItemFromCartException;
 use Biblys\Service\BodyParamsService;
 use Biblys\Service\CurrentSite;
 use Biblys\Service\CurrentUser;
@@ -41,6 +42,7 @@ use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Generator\UrlGenerator;
 use Usecase\AddStockItemToPointOfSaleCartUsecase;
+use Usecase\RemoveStockItemFromPointOfSaleCartUsecase;
 use Twig\Error\LoaderError;
 use Twig\Error\RuntimeError;
 use Twig\Error\SyntaxError;
@@ -209,6 +211,40 @@ class PointOfSaleController extends Controller
             return new JsonResponse([
                 "success" => "L'exemplaire n° $stockItemId a été ajouté au panier.",
                 "line" => $line,
+            ]);
+        }
+
+        return new RedirectResponse("/admin/caisse?cart_id=$cartId");
+    }
+
+    /**
+     * @throws PropelException
+     */
+    public function removeItemAction(
+        Request     $request,
+        CurrentUser $currentUser,
+        int         $cartId,
+        int         $stockId,
+    ): Response
+    {
+        $currentUser->authAdmin();
+
+        $cm = new CartManager();
+        $cart = $cm->getById($cartId);
+        if (!$cart) {
+            throw new NotFoundHttpException("Panier $cartId introuvable");
+        }
+
+        try {
+            $usecase = new RemoveStockItemFromPointOfSaleCartUsecase();
+            $usecase->execute($cartId, $stockId);
+        } catch (CannotRemoveStockItemFromCartException $exception) {
+            throw new NotFoundHttpException($exception->getMessage(), $exception);
+        }
+
+        if (in_array("application/json", $request->getAcceptableContentTypes())) {
+            return new JsonResponse([
+                "success" => "L'exemplaire n° $stockId a été retiré du panier et remis en stock.",
             ]);
         }
 

--- a/src/AppBundle/routes.yml
+++ b/src/AppBundle/routes.yml
@@ -423,6 +423,14 @@ point_of_sale_add_item:
   requirements:
     cartId: \d+
 
+point_of_sale_remove_item:
+  path: /admin/pos/carts/{cartId}/items/{stockId}
+  controller: AppBundle\Controller\PointOfSaleController::removeItemAction
+  methods: [DELETE]
+  requirements:
+    cartId: \d+
+    stockId: \d+
+
 # Orders
 
 order_index:

--- a/src/Biblys/Exception/CannotRemoveStockItemFromCartException.php
+++ b/src/Biblys/Exception/CannotRemoveStockItemFromCartException.php
@@ -1,0 +1,23 @@
+<?php
+/*
+ * Copyright (C) 2026 Clément Latzarus
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+
+namespace Biblys\Exception;
+
+use Exception;
+
+class CannotRemoveStockItemFromCartException extends Exception {}

--- a/src/Usecase/RemoveStockItemFromPointOfSaleCartUsecase.php
+++ b/src/Usecase/RemoveStockItemFromPointOfSaleCartUsecase.php
@@ -1,0 +1,51 @@
+<?php
+/*
+ * Copyright (C) 2026 Clément Latzarus
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+
+namespace Usecase;
+
+use Biblys\Exception\CannotRemoveStockItemFromCartException;
+use CartManager;
+use Exception;
+use Propel\Runtime\Exception\PropelException;
+use StockManager;
+
+class RemoveStockItemFromPointOfSaleCartUsecase
+{
+    /**
+     * Retire un exemplaire (stock item) d'un panier caisse et le remet en stock.
+     *
+     * @throws CannotRemoveStockItemFromCartException si l'exemplaire n'est pas présent dans ce panier
+     * @throws PropelException
+     * @throws Exception
+     */
+    public function execute(int $cartId, int $stockItemId): void
+    {
+        $sm = new StockManager();
+        $stock = $sm->getById($stockItemId);
+        if (!$stock || (int) $stock->get('cart_id') !== $cartId) {
+            throw new CannotRemoveStockItemFromCartException(
+                "L'exemplaire n° $stockItemId n'est pas présent dans ce panier."
+            );
+        }
+
+        $cm = new CartManager();
+        $cart = $cm->getById($cartId);
+        $cm->removeStock($stock);
+        $cm->updateFromStock($cart);
+    }
+}

--- a/tests/AppBundle/Controller/PointOfSaleControllerTest.php
+++ b/tests/AppBundle/Controller/PointOfSaleControllerTest.php
@@ -343,4 +343,128 @@ class PointOfSaleControllerTest extends TestCase
             $secondCart->getId(),
         );
     }
+
+    /**
+     * @throws PropelException
+     */
+    public function testRemoveItemActionRemovesStockAndReturnsJsonSuccess(): void
+    {
+        // given
+        $controller = $this->_getController();
+        $cart = ModelFactory::createCart();
+        $cart->setType("shop");
+        $cart->save();
+        $stock = ModelFactory::createStockItem(cart: $cart, sellingPrice: 1899);
+
+        $request = new Request();
+        $request->headers->set('Accept', 'application/json');
+
+        $currentUser = Mockery::mock(CurrentUser::class);
+        $currentUser->expects("authAdmin");
+
+        // when
+        $response = $controller->removeItemAction(
+            $request,
+            $currentUser,
+            $cart->getId(),
+            $stock->getId(),
+        );
+
+        // then
+        $this->assertEquals(200, $response->getStatusCode());
+        $data = json_decode($response->getContent(), true);
+        $this->assertArrayHasKey('success', $data);
+        $stock->reload();
+        $this->assertNull($stock->getCartId());
+    }
+
+    /**
+     * @throws PropelException
+     */
+    public function testRemoveItemActionRedirectsWhenNotAcceptingJson(): void
+    {
+        // given
+        $controller = $this->_getController();
+        $cart = ModelFactory::createCart();
+        $cart->setType("shop");
+        $cart->save();
+        $stock = ModelFactory::createStockItem(cart: $cart);
+
+        $request = new Request();
+
+        $currentUser = Mockery::mock(CurrentUser::class);
+        $currentUser->expects("authAdmin");
+
+        // when
+        $response = $controller->removeItemAction(
+            $request,
+            $currentUser,
+            $cart->getId(),
+            $stock->getId(),
+        );
+
+        // then
+        $this->assertEquals(302, $response->getStatusCode());
+        $this->assertEquals(
+            "/admin/caisse?cart_id=" . $cart->getId(),
+            $response->headers->get("Location")
+        );
+    }
+
+    /**
+     * @throws PropelException
+     */
+    public function testRemoveItemActionReturns404WhenCartNotFound(): void
+    {
+        // given
+        $controller = $this->_getController();
+        $stock = ModelFactory::createStockItem();
+        $request = new Request();
+
+        $currentUser = Mockery::mock(CurrentUser::class);
+        $currentUser->expects("authAdmin");
+
+        // then
+        $this->expectException(\Symfony\Component\HttpKernel\Exception\NotFoundHttpException::class);
+
+        // when
+        $controller->removeItemAction(
+            $request,
+            $currentUser,
+            99999,
+            $stock->getId(),
+        );
+    }
+
+    /**
+     * @throws PropelException
+     */
+    public function testRemoveItemActionReturns404WhenStockNotInCart(): void
+    {
+        // given
+        $controller = $this->_getController();
+        $firstCart = ModelFactory::createCart();
+        $firstCart->setType("shop");
+        $firstCart->save();
+        $secondCart = ModelFactory::createCart();
+        $secondCart->setType("shop");
+        $secondCart->save();
+        $stock = ModelFactory::createStockItem(cart: $firstCart);
+
+        $request = new Request();
+
+        $currentUser = Mockery::mock(CurrentUser::class);
+        $currentUser->expects("authAdmin");
+
+        // then
+        $this->expectException(\Symfony\Component\HttpKernel\Exception\NotFoundHttpException::class);
+
+        // when
+        $controller->removeItemAction(
+            $request,
+            $currentUser,
+            $secondCart->getId(),
+            $stock->getId(),
+        );
+    }
 }

--- a/tests/Usecase/RemoveStockItemFromPointOfSaleCartUsecaseTest.php
+++ b/tests/Usecase/RemoveStockItemFromPointOfSaleCartUsecaseTest.php
@@ -1,0 +1,95 @@
+<?php
+/*
+ * Copyright (C) 2026 Clément Latzarus
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+
+namespace Usecase;
+
+use Biblys\Exception\CannotRemoveStockItemFromCartException;
+use Biblys\Test\ModelFactory;
+use PHPUnit\Framework\TestCase;
+use Propel\Runtime\Exception\PropelException;
+
+class RemoveStockItemFromPointOfSaleCartUsecaseTest extends TestCase
+{
+    /**
+     * @throws PropelException
+     */
+    public function testRemovesStockItemFromPointOfSaleCart(): void
+    {
+        // given
+        $cart = ModelFactory::createCart();
+        $cart->setType("shop");
+        $cart->save();
+        $stock = ModelFactory::createStockItem(cart: $cart, sellingPrice: 1899);
+        $cart->setCount(1);
+        $cart->setAmount(1899);
+        $cart->save();
+        $usecase = new RemoveStockItemFromPointOfSaleCartUsecase();
+
+        // when
+        $usecase->execute($cart->getId(), $stock->getId());
+
+        // then
+        $stock->reload();
+        $this->assertNull($stock->getCartId());
+        $cart->reload();
+        $this->assertEquals(0, $cart->getCount());
+        $this->assertEquals(0, $cart->getAmount());
+    }
+
+    /**
+     * @throws PropelException
+     */
+    public function testThrowsWhenStockItemNotInGivenCart(): void
+    {
+        // given
+        $firstCart = ModelFactory::createCart();
+        $firstCart->setType("shop");
+        $firstCart->save();
+        $secondCart = ModelFactory::createCart();
+        $secondCart->setType("shop");
+        $secondCart->save();
+        $stock = ModelFactory::createStockItem(cart: $firstCart);
+
+        $usecase = new RemoveStockItemFromPointOfSaleCartUsecase();
+
+        // then
+        $this->expectException(CannotRemoveStockItemFromCartException::class);
+
+        // when
+        $usecase->execute($secondCart->getId(), $stock->getId());
+    }
+
+    /**
+     * @throws PropelException
+     */
+    public function testThrowsWhenStockItemNotFound(): void
+    {
+        // given
+        $cart = ModelFactory::createCart();
+        $cart->setType("shop");
+        $cart->save();
+
+        $usecase = new RemoveStockItemFromPointOfSaleCartUsecase();
+
+        // then
+        $this->expectException(CannotRemoveStockItemFromCartException::class);
+
+        // when
+        $usecase->execute($cart->getId(), 99999);
+    }
+}


### PR DESCRIPTION
## Résumé

- PR 3/8 de la migration de la caisse ("Point of Sale"), voir #512
- Ajoute `RemoveStockItemFromPointOfSaleCartUsecase` : retire un exemplaire d'un panier caisse et le remet en stock, après vérification qu'il appartient bien au panier ciblé
- Ajoute `PointOfSaleController::removeItemAction` et la route `DELETE /admin/pos/carts/{cartId}/items/{stockId}`
- Met à jour le JS de la caisse pour appeler cette nouvelle route au lieu de l'ancienne URL legacy `/pages/adm_checkout?remove_stock=`

L'ancienne URL `/pages/adm_checkout` reste active et inchangée (suppression prévue en PR 8).

## Plan de test

- [x] `composer test` passe (1264 tests, aucune régression)
- [x] Nouveaux tests usecase : retrait avec mise à jour des totaux, 404 si exemplaire absent, 404 si exemplaire dans un autre panier
- [x] Nouveaux tests controller : 200 JSON, redirection non-JSON, 404 panier introuvable, 404 exemplaire hors panier
- [ ] Vérification manuelle en caisse (ajout puis retrait d'un article)