### PR TITLE
Caisse : mise à jour du titre et du client du panier

### DIFF
--- a/public/common/js/biblys-admin.js
+++ b/public/common/js/biblys-admin.js
@@ -532,6 +532,32 @@ function reloadAdminEvents() {
     }
   });
 
+  // Mettre à jour le titre et/ou le client d'un panier
+  async function update_cart_info(cartId, field, value) {
+    const response = await fetch(`/admin/pos/carts/${cartId}`, {
+      method: 'PATCH',
+      headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: `${field}=${encodeURIComponent(value)}`,
+    });
+
+    if (!response.ok) {
+      let message = "Le panier n'a pas pu être mis à jour.";
+      try {
+        const error = await response.json();
+        if (error && error.message) message = error.message;
+      } catch (e) {
+        // réponse d'erreur non-JSON : on conserve le message générique
+      }
+      window._alert(message);
+      return null;
+    }
+
+    return await response.json();
+  }
+
   // Rechercher un article
   function checkout_lookup(event) {
     var input = $('#checkout_add_input').val();
@@ -634,16 +660,13 @@ function reloadAdminEvents() {
         return true;
       }
 
-      $.post(
-        '/pages/adm_checkout?cart_id=' + $('#cart_id').val(),
-        {
-          set_title: '' + $(this).text() + ''
-        },
-        function(res) {
-          if (res.error) _alert(res.error);
-          else notify(res.success);
-        }
-      );
+      update_cart_info(
+        $('#cart_id').val(),
+        'title',
+        $(this).text()
+      ).then(function(res) {
+        if (res) notify(res.success);
+      });
 
       return true;
     })
