### PR TITLE
Caisse : vidage du panier via la nouvelle route

### DIFF
--- a/public/common/js/biblys-admin.js
+++ b/public/common/js/biblys-admin.js
@@ -501,6 +501,37 @@ function reloadAdminEvents() {
     })
     .removeClass('event');
 
+  // Vider un panier
+  async function clear_cart(cartId) {
+    const response = await fetch(`/admin/pos/carts/${cartId}/items`, {
+      method: 'DELETE',
+      headers: {
+        'Accept': 'application/json',
+      },
+    });
+
+    if (!response.ok) {
+      let message = "Le panier n'a pas pu être vidé.";
+      try {
+        const error = await response.json();
+        if (error && error.message) message = error.message;
+      } catch (e) {
+        // réponse d'erreur non-JSON : on conserve le message générique
+      }
+      window._alert(message);
+      return;
+    }
+
+    window.location.reload();
+  }
+
+  document.addEventListener('click', function(event) {
+    const button = event.target.closest('[data-clear_cart]');
+    if (button) {
+      clear_cart(button.getAttribute('data-clear_cart'));
+    }
+  });
+
   // Rechercher un article
   function checkout_lookup(event) {
     var input = $('#checkout_add_input').val();

--- a/src/AppBundle/Controller/PointOfSaleController.php
+++ b/src/AppBundle/Controller/PointOfSaleController.php
@@ -29,6 +29,7 @@ use Biblys\Service\TemplateService;
 use CartManager;
 use CustomerManager;
 use Framework\Controller;
+use Model\CartQuery;
 use Model\UserQuery;
 use Propel\Runtime\Exception\PropelException;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -39,6 +40,7 @@ use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Generator\UrlGenerator;
 use Usecase\AddStockItemToPointOfSaleCartUsecase;
+use Usecase\ClearPointOfSaleCartUsecase;
 use Usecase\RemoveStockItemFromPointOfSaleCartUsecase;
 use Twig\Error\LoaderError;
 use Twig\Error\RuntimeError;
@@ -228,5 +230,27 @@ class PointOfSaleController extends Controller
         }
 
         return new RedirectResponse("/admin/caisse?cart_id=$cartId");
+    }
+
+    /**
+     * @throws PropelException
+     */
+    public function clearCartAction(
+        CurrentUser $currentUser,
+        int         $cartId,
+    ): Response
+    {
+        $currentUser->authAdmin();
+
+        if (!CartQuery::create()->filterById($cartId)->exists()) {
+            throw new NotFoundHttpException("Panier $cartId introuvable");
+        }
+
+        $usecase = new ClearPointOfSaleCartUsecase();
+        $usecase->execute($cartId);
+
+        return new JsonResponse([
+            "success" => "Le panier a été vidé.",
+        ]);
     }
 }

--- a/src/AppBundle/Resources/views/PointOfSale/index.html.twig
+++ b/src/AppBundle/Resources/views/PointOfSale/index.html.twig
@@ -195,12 +195,12 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
                 <td class="text-right">{{ pointOfSaleCart.count }}</td>
                 <td class="text-right">{{ pointOfSaleCart.amount|currency(true)|raw }}</td>
                 <td class="text-center">
-                  <a href="/pages/adm_checkout?cart_id={{ pointOfSaleCart.id }}&vacuum_cart=1"
+                  <button data-clear_cart="{{ pointOfSaleCart.id }}"
                      data-confirm="Voulez-vous vraiment VIDER ce panier et remettre {{ pointOfSaleCart.count }} exemplaire{% if pointOfSaleCart.count > 1 %}s{% endif %} en vente ?"
                      title="Vider le panier et remettre {{ pointOfSaleCart.count }} exemplaire{% if pointOfSaleCart.count > 1 %}s{% endif %} en vente."
                      class="btn btn-danger btn-sm">
                     <i class="fa fa-trash-can"></i>
-                  </a>
+                  </button>
                 </td>
               </tr>
             {% endfor %}

--- a/src/AppBundle/routes.yml
+++ b/src/AppBundle/routes.yml
@@ -431,6 +431,13 @@ point_of_sale_remove_item:
     cartId: \d+
     stockId: \d+
 
+point_of_sale_clear_cart:
+  path: /admin/pos/carts/{cartId}/items
+  controller: AppBundle\Controller\PointOfSaleController::clearCartAction
+  methods: [DELETE]
+  requirements:
+    cartId: \d+
+
 # Orders
 
 order_index:

--- a/src/Usecase/ClearPointOfSaleCartUsecase.php
+++ b/src/Usecase/ClearPointOfSaleCartUsecase.php
@@ -1,0 +1,48 @@
+<?php
+/*
+ * Copyright (C) 2026 Clément Latzarus
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+
+namespace Usecase;
+
+use CartManager;
+use Exception;
+use Propel\Runtime\Exception\PropelException;
+
+class ClearPointOfSaleCartUsecase
+{
+    /**
+     * Retire tous les exemplaires d'un panier caisse, les remet en stock,
+     * et réinitialise le client, le titre et la date du panier.
+     *
+     * @throws PropelException
+     * @throws Exception
+     */
+    public function execute(int $cartId): void
+    {
+        $cm = new CartManager();
+        $cart = $cm->getById($cartId);
+
+        foreach ($cm->getStock($cart) as $stock) {
+            $cm->removeStock($stock);
+        }
+
+        $cart->set('customer_id', '');
+        $cart->set('cart_title', '');
+        $cart->set('cart_date', '');
+        $cm->updateFromStock($cart);
+    }
+}

