### PR TITLE
Fixer le montant de la commande générée par les seeds

### DIFF
--- a/src/Command/CreateSeedsCommand.php
+++ b/src/Command/CreateSeedsCommand.php
@@ -129,7 +129,8 @@ class CreateSeedsCommand extends Command
 
         // Order
         $order = ModelFactory::createOrder(
-            
+            amount: 999,
+            amountToBePaid: 999,
         );
 
         // Stock Item


### PR DESCRIPTION
## Résumé
- La commande créée par `CreateSeedsCommand` (`composer db:seed`) avait un montant à payer de 0 €
- Ce montant nul déclenche l'avertissement "montant inférieur à 0,50 €" sur la page de paiement et masque les boutons de paiement, ce qui gêne les tests manuels du flux de paiement
- Le montant est désormais aligné sur le prix de l'article seedé (9,99 €)

## Test plan
- [x] `php -l src/Command/CreateSeedsCommand.php`
- [ ] Relancer `composer db:seed` (ou `composer db:prepare`) en local et vérifier que la commande générée a bien un montant à payer non nul