@@ -667,46 +690,39 @@ function reloadAdminEvents() {
       // Annuler la sélection du client
     })
     .click(function() {
-      $.post(
-        '/pages/adm_checkout?cart_id=' + $('#cart_id').val(),
-        {
-          set_customer: ''
-        },
-        function(res) {
-          if (res.error) _alert(res.error.message);
-          else {
-            $('#customer')
-              .removeClass('pointer')
-              .removeAttr('readonly')
-              .val('');
-            $('#customer_id').val('');
-            //notify(res.success);
-          }
+      update_cart_info(
+        $('#cart_id').val(),
+        'customer_id',
+        0
+      ).then(function(res) {
+        if (res) {
+          $('#customer')
+            .removeClass('pointer')
+            .removeAttr('readonly')
+            .val('');
+          $('#customer_id').val('');
         }
-      );
+      });
     })
     .removeClass('event');
 
   // Sélectionner un client
   function selectCustomer(id, name) {
-    $.post(
-      '/pages/adm_checkout?cart_id=' + $('#cart_id').val(),
-      {
-        set_customer: '' + id + ''
-      },
-      function(res) {
-        if (res.error) _alert(res.error.message);
-        else {
-          $('#customer')
-            .addClass('pointer')
-            .attr('readonly', 'readonly')
-            .val(name);
-          $('#customer_id').val(id);
-          $('#article').focus();
-          notify(res.success);
-        }
+    update_cart_info(
+      $('#cart_id').val(),
+      'customer_id',
+      id
+    ).then(function(res) {
+      if (res) {
+        $('#customer')
+          .addClass('pointer')
+          .attr('readonly', 'readonly')
+          .val(name);
+        $('#customer_id').val(id);
+        $('#article').focus();
+        notify(res.success);
       }
-    );
+    });
   }
 
   document.addEventListener('keyup', function(event) {

--- a/src/AppBundle/Controller/PointOfSaleController.php
+++ b/src/AppBundle/Controller/PointOfSaleController.php
@@ -19,6 +19,7 @@
 namespace AppBundle\Controller;
 
 use Biblys\Exception\CannotAddStockItemToCartException;
+use Biblys\Exception\CannotFindCustomerException;
 use Biblys\Exception\CannotRemoveStockItemFromCartException;
 use Biblys\Service\BodyParamsService;
 use Biblys\Service\CurrentSite;
@@ -42,6 +43,7 @@ use Symfony\Component\Routing\Generator\UrlGenerator;
 use Usecase\AddStockItemToPointOfSaleCartUsecase;
 use Usecase\ClearPointOfSaleCartUsecase;
 use Usecase\RemoveStockItemFromPointOfSaleCartUsecase;
+use Usecase\UpdatePointOfSaleCartUsecase;
 use Twig\Error\LoaderError;
 use Twig\Error\RuntimeError;
 use Twig\Error\SyntaxError;
@@ -251,6 +253,43 @@ class PointOfSaleController extends Controller
 
         return new JsonResponse([
             "success" => "Le panier a été vidé.",
+        ]);
+    }
+
+    /**
+     * @throws PropelException
+     */
+    public function updateCartAction(
+        Request     $request,
+        CurrentUser $currentUser,
+        int         $cartId,
+    ): Response
+    {
+        $currentUser->authAdmin();
+
+        if (!CartQuery::create()->filterById($cartId)->exists()) {
+            throw new NotFoundHttpException("Panier $cartId introuvable");
+        }
+
+        $bodyParams = new BodyParamsService($request);
+        $bodyParams->parse([
+            "title" => ["type" => "string", "default" => null],
+            "customer_id" => ["type" => "numeric", "default" => null],
+        ]);
+
+        try {
+            $usecase = new UpdatePointOfSaleCartUsecase();
+            $usecase->execute(
+                $cartId,
+                title: $bodyParams->get("title"),
+                customerId: $bodyParams->getInteger("customer_id"),
+            );
+        } catch (CannotFindCustomerException $exception) {
+            throw new NotFoundHttpException($exception->getMessage(), $exception);
+        }
+
+        return new JsonResponse([
+            "success" => "Le panier a été mis à jour.",
         ]);
     }
 }

--- a/src/AppBundle/routes.yml
+++ b/src/AppBundle/routes.yml
@@ -414,6 +414,13 @@ point_of_sale_clear_cart:
   requirements:
     cartId: \d+
 
+point_of_sale_update_cart:
+  path: /admin/pos/carts/{cartId}
+  controller: AppBundle\Controller\PointOfSaleController::updateCartAction
+  methods: [PATCH]
+  requirements:
+    cartId: \d+
+
 # Orders
 
 order_index:

--- a/src/Biblys/Exception/CannotFindCustomerException.php
+++ b/src/Biblys/Exception/CannotFindCustomerException.php
@@ -1,0 +1,23 @@
+<?php
+/*
+ * Copyright (C) 2026 Clément Latzarus
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+
+namespace Biblys\Exception;
+
+use Exception;
+
+class CannotFindCustomerException extends Exception {}

--- a/src/Usecase/UpdatePointOfSaleCartUsecase.php
+++ b/src/Usecase/UpdatePointOfSaleCartUsecase.php
@@ -1,0 +1,59 @@
+<?php
+/*
+ * Copyright (C) 2026 Clément Latzarus
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+
+namespace Usecase;
+
+use Biblys\Exception\CannotFindCustomerException;
+use Model\CartQuery;
+use Model\CustomerQuery;
+use Propel\Runtime\Exception\PropelException;
+
+class UpdatePointOfSaleCartUsecase
+{
+    /**
+     * Renomme un panier caisse et/ou change le client qui lui est associé.
+     *
+     * @param string|null $title Nouveau titre du panier, ou null pour ne pas le modifier.
+     * @param int|null $customerId Nouveau client, 0 pour désassocier le client, ou null pour ne pas le modifier.
+     *
+     * @throws CannotFindCustomerException si le client indiqué n'existe pas
+     * @throws PropelException
+     */
+    public function execute(int $cartId, ?string $title = null, ?int $customerId = null): void
+    {
+        $cart = CartQuery::create()->findPk($cartId);
+
+        if ($title !== null) {
+            $cart->setTitle($title);
+        }
+
+        if ($customerId !== null) {
+            if ($customerId === 0) {
+                $cart->setCustomerId(null);
+            } else {
+                $customer = CustomerQuery::create()->findPk($customerId);
+                if (!$customer) {
+                    throw new CannotFindCustomerException("Client n° $customerId introuvable.");
+                }
+                $cart->setCustomerId($customerId);
+            }
+        }
+
+        $cart->save();
+    }
+}

--- a/tests/AppBundle/Controller/PointOfSaleControllerTest.php
+++ b/tests/AppBundle/Controller/PointOfSaleControllerTest.php
@@ -478,4 +478,146 @@ class PointOfSaleControllerTest extends TestCase
             99999,
         );
     }