--- a/tests/AppBundle/Controller/PointOfSaleControllerTest.php
+++ b/tests/AppBundle/Controller/PointOfSaleControllerTest.php
@@ -426,4 +426,56 @@ class PointOfSaleControllerTest extends TestCase
             $stock->getId(),
         );
     }
+
+    /**
+     * @throws PropelException
+     */
+    public function testClearCartActionClearsCartAndReturnsJsonSuccess(): void
+    {
+        // given
+        $controller = $this->_getController();
+        $cart = ModelFactory::createCart();
+        $cart->setType("shop");
+        $cart->save();
+        $stock = ModelFactory::createStockItem(cart: $cart, sellingPrice: 1899);
+
+        $currentUser = Mockery::mock(CurrentUser::class);
+        $currentUser->expects("authAdmin");
+
+        // when
+        $response = $controller->clearCartAction(
+            $currentUser,
+            $cart->getId(),
+        );
+
+        // then
+        $this->assertEquals(200, $response->getStatusCode());
+        $data = json_decode($response->getContent(), true);
+        $this->assertArrayHasKey('success', $data);
+        $stock->reload();
+        $this->assertNull($stock->getCartId());
+        $cart->reload();
+        $this->assertEquals(0, $cart->getCount());
+    }
+
+    /**
+     * @throws PropelException
+     */
+    public function testClearCartActionReturns404WhenCartNotFound(): void
+    {
+        // given
+        $controller = $this->_getController();
+
+        $currentUser = Mockery::mock(CurrentUser::class);
+        $currentUser->expects("authAdmin");
+
+        // then
+        $this->expectException(\Symfony\Component\HttpKernel\Exception\NotFoundHttpException::class);
+
+        // when
+        $controller->clearCartAction(
+            $currentUser,
+            99999,
+        );
+    }
 }

--- a/tests/Usecase/ClearPointOfSaleCartUsecaseTest.php
+++ b/tests/Usecase/ClearPointOfSaleCartUsecaseTest.php
@@ -1,0 +1,78 @@
+<?php
+/*
+ * Copyright (C) 2026 Clément Latzarus
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+
+namespace Usecase;
+
+use Biblys\Test\ModelFactory;
+use PHPUnit\Framework\TestCase;
+use Propel\Runtime\Exception\PropelException;
+
+class ClearPointOfSaleCartUsecaseTest extends TestCase
+{
+    /**
+     * @throws PropelException
+     */
+    public function testClearsCartAndPutsStockItemsBackInStock(): void
+    {
+        // given
+        $cart = ModelFactory::createCart();
+        $cart->setType("shop");
+        $cart->setCustomerId(1);
+        $cart->setTitle("Panier de test");
+        $cart->save();
+        $firstStock = ModelFactory::createStockItem(cart: $cart, sellingPrice: 1899);
+        $secondStock = ModelFactory::createStockItem(cart: $cart, sellingPrice: 1299);
+        $cart->setCount(2);
+        $cart->setAmount(3198);
+        $cart->save();
+        $usecase = new ClearPointOfSaleCartUsecase();
+
+        // when
+        $usecase->execute($cart->getId());
+
+        // then
+        $firstStock->reload();
+        $this->assertNull($firstStock->getCartId());
+        $secondStock->reload();
+        $this->assertNull($secondStock->getCartId());
+        $cart->reload();
+        $this->assertEquals(0, $cart->getCount());
+        $this->assertEquals(0, $cart->getAmount());
+        $this->assertNull($cart->getCustomerId());
+        $this->assertEquals("Panier n&deg; " . $cart->getId(), $cart->getTitle());
+    }
+
+    /**
+     * @throws PropelException
+     */
+    public function testClearsAlreadyEmptyCartWithoutError(): void
+    {
+        // given
+        $cart = ModelFactory::createCart();
+        $cart->setType("shop");
+        $cart->save();
+        $usecase = new ClearPointOfSaleCartUsecase();
+
+        // when
+        $usecase->execute($cart->getId());
+
+        // then
+        $cart->reload();
+        $this->assertEquals(0, $cart->getCount());
+    }
+}


### PR DESCRIPTION
## Résumé

- Ajoute `PointOfSaleController::clearCartAction` (`DELETE /admin/pos/carts/{cartId}/items`), migrant le paramètre legacy `vacuum_cart` du controller `adm_checkout.php`
- Ajoute `ClearPointOfSaleCartUsecase`, qui encapsule `CartManager::vacuum()` : retire les exemplaires du panier (remise en stock) et réinitialise client/titre/date, à l'identique du comportement legacy
- Met à jour le bouton « vider le panier » du template `PointOfSale/index.html.twig` et le JS associé (`clear_cart()`) pour utiliser la nouvelle route au lieu du lien `/pages/adm_checkout?vacuum_cart=1`

PR 4 du plan de migration décrit dans #512.

## Plan de test

- [x] `composer test` passe (1268 tests)
- [ ] Depuis `/admin/caisse`, vider un panier ayant des articles et vérifier qu'ils sont remis en vente et que le panier disparaît de la liste « Autres paniers »
- [ ] Vérifier qu'un panier déjà vide peut être vidé sans erreur
- [ ] L'ancienne URL `/pages/adm_checkout?vacuum_cart=1` continue de fonctionner (non touchée par cette PR)