### PR TITLE
Caisse : sortir indexAction des managers legacy CartManager/CustomerManager

### DIFF
--- a/src/AppBundle/Controller/PointOfSaleController.php
+++ b/src/AppBundle/Controller/PointOfSaleController.php
@@ -29,10 +29,12 @@ use Biblys\Service\Images\ImagesService;
 use Biblys\Service\QueryParamsService;
 use Biblys\Service\TemplateService;
 use CartManager;
-use CustomerManager;
 use Framework\Controller;
+use Model\Cart;
 use Model\CartQuery;
+use Model\CustomerQuery;
 use Model\UserQuery;
+use Propel\Runtime\ActiveQuery\Criteria;
 use Propel\Runtime\Exception\PropelException;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -80,21 +82,21 @@ class PointOfSaleController extends Controller
 
         $cartId = $queryParams->getInteger("cart_id");
         if (!$cartId) {
-            $cartForCurrentSeller = $cm->get([
-                "cart_type" => "shop",
-                "cart_seller_id" => $currentUser->getUser()->getId(),
-                "cart_count" => 0,
-            ]);
+            $cartForCurrentSeller = CartQuery::create()
+                ->filterByType('shop')
+                ->filterBySellerId($currentUser->getUser()->getId())
+                ->filterByCount(0)
+                ->findOne();
 
             if ($cartForCurrentSeller) {
-                return new RedirectResponse("/admin/caisse?cart_id={$cartForCurrentSeller->get('id')}");
+                return new RedirectResponse("/admin/caisse?cart_id={$cartForCurrentSeller->getId()}");
             }
 
-            $newCart = $cm->create();
-            $newCart->set("cart_type", "shop");
-            $newCart->set("cart_seller_id", $currentUser->getUser()->getId());
-            $newCart = $cm->update($newCart);
-            return new RedirectResponse("/admin/caisse?cart_id={$newCart->get('id')}");
+            $newCart = new Cart();
+            $newCart->setType('shop');
+            $newCart->setSellerId($currentUser->getUser()->getId());
+            $newCart->save();
+            return new RedirectResponse("/admin/caisse?cart_id={$newCart->getId()}");
         }
 
         $cart = $cm->get(['cart_id' => $cartId]);
@@ -108,9 +110,9 @@ class PointOfSaleController extends Controller
         }
 
         $customer = null;