+
+    /**
+     * @throws PropelException
+     */
+    public function testUpdateCartActionRenamesCartAndReturnsJsonSuccess(): void
+    {
+        // given
+        $controller = $this->_getController();
+        $cart = ModelFactory::createCart();
+        $cart->setType("shop");
+        $cart->save();
+
+        $request = new Request(request: ['title' => 'Nouveau nom']);
+
+        $currentUser = Mockery::mock(CurrentUser::class);
+        $currentUser->expects("authAdmin");
+
+        // when
+        $response = $controller->updateCartAction(
+            $request,
+            $currentUser,
+            $cart->getId(),
+        );
+
+        // then
+        $this->assertEquals(200, $response->getStatusCode());
+        $data = json_decode($response->getContent(), true);
+        $this->assertArrayHasKey('success', $data);
+        $cart->reload();
+        $this->assertEquals('Nouveau nom', $cart->getTitle());
+    }
+
+    /**
+     * @throws PropelException
+     */
+    public function testUpdateCartActionSetsCustomerAndReturnsJsonSuccess(): void
+    {
+        // given
+        $controller = $this->_getController();
+        $cart = ModelFactory::createCart();
+        $cart->setType("shop");
+        $cart->save();
+        $customer = ModelFactory::createCustomer();
+
+        $request = new Request(request: ['customer_id' => $customer->getId()]);
+
+        $currentUser = Mockery::mock(CurrentUser::class);
+        $currentUser->expects("authAdmin");
+
+        // when
+        $response = $controller->updateCartAction(
+            $request,
+            $currentUser,
+            $cart->getId(),
+        );
+
+        // then
+        $this->assertEquals(200, $response->getStatusCode());
+        $cart->reload();
+        $this->assertEquals($customer->getId(), $cart->getCustomerId());
+    }
+
+    /**
+     * @throws PropelException
+     */
+    public function testUpdateCartActionUnsetsCustomerWhenCustomerIdIsEmpty(): void
+    {
+        // given
+        $controller = $this->_getController();
+        $cart = ModelFactory::createCart();
+        $cart->setType("shop");
+        $customer = ModelFactory::createCustomer();
+        $cart->setCustomerId($customer->getId());
+        $cart->save();
+
+        $request = new Request(request: ['customer_id' => '0']);
+
+        $currentUser = Mockery::mock(CurrentUser::class);
+        $currentUser->expects("authAdmin");
+
+        // when
+        $response = $controller->updateCartAction(
+            $request,
+            $currentUser,
+            $cart->getId(),
+        );
+
+        // then
+        $this->assertEquals(200, $response->getStatusCode());
+        $cart->reload();
+        $this->assertNull($cart->getCustomerId());
+    }
+
+    /**
+     * @throws PropelException
+     */
+    public function testUpdateCartActionReturns404WhenCartNotFound(): void
+    {
+        // given
+        $controller = $this->_getController();
+        $request = new Request(request: ['title' => 'Nouveau nom']);
+
+        $currentUser = Mockery::mock(CurrentUser::class);
+        $currentUser->expects("authAdmin");
+
+        // then
+        $this->expectException(\Symfony\Component\HttpKernel\Exception\NotFoundHttpException::class);
+
+        // when
+        $controller->updateCartAction(
+            $request,
+            $currentUser,
+            99999,
+        );
+    }
+
+    /**
+     * @throws PropelException
+     */
+    public function testUpdateCartActionReturns404WhenCustomerNotFound(): void
+    {
+        // given
+        $controller = $this->_getController();
+        $cart = ModelFactory::createCart();
+        $cart->setType("shop");
+        $cart->save();
+
+        $request = new Request(request: ['customer_id' => '99999']);
+
+        $currentUser = Mockery::mock(CurrentUser::class);
+        $currentUser->expects("authAdmin");
+
+        // then
+        $this->expectException(\Symfony\Component\HttpKernel\Exception\NotFoundHttpException::class);
+
+        // when
+        $controller->updateCartAction(
+            $request,
+            $currentUser,
+            $cart->getId(),
+        );
+    }
 }

