### PR TITLE
Correctif 3.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Corrections
 
+- La facture d'une commande indique à nouveau le nombre d'articles et, lorsqu'il
+  est connu, le poids total de la commande, en kilogrammes.
 - Corrigé un arrondi flottant lors de la capture d'un paiement PayPal qui
   pouvait laisser un centime "restant à payer" sur des commandes pourtant
   payées intégralement.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Corrigé un arrondi flottant lors de la capture d'un paiement PayPal qui
   pouvait laisser un centime "restant à payer" sur des commandes pourtant
   payées intégralement.
+- La pagination s'affiche à nouveau sur les pages de catégorie du blog.
 
 ## 3.15.0 (12 août 2026)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Historique des modifications
 
+## 3.15.1 (13 août 2026)
+
+### Corrections
+
+- Corrigé un arrondi flottant lors de la capture d'un paiement PayPal qui
+  pouvait laisser un centime "restant à payer" sur des commandes pourtant
+  payées intégralement.
+
 ## 3.15.0 (12 août 2026)
 
 ### Conformité NF525

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Historique des modifications
 
-## 3.15.1 (13 août 2026)
+## 3.15.1 (19 août 2026)
 
 ### Corrections
 

--- a/inc/constants.php
+++ b/inc/constants.php
@@ -15,4 +15,4 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-const BIBLYS_VERSION = "3.15.0";
+const BIBLYS_VERSION = "3.15.1-dev";

--- a/inc/constants.php
+++ b/inc/constants.php
@@ -15,4 +15,4 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-const BIBLYS_VERSION = "3.15.1-dev";
+const BIBLYS_VERSION = "3.15.1";

--- a/src/ApiBundle/Controller/PaymentController.php
+++ b/src/ApiBundle/Controller/PaymentController.php
@@ -171,7 +171,7 @@ class PaymentController extends Controller
                 $payment = new Payment();
                 $payment->setOrder($order);
                 $payment->setMode(Payment::MODE_PAYPAL);
-                $payment->setAmount($paidAmount * 100);
+                $payment->setAmount(round($paidAmount * 100));
 
                 $addArticleToLibraryUsecase = new AddArticleToUserLibraryUsecase(
                     mailer: $mailer,

--- a/src/AppBundle/Controller/OrderController.php
+++ b/src/AppBundle/Controller/OrderController.php
@@ -284,9 +284,11 @@ class OrderController extends Controller
         $lines = [];
         $totalHt = 0;
         $totalVat = 0;
+        $totalWeight = 0;
         $vatBreakdown = [];
         foreach ($stocks as $stock) {
             $article = $stock->getArticle();
+            $totalWeight += (int) $stock->getWeight();
             $priceHt = (int) $stock->getSellingPriceHt();
             $priceVat = (int) $stock->getSellingPriceTva();
             $vatRate = $stock->getTvaRate();
@@ -355,6 +357,8 @@ class OrderController extends Controller
             "page_title" => $pageTitle,
             "order" => $order,
             "lines" => $lines,
+            "article_count" => count($lines),
+            "total_weight" => $totalWeight > 0 ? $totalWeight : null,
             "total_ht" => $totalHt,
             "total_vat" => $totalVat,
             "vat_breakdown" => $vatBreakdown,

--- a/src/AppBundle/Controller/PostCategoryController.php
+++ b/src/AppBundle/Controller/PostCategoryController.php
@@ -84,10 +84,7 @@ class PostCategoryController extends Controller
         return $this->render('AppBundle:PostCategory:show.html.twig', [
             'category' => $category,
             'posts' => $posts,
-            'current_page' => $pagination->getCurrent(),
-            'prev_page' => $pagination->getPrevious(),
-            'next_page' => $pagination->getNext(),
-            'total_pages' => $pagination->getTotal()
+            'pages' => $pagination,
         ]);
     }
 

--- a/src/AppBundle/Resources/views/Order/invoice.html.twig
+++ b/src/AppBundle/Resources/views/Order/invoice.html.twig
@@ -75,8 +75,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
             font-weight: bold;
         }
 
