### PR TITLE
Caisse : createSaleAction et CreateShopSaleUsecase (PR 6/8)

### DIFF
--- a/public/common/js/biblys-admin.js
+++ b/public/common/js/biblys-admin.js
@@ -361,8 +361,7 @@ function reloadAdminEvents() {
       }
 
       if (go == 1) {
-        var data = {
-          validate: 1,
+        create_sale($('#cart_id').val(), {
           seller_id: $('#seller_id').val(),
           customer_id: $('#customer_id').val(),
           cart_cash: $('#cart_cash').val() * 100,
@@ -370,22 +369,36 @@ function reloadAdminEvents() {
           cart_card: $('#cart_card').val() * 100,
           cart_topay: $('#cart_topay').attr('data-value'),
           cart_togive: $('#cart_togive').attr('data-value')
-        };
-        $.post({
-          url: '/pages/adm_checkout?cart_id=' + $('#cart_id').val(),
-          data: data,
-          dataType: 'json'
-        })
-          .done(function() {
-            window.location.href = '/admin/caisse';
-          })
-          .fail(function(res) {
-            var json = res.responseJSON;
-            _alert(json.error.message);
-          });
+        });
       }
     })
     .removeClass('event');
+
+  // Enregistrer la vente
+  async function create_sale(cartId, data) {
+    const response = await fetch(`/admin/pos/carts/${cartId}/sale`, {
+      method: 'POST',
+      headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: new URLSearchParams(data).toString(),
+    });
+
+    if (!response.ok) {
+      let message = "La vente n'a pas pu être enregistrée.";
+      try {
+        const error = await response.json();
+        if (error && error.message) message = error.message;
+      } catch (e) {
+        // réponse d'erreur non-JSON : on conserve le message générique
+      }
+      window._alert(message);
+      return;
+    }
+
+    window.location.href = '/admin/caisse';
+  }
 
   // Update cart
   function update_cart() {

--- a/src/AppBundle/Controller/PointOfSaleController.php
+++ b/src/AppBundle/Controller/PointOfSaleController.php
@@ -24,6 +24,7 @@ use Biblys\Exception\CannotRemoveStockItemFromCartException;
 use Biblys\Service\BodyParamsService;
 use Biblys\Service\CurrentSite;
 use Biblys\Service\CurrentUser;
+use Biblys\Service\FlashMessagesService;
 use Biblys\Service\Images\ImagesService;
 use Biblys\Service\QueryParamsService;
 use Biblys\Service\TemplateService;
@@ -42,6 +43,7 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Generator\UrlGenerator;
 use Usecase\AddStockItemToPointOfSaleCartUsecase;
 use Usecase\ClearPointOfSaleCartUsecase;
+use Usecase\CreatePointOfSaleOrderUsecase;
 use Usecase\RemoveStockItemFromPointOfSaleCartUsecase;
 use Usecase\UpdatePointOfSaleCartUsecase;
 use Twig\Error\LoaderError;
@@ -291,5 +293,56 @@ class PointOfSaleController extends Controller
         return new JsonResponse([
             "success" => "Le panier a été mis à jour.",
         ]);
+    }
+
+    /**
+     * @throws PropelException
+     */
+    public function createSaleAction(
+        Request               $request,
+        CurrentUser           $currentUser,
+        FlashMessagesService  $flashMessagesService,
+        int                   $cartId,
+    ): Response
+    {
+        $currentUser->authAdmin();
+
+        if (!CartQuery::create()->filterById($cartId)->exists()) {
+            throw new NotFoundHttpException("Panier $cartId introuvable");
+        }
+
+        $bodyParams = new BodyParamsService($request);
+        $bodyParams->parse([
+            "seller_id" => ["type" => "numeric", "default" => null],
+            "customer_id" => ["type" => "numeric", "default" => null],
+            "cart_cash" => ["type" => "numeric", "default" => 0],
+            "cart_cheque" => ["type" => "numeric", "default" => 0],
+            "cart_card" => ["type" => "numeric", "default" => 0],
+            "cart_topay" => ["type" => "numeric", "default" => 0],
+            "cart_togive" => ["type" => "numeric", "default" => 0],
+        ]);
+
+        $usecase = new CreatePointOfSaleOrderUsecase();
+        $orderId = $usecase->execute(
+            $cartId,
+            sellerId: $bodyParams->getInteger("seller_id"),
+            customerId: $bodyParams->getInteger("customer_id"),
+            cashAmount: $bodyParams->getInteger("cart_cash"),
+            chequeAmount: $bodyParams->getInteger("cart_cheque"),
+            cardAmount: $bodyParams->getInteger("cart_card"),
+            amountToBePaid: $bodyParams->getInteger("cart_topay"),
+            paymentLeft: $bodyParams->getInteger("cart_togive"),
+        );
+
+        $flashMessagesService->add("success", "La vente a été enregistrée.");
+
+        if (in_array("application/json", $request->getAcceptableContentTypes())) {
+            return new JsonResponse([
+                "success" => "La vente a été enregistrée.",
+                "order_id" => $orderId,
+            ]);
+        }
+
+        return new RedirectResponse("/admin/caisse");
     }
 }