--- a/tests/Usecase/UpdatePointOfSaleCartUsecaseTest.php
+++ b/tests/Usecase/UpdatePointOfSaleCartUsecaseTest.php
@@ -1,0 +1,132 @@
+<?php
+/*
+ * Copyright (C) 2026 Clément Latzarus
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+
+namespace Usecase;
+
+use Biblys\Exception\CannotFindCustomerException;
+use Biblys\Test\ModelFactory;
+use PHPUnit\Framework\TestCase;
+use Propel\Runtime\Exception\PropelException;
+
+class UpdatePointOfSaleCartUsecaseTest extends TestCase
+{
+    /**
+     * @throws PropelException
+     */
+    public function testRenamesTheCart(): void
+    {
+        // given
+        $cart = ModelFactory::createCart();
+        $cart->setType("shop");
+        $cart->setTitle("Ancien nom");
+        $cart->save();
+        $usecase = new UpdatePointOfSaleCartUsecase();
+
+        // when
+        $usecase->execute($cart->getId(), title: "Nouveau nom");
+
+        // then
+        $cart->reload();
+        $this->assertEquals("Nouveau nom", $cart->getTitle());
+    }
+
+    /**
+     * @throws PropelException
+     * @throws CannotFindCustomerException
+     */
+    public function testAssociatesACustomerToTheCart(): void
+    {
+        // given
+        $cart = ModelFactory::createCart();
+        $cart->setType("shop");
+        $cart->save();
+        $customer = ModelFactory::createCustomer();
+        $usecase = new UpdatePointOfSaleCartUsecase();
+
+        // when
+        $usecase->execute($cart->getId(), customerId: $customer->getId());
+
+        // then
+        $cart->reload();
+        $this->assertEquals($customer->getId(), $cart->getCustomerId());
+    }
+
+    /**
+     * @throws PropelException
+     * @throws CannotFindCustomerException
+     */
+    public function testUnassociatesTheCustomerFromTheCart(): void
+    {
+        // given
+        $cart = ModelFactory::createCart();
+        $cart->setType("shop");
+        $customer = ModelFactory::createCustomer();
+        $cart->setCustomerId($customer->getId());
+        $cart->save();
+        $usecase = new UpdatePointOfSaleCartUsecase();
+
+        // when
+        $usecase->execute($cart->getId(), customerId: 0);
+
+        // then
+        $cart->reload();
+        $this->assertNull($cart->getCustomerId());
+    }
+
+    /**
+     * @throws PropelException
+     */
+    public function testThrowsIfCustomerDoesNotExist(): void
+    {
+        // given
+        $cart = ModelFactory::createCart();
+        $cart->setType("shop");
+        $cart->save();
+        $usecase = new UpdatePointOfSaleCartUsecase();
+
+        // then
+        $this->expectException(CannotFindCustomerException::class);
+
+        // when
+        $usecase->execute($cart->getId(), customerId: 99999);
+    }
+
+    /**
+     * @throws PropelException
+     * @throws CannotFindCustomerException
+     */
+    public function testDoesNotChangeAnythingIfNoParameterIsProvided(): void
+    {
+        // given
+        $cart = ModelFactory::createCart();
+        $cart->setType("shop");
+        $cart->setTitle("Panier de test");
+        $customer = ModelFactory::createCustomer();
+        $cart->setCustomerId($customer->getId());
+        $cart->save();
+        $usecase = new UpdatePointOfSaleCartUsecase();
+
+        // when
+        $usecase->execute($cart->getId());
+
+        // then
+        $cart->reload();
+        $this->assertEquals("Panier de test", $cart->getTitle());
+        $this->assertEquals($customer->getId(), $cart->getCustomerId());
+    }
+}


### PR DESCRIPTION
## Résumé

- Ajoute `UpdatePointOfSaleCartUsecase`, qui renomme un panier caisse et/ou lui associe un client (avec vérification de son existence via `CannotFindCustomerException`), à l'identique du comportement legacy
- Ajoute `PointOfSaleController::updateCartAction` (`PATCH /admin/pos/carts/{cartId}`), migrant les paramètres legacy `set_title` et `set_customer` du controller `adm_checkout.php`
- Met à jour le JS des champs « titre du panier » (contenteditable) et « client » du template `PointOfSale/index.html.twig` pour utiliser la nouvelle route au lieu de `/pages/adm_checkout`

PR 5 du plan de migration décrit dans #512.

## Plan de test

- [x] `composer test` passe (1272 tests)
- [x] Depuis `/admin/caisse`, renommer le panier via le titre éditable et vérifier que le nouveau nom est bien enregistré
- [x] Rechercher et associer un client au panier, vérifier son affichage
- [x] Désassocier le client, vérifier que le champ se vide et redevient éditable
- [x] L'ancienne URL `/pages/adm_checkout` continue de fonctionner (non touchée par cette PR)