-        .invoice-document .text-right { 
-            text-align: right; 
+        .invoice-document .text-right {
+            text-align: right;
         }
 
         .invoice-document .text-center { 
@@ -118,7 +118,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
         <table class="table article-list mt-4">
             <thead>
                 <tr>
-                    <th>Article</th>
+                    <th>{{ article_count }} {{ "article"|pluralize(article_count) }}</th>
                     {% if is_shop %}<th>État</th>{% endif %}
                     {% if has_vat %}
                         <th class="text-right">Taux</th>
@@ -155,9 +155,11 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
                 {% if order.shippingCost > 0 %}
                     <tr class="p-4">
                         <td>
+                            {% set shippingWeight = total_weight ? (total_weight / 1000)|number_format(2, ',', ' ') ~ ' kg' : null %}
+                            {% set shippingDetails = [order.shippingMode, shippingWeight]|filter(detail => detail)|join(' · ') %}
                             <p class="article-title py-1 m-0">
                                 Port
-                                <small class="text-muted">({{ order.shippingMode }})</small>
+                                {% if shippingDetails %}<small class="text-muted">({{ shippingDetails }})</small>{% endif %}
                             </p>
                         </td>
                         {% if is_shop %}<td></td>{% endif %}

--- a/tests/ApiBundle/Controller/PaymentControllerTest.php
+++ b/tests/ApiBundle/Controller/PaymentControllerTest.php
@@ -157,4 +157,86 @@ class PaymentControllerTest extends TestCase
         $this->assertEquals(2500, $payment->getAmount());
         $this->assertTrue($payment->isExecuted(), "the payment should have been marked as executed");
     }
+
+    /**
+     * Regression test: PayPal returns captured amounts as decimal strings (e.g. "19.99").
+     * Converting them to cents via a plain float multiplication (value * 100) is subject to
+     * floating-point representation error (19.99 * 100 = 1998.9999999999998), which the
+     * subsequent (int) cast in Payment::setAmount() truncates down to 1998 instead of 1999,
+     * leaving the order 1 cent short of fully paid despite PayPal having captured it in full.
+     *
+     * @throws PropelException
+     * @throws TransportExceptionInterface
+     * @throws Exception
+     */
+    public function testPaypalCaptureActionWithAmountProneToFloatingPointError(): void
+    {
+        // given
+        $order = ModelFactory::createOrder(amountToBePaid: 1999);
+
+        $config = Mockery::mock(Config::class);
+        $config->expects("isPayPalEnabled")->andReturn(true);
+
+        $paymentService = Mockery::mock(PaymentService::class);
+        $paymentService->expects("getPayableOrderBySlug")->andReturn($order);
+
+        $request = new Request([], [], [], [], [], [], json_encode(["paypalOrderId" => "PAYPAL_ORDER_123"]));
+
+        $captureResponseData = [
+            "status" => "COMPLETED",
+            "purchase_units" => [
+                [
+                    "payments" => [
+                        "captures" => [
+                            ["amount" => ["value" => "19.99"]],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $mockApiResponse = Mockery::mock(ApiResponse::class);
+        $mockApiResponse->allows("getBody")->andReturn(json_encode($captureResponseData));
+        $mockApiResponse->allows("getStatusCode")->andReturn(201);
+
+        $mockOrdersController = Mockery::mock(OrdersController::class);
+        $mockOrdersController->expects("captureOrder")
+            ->with(["id" => "PAYPAL_ORDER_123"])
+            ->andReturn($mockApiResponse);
+
+        $mockPaypalClient = Mockery::mock(PaypalServerSdkClient::class);
+        $mockPaypalClient->allows("getOrdersController")->andReturn($mockOrdersController);
+
+        $controller = Mockery::mock(PaymentController::class)->makePartial()->shouldAllowMockingProtectedMethods();
+        $controller->shouldAllowMockingProtectedMethods();
+        $controller->expects("_createPayPalClient")->andReturn($mockPaypalClient);
+
+        $mailer = Mockery::mock(Mailer::class);
+        $mailer->expects("send")->once();
+        $currentSite = Mockery::mock(CurrentSite::class);
+        $urlGenerator = Mockery::mock(UrlGenerator::class);
+        $urlGenerator->expects("generate");
+        $templateService = Helpers::getTemplateService();
+        $loggerService = Mockery::mock(LoggerService::class);
+        $loggerService->shouldReceive("log");
+
+        // when
+        $controller->paypalCaptureAction(
+            config: $config,
+            paymentService: $paymentService,
+            request: $request,
+            logger: $loggerService,
+            mailer: $mailer,
+            currentSite: $currentSite,
+            urlGenerator: $urlGenerator,
+            templateService: $templateService,
+            slug: $order->getSlug(),
+        );
+
+        // then
+        $order->reload();
+        $payment = PaymentQuery::create()->findOneByOrderId($order->getId());
+        $this->assertEquals(1999, $payment->getAmount(), "payment amount should be 1999 cents, not 1998");
+        $this->assertTrue($order->isPaid(), "the order should have been marked as fully paid");
+    }
 }

--- a/tests/AppBundle/Controller/OrderControllerTest.php
+++ b/tests/AppBundle/Controller/OrderControllerTest.php
@@ -402,6 +402,126 @@ class OrderControllerTest extends TestCase
         $this->assertStringContainsString("Port", $content, "La ligne de port doit être affichée quand des frais existent (500 c)");
     }
 
+    public function testInvoiceActionShowsArticleCountAndTotalWeight(): void
+    {
+        // given
+        $controller = new OrderController();
+        $request = new Request();
+        $shippingOption = ModelFactory::createShippingOption(type: "normal");
+        $order = ModelFactory::createOrder(
+            shippingOption: $shippingOption,
+            slug: "invoice-summary1",
+            amount: 3000,
+            shippingCost: 500,
+        );
+        $article = ModelFactory::createArticle(title: "Le Livre Test");
+        ModelFactory::createStockItem(article: $article, order: $order, sellingPrice: 2000, weight: 300);
+        ModelFactory::createStockItem(article: $article, order: $order, sellingPrice: 1000, weight: 150);
+
+        $currentUser = Mockery::mock(CurrentUser::class);
+        $currentUser->shouldReceive("isAuthenticated")->andReturn(false);
+        $currentUser->shouldReceive("isAdmin")->andReturn(false);
+        $currentSite = $this->_mockCurrentSiteForInvoice();
+        $templateService = Helpers::getTemplateService();
+
+        // when
+        $response = $controller->invoiceAction($request, $currentUser, $currentSite, $templateService, "invoice-summary1");
+        $content = $response->getContent();
+
+        // then
+        $this->assertStringContainsString("2 articles", $content);
+        $this->assertStringContainsString(
+            "normal · 0,45 kg",
+            $content,
+            "La ligne de port doit afficher le mode d'expédition et le poids total (300 g + 150 g) en kilogrammes, séparés par un point médian"
+        );
+    }
+
+    public function testInvoiceActionShowsArticleCountInSingular(): void
+    {
+        // given
+        $controller = new OrderController();
+        $request = new Request();
+        $order = ModelFactory::createOrder(slug: "invoice-summary2", amount: 2000, shippingCost: 500);
+        $article = ModelFactory::createArticle(title: "Le Livre Test");
+        ModelFactory::createStockItem(article: $article, order: $order, sellingPrice: 2000, weight: 300);
+
+        $currentUser = Mockery::mock(CurrentUser::class);
+        $currentUser->shouldReceive("isAuthenticated")->andReturn(false);
+        $currentUser->shouldReceive("isAdmin")->andReturn(false);
+        $currentSite = $this->_mockCurrentSiteForInvoice();
+        $templateService = Helpers::getTemplateService();
+
+        // when
+        $response = $controller->invoiceAction($request, $currentUser, $currentSite, $templateService, "invoice-summary2");
+        $content = $response->getContent();
+
+        // then
+        $this->assertStringContainsString("1 article", $content);
+        $this->assertStringNotContainsString("1 articles", $content);
+    }
+
+    public function testInvoiceActionHidesWeightWhenUnknown(): void
+    {
+        // given
+        $controller = new OrderController();
+        $request = new Request();
+        $order = ModelFactory::createOrder(slug: "invoice-summary3", amount: 2000, shippingCost: 500);
+        $article = ModelFactory::createArticle(title: "Le Livre Test");
+        ModelFactory::createStockItem(article: $article, order: $order, sellingPrice: 2000);
+
+        $currentUser = Mockery::mock(CurrentUser::class);
+        $currentUser->shouldReceive("isAuthenticated")->andReturn(false);
+        $currentUser->shouldReceive("isAdmin")->andReturn(false);
+        $currentSite = $this->_mockCurrentSiteForInvoice();
+        $templateService = Helpers::getTemplateService();
+
+        // when
+        $response = $controller->invoiceAction($request, $currentUser, $currentSite, $templateService, "invoice-summary3");
+        $content = $response->getContent();
+
+        // then
+        $this->assertStringContainsString("1 article", $content);
+        $this->assertDoesNotMatchRegularExpression(
+            '/[\d,]+ kg\b/',
+            $content,
+            "Aucun poids ne doit être affiché quand il est inconnu"
+        );
+    }
+
+    /**
+     * Le poids est affiché sur la ligne de port, qui n'existe que si des frais
+     * de port sont facturés. Une commande au port offert n'affiche donc aucun
+     * poids, même quand celui-ci est connu.
+     */
+    public function testInvoiceActionHidesWeightWhenShippingIsFree(): void
+    {
+        // given
+        $controller = new OrderController();
+        $request = new Request();
+        $order = ModelFactory::createOrder(slug: "invoice-summary4", amount: 2000, shippingCost: 0);
+        $article = ModelFactory::createArticle(title: "Le Livre Test");
+        ModelFactory::createStockItem(article: $article, order: $order, sellingPrice: 2000, weight: 300);
+
+        $currentUser = Mockery::mock(CurrentUser::class);
+        $currentUser->shouldReceive("isAuthenticated")->andReturn(false);
+        $currentUser->shouldReceive("isAdmin")->andReturn(false);
+        $currentSite = $this->_mockCurrentSiteForInvoice();
+        $templateService = Helpers::getTemplateService();
+
+        // when
+        $response = $controller->invoiceAction($request, $currentUser, $currentSite, $templateService, "invoice-summary4");
+        $content = $response->getContent();
+
+        // then
+        $this->assertStringContainsString("1 article", $content, "Le nombre d'articles reste affiché dans l'en-tête du tableau");
+        $this->assertDoesNotMatchRegularExpression(
+            '/[\d,]+ kg\b/',
+            $content,
+            "Sans ligne de port, aucun poids n'est affiché même s'il est connu"
+        );
+    }
+
     public function testInvoiceActionHidesShippingLineWhenFree(): void
     {
         // given


### PR DESCRIPTION
## Corrections

- Corrigé un arrondi flottant lors de la capture d'un paiement PayPal qui
  pouvait laisser un centime "restant à payer" sur des commandes pourtant
  payées intégralement.