--- a/src/AppBundle/routes.yml
+++ b/src/AppBundle/routes.yml
@@ -421,6 +421,13 @@ point_of_sale_update_cart:
   requirements:
     cartId: \d+
 
+point_of_sale_create_sale:
+  path: /admin/pos/carts/{cartId}/sale
+  controller: AppBundle\Controller\PointOfSaleController::createSaleAction
+  methods: [POST]
+  requirements:
+    cartId: \d+
+
 # Orders
 
 order_index:

--- a/src/Usecase/CreatePointOfSaleOrderUsecase.php
+++ b/src/Usecase/CreatePointOfSaleOrderUsecase.php
@@ -1,0 +1,93 @@
+<?php
+/*
+ * Copyright (C) 2026 Clément Latzarus
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+
+namespace Usecase;
+
+use CartManager;
+use Exception;
+use Model\Map\OrderTableMap;
+use Model\Payment;
+use OrderManager;
+use Propel\Runtime\Exception\PropelException;
+use Propel\Runtime\Propel;
+
+class CreatePointOfSaleOrderUsecase
+{
+    /**
+     * Crée une commande à partir d'un panier caisse, enregistre les paiements et vide le panier.
+     *
+     * @throws PropelException
+     */
+    public function execute(
+        int  $cartId,
+        ?int $sellerId,
+        ?int $customerId,
+        int  $cashAmount,
+        int  $chequeAmount,
+        int  $cardAmount,
+        int  $amountToBePaid,
+        int  $paymentLeft,
+    ): int
+    {
+        $cm = new CartManager();
+        $cart = $cm->getById($cartId);
+
+        $con = Propel::getWriteConnection(OrderTableMap::DATABASE_NAME);
+        $con->beginTransaction();
+
+        try {
+            $om = new OrderManager();
+            $order = $om->create();
+
+            if ($sellerId) {
+                $order->set('seller_id', $sellerId);
+            }
+            if ($customerId) {
+                $order->set('customer_id', $customerId);
+            }
+
+            $order->set('order_type', 'shop');
+            $order->set('order_payment_cash', $cashAmount);
+            $order->set('order_payment_cheque', $chequeAmount);
+            $order->set('order_payment_card', $cardAmount);
+            $order->set('order_amount_tobepaid', $amountToBePaid);
+            $order->set('order_payment_left', $paymentLeft);
+            $order->set('order_payment_date', date('Y-m-d H:i:s'));
+
+            $om->hydrateFromCart($order, $cart);
+            $order = $om->update($order);
+
+            $paymentsUsecase = new RecordPointOfSalePaymentsUsecase();
+            $paymentsUsecase->execute((int) $order->get('order_id'), [
+                Payment::MODE_CASH  => $cashAmount,
+                Payment::MODE_CHECK => $chequeAmount,
+                Payment::MODE_CARD  => $cardAmount,
+            ]);
+
+            $cm->vacuum($cart);
+            $cm->delete($cart);
+
+            $con->commit();
+        } catch (Exception $exception) {
+            $con->rollBack();
+            throw $exception;
+        }
+
+        return (int) $order->get('order_id');
+    }
+}

--- a/tests/AppBundle/Controller/PointOfSaleControllerTest.php
+++ b/tests/AppBundle/Controller/PointOfSaleControllerTest.php
@@ -21,6 +21,7 @@ namespace AppBundle\Controller;
 use Biblys\Service\BodyParamsService;
 use Biblys\Service\CurrentSite;
 use Biblys\Service\CurrentUser;