-        if ($cart->has('customer_id')) {
-            $customerManager = new CustomerManager();
-            $customer = $customerManager->get(['customer_id' => $cart->get('customer_id')]);
+        $customerId = $cart->get('customer_id');
+        if ($customerId) {
+            $customer = CustomerQuery::create()->findPk($customerId);
         }
 
         $cartContent = '';
@@ -124,25 +126,28 @@ class PointOfSaleController extends Controller
         $cm->updateFromStock($cart);
 
         $pointOfSaleCarts = [];
-        foreach ($cm->getAll() as $pointOfSaleCart) {
-            if ($pointOfSaleCart->get('cart_count') > 0 && $pointOfSaleCart->get('cart_type') === 'shop') {
-                $cartSeller = null;
-                if ($pointOfSaleCart->has('seller_user_id')) {
-                    $cartSeller = UserQuery::create()->findPk($pointOfSaleCart->get('seller_user_id'));
-                } elseif ($pointOfSaleCart->has('seller_id')) {
-                    $cartSeller = UserQuery::create()->findPk($pointOfSaleCart->get('seller_id'));
-                }
-                $pointOfSaleCarts[] = [
-                    'id' => $pointOfSaleCart->get('cart_id'),
-                    'title' => $pointOfSaleCart->get('cart_title'),
-                    'seller_email' => $cartSeller?->getEmail() ?? "Vendeur inconnu",
-                    'customer_name' => $pointOfSaleCart->has('customer')
-                        ? $pointOfSaleCart->get('customer')->get('first_name') . ' ' . $pointOfSaleCart->get('customer')->get('last_name')
-                        : null,
-                    'count' => $pointOfSaleCart->get('cart_count'),
-                    'amount' => $pointOfSaleCart->get('cart_amount'),
-                ];
+        $openShopCarts = CartQuery::create()
+            ->filterByType('shop')
+            ->filterByCount(0, Criteria::GREATER_THAN)
+            ->find();
+        foreach ($openShopCarts as $pointOfSaleCart) {
+            $cartSeller = null;
+            if ($pointOfSaleCart->getSellerUserId()) {
+                $cartSeller = UserQuery::create()->findPk($pointOfSaleCart->getSellerUserId());
+            } elseif ($pointOfSaleCart->getSellerId()) {
+                $cartSeller = UserQuery::create()->findPk($pointOfSaleCart->getSellerId());
             }
+            $customerForCart = $pointOfSaleCart->getCustomerId()
+                ? CustomerQuery::create()->findPk($pointOfSaleCart->getCustomerId())
+                : null;
+            $pointOfSaleCarts[] = [
+                'id' => $pointOfSaleCart->getId(),
+                'title' => $pointOfSaleCart->getTitle(),
+                'seller_email' => $cartSeller?->getEmail() ?? "Vendeur inconnu",
+                'customer_name' => $customerForCart?->getFullName(),
+                'count' => $pointOfSaleCart->getCount(),
+                'amount' => $pointOfSaleCart->getAmount(),
+            ];
         }
 
         return $templateService->renderResponse("AppBundle:PointOfSale:index.html.twig", [

--- a/src/AppBundle/Resources/views/PointOfSale/index.html.twig
+++ b/src/AppBundle/Resources/views/PointOfSale/index.html.twig
@@ -78,9 +78,9 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
               {% if customer %}
                 <input type="text" name="customer" id="customer"
                        placeholder="Rechercher un client..."
-                       value="{{ customer.get('customer_last_name') }}, {{ customer.get('customer_first_name') }} ({{ customer.get('customer_email') }})"
+                       value="{{ customer.getLastName() }}, {{ customer.getFirstName() }} ({{ customer.getEmail() }})"
                        readonly class="form-control pointer event">
-                <input type="hidden" name="customer_id" id="customer_id" value="{{ customer.get('customer_id') }}" required>
+                <input type="hidden" name="customer_id" id="customer_id" value="{{ customer.getId() }}" required>
               {% else %}
                 <input type="text" name="customer" id="customer" placeholder="Rechercher un client..." class="form-control event">
                 <input type="hidden" name="customer_id" id="customer_id" required>


### PR DESCRIPTION
## Changes

- `PointOfSaleController::indexAction` n'utilise plus `CustomerManager::get` : remplacé par `CustomerQuery::create()->findPk()`.
- La recherche/création du panier caisse du vendeur courant (avant obtention d'un `cart_id`) passe par `CartQuery`/`Model\Cart` (Propel) au lieu de `CartManager::get/create/update`.
- La liste des paniers caisse ouverts (`point_of_sale_carts`) est construite via `CartQuery` filtrée en SQL au lieu d'un `CartManager::getAll()` filtré en PHP.
- Le template `PointOfSale/index.html.twig` est adapté pour utiliser les getters Propel du client (`getLastName()`, `getFirstName()`, `getEmail()`, `getId()`) au lieu de l'API ArrayAccess legacy (`customer.get('customer_last_name')`, etc.).
- `CartManager` reste utilisé uniquement pour récupérer le panier principal et son contenu (`get`, `getStock`, `updateFromStock`), car `Cart::getLine()` dépend de l'entité legacy `Cart`/`Stock` (ArrayAccess) — hors périmètre de cette étape.

Première sous-étape de l'issue #614 (migration incrémentale des managers legacy vers des repositories/requêtes Propel dans la couche caisse). D'autres PR suivront pour les étapes suivantes, l'issue reste ouverte jusqu'à leur complétion.

Réf #614

## Test plan

- [x] `composer test:path tests/AppBundle/Controller/PointOfSaleControllerTest.php` — 24 tests passent sans modification
- [ ] Vérification manuelle en local : ouvrir `/admin/caisse`, vérifier la redirection vers un nouveau panier, l'affichage du contenu, et l'affichage correct d'un client associé (nom, prénom, email)