+use Biblys\Service\FlashMessagesService;
 use Biblys\Service\Images\ImagesService;
 use Biblys\Service\QueryParamsService;
 use Biblys\Test\EntityFactory;
@@ -618,6 +619,107 @@ class PointOfSaleControllerTest extends TestCase
             $request,
             $currentUser,
             $cart->getId(),
+        );
+    }
+
+    /**
+     * @throws PropelException
+     */
+    public function testCreateSaleActionCreatesOrderAndReturnsJson(): void
+    {
+        // given
+        $controller = $this->_getController();
+        $cart = ModelFactory::createCart();
+        $cart->setType("shop");
+        $cart->save();
+        $stock = ModelFactory::createStockItem(cart: $cart, sellingPrice: 1899);
+
+        $request = new Request(request: [
+            'cart_cash' => '1899',
+            'cart_topay' => '0',
+            'cart_togive' => '0',
+        ]);
+        $request->headers->set('Accept', 'application/json');
+
+        $currentUser = Mockery::mock(CurrentUser::class);
+        $currentUser->expects("authAdmin");
+
+        $flashMessagesService = Mockery::mock(FlashMessagesService::class);
+        $flashMessagesService->expects("add")->with("success", "La vente a été enregistrée.");
+
+        // when
+        $response = $controller->createSaleAction(
+            $request,
+            $currentUser,
+            $flashMessagesService,
+            $cart->getId(),
+        );
+
+        // then
+        $this->assertEquals(200, $response->getStatusCode());
+        $data = json_decode($response->getContent(), true);
+        $this->assertArrayHasKey('order_id', $data);
+        $stock->reload();
+        $this->assertEquals($data['order_id'], $stock->getOrderId());
+    }
+
+    /**
+     * @throws PropelException
+     */
+    public function testCreateSaleActionRedirectsWhenNotAcceptingJson(): void
+    {
+        // given
+        $controller = $this->_getController();
+        $cart = ModelFactory::createCart();
+        $cart->setType("shop");
+        $cart->save();
+
+        $request = new Request(request: [
+            'cart_cash' => '0',
+            'cart_topay' => '0',
+            'cart_togive' => '0',
+        ]);
+
+        $currentUser = Mockery::mock(CurrentUser::class);
+        $currentUser->expects("authAdmin");
+
+        $flashMessagesService = Mockery::mock(FlashMessagesService::class);
+        $flashMessagesService->expects("add")->with("success", "La vente a été enregistrée.");
+
+        // when
+        $response = $controller->createSaleAction(
+            $request,
+            $currentUser,
+            $flashMessagesService,
+            $cart->getId(),
+        );
+
+        // then
+        $this->assertEquals(302, $response->getStatusCode());
+        $this->assertEquals("/admin/caisse", $response->headers->get("Location"));
+    }
+
+    /**
+     * @throws PropelException
+     */
+    public function testCreateSaleActionReturns404WhenCartNotFound(): void
+    {
+        // given
+        $controller = $this->_getController();
+        $request = new Request();
+
+        $currentUser = Mockery::mock(CurrentUser::class);
+        $currentUser->expects("authAdmin");
+
+        // then
+        $this->expectException(\Symfony\Component\HttpKernel\Exception\NotFoundHttpException::class);
+
+        // when
+        $controller->createSaleAction(
+            $request,
+            $currentUser,
+            Mockery::mock(FlashMessagesService::class),
+            99999,
         );
     }
 }

--- a/tests/Usecase/CreatePointOfSaleOrderUsecaseTest.php
+++ b/tests/Usecase/CreatePointOfSaleOrderUsecaseTest.php
@@ -1,0 +1,132 @@
+<?php
+/*
+ * Copyright (C) 2026 Clément Latzarus
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+
+namespace Usecase;
+
+use Biblys\Test\ModelFactory;
+use Model\CartQuery;
+use Model\OrderQuery;
+use Model\Payment;
+use Model\PaymentQuery;
+use PHPUnit\Framework\TestCase;
+use Propel\Runtime\Exception\PropelException;
+
+class CreatePointOfSaleOrderUsecaseTest extends TestCase
+{
+    /**
+     * @throws PropelException
+     */
+    public function testCreatesShopOrderWithSellerAndCustomer(): void
+    {
+        // given
+        $seller = ModelFactory::createUser();
+        $customer = ModelFactory::createCustomer();
+        $cart = ModelFactory::createCart();
+        $cart->setType("shop");
+        $cart->save();
+        $stock = ModelFactory::createStockItem(cart: $cart, sellingPrice: 1899);
+
+        $usecase = new CreatePointOfSaleOrderUsecase();
+
+        // when
+        $orderId = $usecase->execute(
+            $cart->getId(),
+            sellerId: $seller->getId(),
+            customerId: $customer->getId(),
+            cashAmount: 1899,
+            chequeAmount: 0,
+            cardAmount: 0,
+            amountToBePaid: 0,
+            paymentLeft: 0,
+        );
+
+        // then
+        $order = OrderQuery::create()->findPk($orderId);
+        $this->assertNotNull($order);
+        $this->assertEquals("shop", $order->getType());
+        $this->assertEquals($seller->getId(), $order->getSellerId());
+        $this->assertEquals($customer->getId(), $order->getCustomerId());
+        $this->assertEquals(1899, $order->getPaymentCash());
+
+        $stock->reload();
+        $this->assertEquals($orderId, $stock->getOrderId());
+    }
+
+    /**
+     * @throws PropelException
+     */
+    public function testRecordsPaymentsForEachMode(): void
+    {
+        // given
+        $cart = ModelFactory::createCart();
+        $cart->setType("shop");
+        $cart->save();
+        ModelFactory::createStockItem(cart: $cart, sellingPrice: 3000);
+
+        $usecase = new CreatePointOfSaleOrderUsecase();
+
+        // when
+        $orderId = $usecase->execute(
+            $cart->getId(),
+            sellerId: null,
+            customerId: null,
+            cashAmount: 1000,
+            chequeAmount: 1000,
+            cardAmount: 1000,
+            amountToBePaid: 0,
+            paymentLeft: 0,
+        );
+
+        // then
+        $payments = PaymentQuery::create()->filterByOrderId($orderId)->find();
+        $this->assertCount(3, $payments);
+        $modes = array_map(fn(Payment $payment) => $payment->getMode(), iterator_to_array($payments));
+        $this->assertContains(Payment::MODE_CASH, $modes);
+        $this->assertContains(Payment::MODE_CHECK, $modes);
+        $this->assertContains(Payment::MODE_CARD, $modes);
+    }
+
+    /**
+     * @throws PropelException
+     */
+    public function testDeletesCartAfterSale(): void
+    {
+        // given
+        $cart = ModelFactory::createCart();
+        $cart->setType("shop");
+        $cart->save();
+        $cartId = $cart->getId();
+
+        $usecase = new CreatePointOfSaleOrderUsecase();
+
+        // when
+        $usecase->execute(
+            $cartId,
+            sellerId: null,
+            customerId: null,
+            cashAmount: 0,
+            chequeAmount: 0,
+            cardAmount: 0,
+            amountToBePaid: 0,
+            paymentLeft: 0,
+        );
+
+        // then
+        $this->assertFalse(CartQuery::create()->filterById($cartId)->exists());
+    }
+}


### PR DESCRIPTION
## Résumé

- Migre la validation de vente de `adm_checkout.php` vers `PointOfSaleController::createSaleAction`
- Ajoute `CreatePointOfSaleOrderUsecase` : crée la commande depuis le panier, enregistre les paiements (`RecordPointOfSalePaymentsUsecase`), vide et supprime le panier
- Nouvelle route `POST /admin/pos/carts/{cartId}/sale`
- Le formulaire de validation de vente pointe désormais vers la nouvelle route (fetch + gestion d'erreur JSON, comme les actions déjà migrées)
- L'ancienne URL `/pages/adm_checkout` reste active (redirection prévue en PR 8)

Partie de #512.

## Plan de test

- [x] `composer test` passe (1278 tests)
- [x] Tests unitaires du usecase (création de commande, enregistrement des paiements, suppression du panier)
- [x] Tests du controller (réponse JSON avec `order_id`, redirection si non-JSON, 404 si panier introuvable)
- [x] Vérification manuelle : ajout d'article → validation de vente en caisse fonctionne de bout en bout