### PR TITLE
Caisse : réécrire la ligne de panier en Propel/Twig

### DIFF
--- a/inc/Cart.class.php
+++ b/inc/Cart.class.php
@@ -20,10 +20,7 @@ use Biblys\Exception\CannotAddStockItemToCartException;
 use Biblys\Legacy\LegacyCodeHelper;
 use Biblys\Service\Config;
 use Biblys\Service\CurrentUser;
-use Biblys\Service\Images\ImagesService;
 use Entity\Exception\CartException;
-use Model\ArticleQuery;
-use Model\StockQuery;
 use Model\WishQuery;
 use Propel\Runtime\Exception\PropelException;
 use Symfony\Component\HttpFoundation\Request;
@@ -49,52 +46,6 @@ class Cart extends Entity
         if ($field == 'cart_title' && empty($value)) $value = 'Panier n&deg; ' . $this->get('id');
 
         parent::set($field, $value);
-    }
-
-    /**
-     * @throws PropelException
-     * @throws Exception
-     * @throws Exception
-     */
-    public function getLine(ImagesService $imagesService, Stock $stockEntity): string
-    {
-        
-        $stock = StockQuery::create()->findPk($stockEntity->get('id'));
-
-        /** @var Article $articleEntity */
-        $articleEntity = $stockEntity->get('article');
-        $articleModel = ArticleQuery::create()->findPk($articleEntity->get("id"));
-
-        // Image
-        $articleCoverUrl = $imagesService->getImageUrlFor($articleModel, height: 100);
-        $stockItemPhotoUrl = $imagesService->getImageUrlFor($stock, height: 100);
-
-        if ($articleCoverUrl) $cover = '<img src="' . $articleCoverUrl . '" height=55 alt="' . $articleEntity->get('title') . '">';
-        elseif ($stockItemPhotoUrl) $cover = '<img src="' . $stockItemPhotoUrl . '" height=55 alt="' . $articleEntity->get('title') . '">';
-        else $cover = NULL;
-
-        $articleUrl = \Biblys\Legacy\LegacyCodeHelper::getGlobalUrlGenerator()->generate("article_show", ["slug" => $articleEntity->get("url")]);
-
-        return '
-                <tr id="stock_' . $stockEntity->get('id') . '">
-                    <td class="va-middle right"><a href="/pages/adm_stock?id=' . $stockEntity->get('id') . '">' . $stockEntity->get('id') . '</a></td>
-                    <td class="va-middle center">' . $cover . '</td>
-                    <td class="va-middle">
-                        <a href="' . $articleUrl . '">' . $articleEntity->get('title') . '</a><br>
-                        de ' . authors($articleEntity->get('authors')) . '<br>
-                        Ed. ' . $articleEntity->get('publisher')->get('name') . '
-                    </td>
-                    <td class="va-middle right stock_selling_price" data-price="' . (int) $stockEntity->get('selling_price') . '">
-                        ' . $stockEntity->get('condition') . '
-                        ' . currency($stockEntity->get('selling_price') / 100) . '
-                    </td>
-                    <td class="center va-middle">
-                        <button title="Retirer du panier" data-remove_from_cart="' . $stockEntity->get('id') . '" class="btn btn-warning btn-sm event">
-                            <i class="fa fa-close"></i>
-                        </button>
-                    </td>
-                </tr>
-            ';
     }
 
     /**

--- a/src/AppBundle/Controller/PointOfSaleController.php
+++ b/src/AppBundle/Controller/PointOfSaleController.php
@@ -33,6 +33,7 @@ use Framework\Controller;
 use Model\Cart;
 use Model\CartQuery;
 use Model\CustomerQuery;
+use Model\StockQuery;
 use Model\UserQuery;
 use Propel\Runtime\ActiveQuery\Criteria;
 use Propel\Runtime\Exception\PropelException;
@@ -64,7 +65,6 @@ class PointOfSaleController extends Controller
         Request              $request,
         CurrentUser          $currentUser,
         CurrentSite          $currentSite,
-        ImagesService        $imagesService,
         TemplateService      $templateService,
         UrlGenerator         $urlGenerator,
         QueryParamsService   $queryParams,
@@ -115,13 +115,11 @@ class PointOfSaleController extends Controller
             $customer = CustomerQuery::create()->findPk($customerId);
         }
 
-        $cartContent = '';
-        $cartCount = 0;
+        $cartStockItems = StockQuery::create()->filterByCartId($cartId)->find();
+        $cartStockItemCount = count($cartStockItems);
         $cartTotal = 0;
-        foreach ($cm->getStock($cart) as $stockEntity) {
-            $cartContent .= $cart->getLine($imagesService, $stockEntity);
-            $cartCount++;
-            $cartTotal += $stockEntity->get('selling_price');
+        foreach ($cartStockItems as $stockItem) {
+            $cartTotal += $stockItem->getSellingPrice() ?? 0;
         }
         $cm->updateFromStock($cart);
 
@@ -153,8 +151,8 @@ class PointOfSaleController extends Controller
         return $templateService->renderResponse("AppBundle:PointOfSale:index.html.twig", [
             'is_tva_enabled' => $isTvaEnabled,
             'cart' => $cart,
-            'cart_content' => $cartContent,
-            'cart_count' => $cartCount,
+            'cart_stock_items' => $cartStockItems,
+            'cart_count' => $cartStockItemCount,
             'cart_total' => $cartTotal,
             'seller' => $seller,
             'customer' => $customer,

--- a/src/AppBundle/Controller/PointOfSaleController.php
+++ b/src/AppBundle/Controller/PointOfSaleController.php
@@ -25,7 +25,6 @@ use Biblys\Service\BodyParamsService;
 use Biblys\Service\CurrentSite;
 use Biblys\Service\CurrentUser;
 use Biblys\Service\FlashMessagesService;
-use Biblys\Service\Images\ImagesService;
 use Biblys\Service\QueryParamsService;
 use Biblys\Service\TemplateService;
 use CartManager;
@@ -166,16 +165,14 @@ class PointOfSaleController extends Controller
     public function addItemAction(
         Request           $request,
         CurrentUser       $currentUser,
-        ImagesService     $imagesService,
+        TemplateService   $templateService,
         BodyParamsService $bodyParams,
         int               $cartId,
     ): Response
     {
         $currentUser->authAdmin();
 
-        $cm = new CartManager();
-        $cart = $cm->getById($cartId);
-        if (!$cart) {
+        if (!CartQuery::create()->filterById($cartId)->exists()) {
             throw new NotFoundHttpException("Panier $cartId introuvable");
         }
 
@@ -190,12 +187,14 @@ class PointOfSaleController extends Controller
         }
 
         if (in_array("application/json", $request->getAcceptableContentTypes())) {
-            $line = "";
-            foreach ($cm->getStock($cart) as $stockItem) {
-                if ($stockItem->get("id") == $stockItemId) {
-                    $line = $cart->getLine($imagesService, $stockItem);
-                }
-            }
+            $stockItem = StockQuery::create()
+                ->filterByCartId($cartId)
+                ->filterById($stockItemId)
+                ->findOne();
+            $line = $stockItem
+                ? $templateService->render("AppBundle:PointOfSale:_cart_line.html.twig", ["stockItem" => $stockItem])
+                : "";
+
             return new JsonResponse([
                 "success" => "L'exemplaire n° $stockItemId a été ajouté au panier.",
                 "line" => $line,

--- a/src/AppBundle/Resources/views/PointOfSale/_cart_line.html.twig
+++ b/src/AppBundle/Resources/views/PointOfSale/_cart_line.html.twig
@@ -1,0 +1,45 @@
+{#
+Copyright (C) 2026 Clément Latzarus
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, version 3.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#}
+
+{% set articleCoverUrl = stockItem.article|imageUrl(null, 100) %}
+{% set stockItemPhotoUrl = stockItem|imageUrl(null, 100) %}
+
+<tr id="stock_{{ stockItem.id }}">
+  <td class="va-middle right">
+    <a href="/pages/adm_stock?id={{ stockItem.id }}">{{ stockItem.id }}</a>
+  </td>
+  <td class="va-middle center">
+    {% if articleCoverUrl %}
+      <img src="{{ articleCoverUrl }}" height="55" alt="{{ stockItem.article.title }}">
+    {% elseif stockItemPhotoUrl %}
+      <img src="{{ stockItemPhotoUrl }}" height="55" alt="{{ stockItem.article.title }}">
+    {% endif %}
+  </td>
+  <td class="va-middle">
+    <a href="{{ path('article_show', { slug: stockItem.article.url }) }}">{{ stockItem.article.title }}</a><br>
+    de {{ stockItem.article.authors|default('')|authors }}<br>
+    Ed. {{ stockItem.article.publisher.name }}
+  </td>
+  <td class="va-middle right stock_selling_price" data-price="{{ stockItem.sellingPrice ?? 0 }}">
+    {{ stockItem.condition }}
+    {{ (stockItem.sellingPrice ?? 0)|currency(true)|raw }}
+  </td>
+  <td class="center va-middle">
+    <button title="Retirer du panier" data-remove_from_cart="{{ stockItem.id }}" class="btn btn-warning btn-sm event">
+      <i class="fa fa-close"></i>
+    </button>
+  </td>
+</tr>

--- a/src/AppBundle/Resources/views/PointOfSale/index.html.twig
+++ b/src/AppBundle/Resources/views/PointOfSale/index.html.twig
@@ -158,7 +158,9 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
           </tr>
         </thead>
         <tbody>
-          {{ cart_content|raw }}
+          {% for stockItem in cart_stock_items %}
+            {% include 'AppBundle:PointOfSale:_cart_line.html.twig' %}
+          {% endfor %}
         </tbody>
       </table>
 

--- a/src/Command/CreateSeedsCommand.php
+++ b/src/Command/CreateSeedsCommand.php
@@ -20,6 +20,7 @@ namespace Command;
 
 use Biblys\Database\Connection;
 use Biblys\Service\Config;
+use Biblys\Service\Slug\SlugService;
 use Biblys\Test\ModelFactory;
 use Model\Publisher;
 use Model\Right;
@@ -35,6 +36,17 @@ use Symfony\Component\Console\Output\OutputInterface;
 class CreateSeedsCommand extends Command
 {
     protected static $defaultName = 'db:seed';
+
+    public const CATALOG_ARTICLES = [
+        ["title" => "Chaussons d'ours", "firstName" => "Laetitia", "lastName" => "Mani", "ean" => "9781000000016", "price" => 1200],
+        ["title" => "Sous-sol", "firstName" => "Matt", "lastName" => "Yassenar", "ean" => "9781000000023", "price" => 1550],
+        ["title" => "Papeete", "firstName" => "Lili", "lastName" => "Calvaire", "ean" => "9781000000030", "price" => 900],
+        ["title" => "Au-revoir Mao", "firstName" => "Perle", "lastName" => "Maître", "ean" => "9781000000047", "price" => 1800],
+        ["title" => "Le Serpent sur la butte aux pommes", "firstName" => "Gérard", "lastName" => "Ferrori", "ean" => "9781000000054", "price" => 2200],
+        ["title" => "Le lard français pendant la guerre", "firstName" => "Alexei", "lastName" => "Gémit", "ean" => "9781000000061", "price" => 1450],
+        ["title" => "La Tarte et le terroir", "firstName" => "Michelou", "lastName" => "Elbecq", "ean" => "9781000000078", "price" => 1990],
+        ["title" => "Troie, dame bruissante", "firstName" => "Mariette", "lastName" => "D'Ail", "ean" => "9781000000085", "price" => 1650],
+    ];
 
     protected function configure(): void
     {
@@ -130,6 +142,35 @@ class CreateSeedsCommand extends Command
             sellingPrice: 999,
         );
         $output->writeln(["Inserted stock item for L'Ordure du jeu"]);
+
+        // Catalog articles, each with its author and one new stock item
+        $slugService = new SlugService();
+        foreach (self::CATALOG_ARTICLES as $catalogArticle) {
+            $author = ModelFactory::createContributor(
+                firstName: $catalogArticle["firstName"],
+                lastName: $catalogArticle["lastName"],
+            );
+
+            $authorSlug = $slugService->slugify($author->getFullName());
+            $titleSlug = $slugService->slugify($catalogArticle["title"]);
+
+            $catalogArticleModel = ModelFactory::createArticle(
+                title: $catalogArticle["title"],
+                authors: [$author],
+                ean: $catalogArticle["ean"],
+                url: "$authorSlug/$titleSlug",
+                price: $catalogArticle["price"],
+                publisher: $publisher,
+                collection: $collection,
+            );
+
+            ModelFactory::createStockItem(
+                article: $catalogArticleModel,
+                sellingPrice: $catalogArticle["price"],
+            );
+
+            $output->writeln(["Inserted article with stock item: {$catalogArticle["title"]}"]);
+        }
 
         // Order
         $order = ModelFactory::createOrder(

--- a/tests/AppBundle/Controller/PointOfSaleControllerTest.php
+++ b/tests/AppBundle/Controller/PointOfSaleControllerTest.php
@@ -22,7 +22,6 @@ use Biblys\Service\BodyParamsService;
 use Biblys\Service\CurrentSite;
 use Biblys\Service\CurrentUser;
 use Biblys\Service\FlashMessagesService;
-use Biblys\Service\Images\ImagesService;
 use Biblys\Service\QueryParamsService;
 use Biblys\Test\EntityFactory;
 use Biblys\Test\Helpers;
@@ -220,14 +219,11 @@ class PointOfSaleControllerTest extends TestCase
         $currentUser = Mockery::mock(CurrentUser::class);
         $currentUser->expects("authAdmin");
 
-        $imagesService = Mockery::mock(ImagesService::class);
-        $imagesService->shouldReceive("getImageUrlFor")->andReturn(null);
-
         // when
         $response = $controller->addItemAction(
             $request,
             $currentUser,
-            $imagesService,
+            Helpers::getTemplateService(),
             new BodyParamsService($request),
             $cart->getId(),
         );
@@ -239,6 +235,48 @@ class PointOfSaleControllerTest extends TestCase
         $this->assertStringContainsString("stock_" . $stock->getId(), $data['line']);
         $stock->reload();
         $this->assertEquals($cart->getId(), $stock->getCartId());
+    }
+
+    /**
+     * Un exemplaire sans prix de vente doit rendre data-price="0" et non un
+     * attribut vide : le JS de la caisse applique parseInt sur cet attribut
+     * pour calculer le total du panier, et un attribut vide produirait NaN.
+     *
+     * @throws PropelException
+     */
+    public function testAddItemActionReturnsLineWithZeroDataPriceForFreeStockItem(): void
+    {
+        // given
+        $controller = $this->_getController();
+        $cart = ModelFactory::createCart();
+        $cart->setType("shop");
+        $cart->save();
+        $stock = ModelFactory::createStockItem();
+        $stock->setSellingPrice(null);
+        $stock->save();
+
+        $request = new Request(request: ['stock_id' => $stock->getId()]);
+        $request->headers->set('Accept', 'application/json');
+
+        $currentUser = Mockery::mock(CurrentUser::class);
+        $currentUser->expects("authAdmin");
+
+        // when
+        $response = $controller->addItemAction(
+            $request,
+            $currentUser,
+            Helpers::getTemplateService(),
+            new BodyParamsService($request),
+            $cart->getId(),
+        );
+
+        // then
+        $data = json_decode($response->getContent(), true);
+        $this->assertStringContainsString(
+            'data-price="0"',
+            $data['line'],
+            "Un exemplaire gratuit doit avoir data-price=\"0\" et non un attribut vide, sinon le total calculé côté JS devient NaN"
+        );
     }
 
     /**
@@ -262,7 +300,7 @@ class PointOfSaleControllerTest extends TestCase
         $response = $controller->addItemAction(
             $request,
             $currentUser,
-            Mockery::mock(ImagesService::class),
+            Helpers::getTemplateService(),
             new BodyParamsService($request),
             $cart->getId(),
         );
@@ -295,7 +333,7 @@ class PointOfSaleControllerTest extends TestCase
         $controller->addItemAction(
             $request,
             $currentUser,
-            Mockery::mock(ImagesService::class),
+            Helpers::getTemplateService(),
             new BodyParamsService($request),
             99999,
         );
@@ -328,7 +366,7 @@ class PointOfSaleControllerTest extends TestCase
         $controller->addItemAction(
             $request,
             $currentUser,
-            Mockery::mock(ImagesService::class),
+            Helpers::getTemplateService(),
             new BodyParamsService($request),
             $secondCart->getId(),
         );

--- a/tests/AppBundle/Controller/PointOfSaleControllerTest.php
+++ b/tests/AppBundle/Controller/PointOfSaleControllerTest.php
@@ -73,7 +73,6 @@ class PointOfSaleControllerTest extends TestCase
             $request,
             $currentUser,
             $this->_getCurrentSiteMock(tva: "fr"),
-            Mockery::mock(ImagesService::class),
             Helpers::getTemplateService(),
             Mockery::mock(UrlGenerator::class),
             new QueryParamsService($request),
@@ -105,7 +104,6 @@ class PointOfSaleControllerTest extends TestCase
             $request,
             $currentUser,
             $this->_getCurrentSiteMock(),
-            Mockery::mock(ImagesService::class),
             Helpers::getTemplateService(),
             Mockery::mock(UrlGenerator::class),
             new QueryParamsService($request),
@@ -134,7 +132,6 @@ class PointOfSaleControllerTest extends TestCase
             $request,
             $currentUser,
             $this->_getCurrentSiteMock(),
-            Mockery::mock(ImagesService::class),
             Helpers::getTemplateService(),
             Mockery::mock(UrlGenerator::class),
             new QueryParamsService($request),
@@ -143,6 +140,40 @@ class PointOfSaleControllerTest extends TestCase
         // then
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertStringContainsString("Caisse", $response->getContent());
+    }
+
+    /**
+     * @throws PropelException
+     */
+    public function testIndexActionRendersCartLineForStockItemInCart(): void
+    {
+        // given
+        $controller = $this->_getController();
+        $cart = EntityFactory::createCart();
+        $article = ModelFactory::createArticle(title: "Le Horla", url: "maupassant/le-horla");
+        $stockItem = ModelFactory::createStockItem(article: $article, sellingPrice: 1899);
+        $stockItem->setCartId($cart->get("id"));
+        $stockItem->save();
+        $request = new Request(query: ['cart_id' => $cart->get('id')]);
+
+        $currentUser = Mockery::mock(CurrentUser::class);
+        $currentUser->expects("authAdmin");
+
+        // when
+        $response = $controller->indexAction(
+            $request,
+            $currentUser,
+            $this->_getCurrentSiteMock(),
+            Helpers::getTemplateService(),
+            Mockery::mock(UrlGenerator::class),
+            new QueryParamsService($request),
+        );
+
+        // then
+        $content = $response->getContent();
+        $this->assertStringContainsString("stock_{$stockItem->getId()}", $content);
+        $this->assertStringContainsString("Le Horla", $content);
+        $this->assertStringContainsString('data-price="1899"', $content);
     }
 
     /**
@@ -165,7 +196,6 @@ class PointOfSaleControllerTest extends TestCase
             $request,
             $currentUser,
             $this->_getCurrentSiteMock(),
-            Mockery::mock(ImagesService::class),
             Helpers::getTemplateService(),
             Mockery::mock(UrlGenerator::class),
             new QueryParamsService($request),

--- a/tests/CartTest.php
+++ b/tests/CartTest.php
@@ -23,7 +23,6 @@
 
 use Biblys\Exception\CannotAddStockItemToCartException;
 use Biblys\Legacy\LegacyCodeHelper;
-use Biblys\Service\Images\ImagesService;
 use Biblys\Test\EntityFactory;
 use Biblys\Test\ModelFactory;
 use Model\WishQuery;
@@ -237,44 +236,6 @@ class CartTest extends PHPUnit\Framework\TestCase
 
         // when
         $cm->addStock($targetCart, $stockItem);
-    }
-
-    /**
-     * Test that getLine renders a numeric data-price attribute for items
-     * that have no selling price set (e.g. free copies), so that the
-     * front-end JS total (which uses parseInt on data-price) doesn't turn
-     * into NaN.
-     * @throws Exception
-     */
-    public function testGetLineDataPriceIsZeroForFreeStockItem()
-    {
-        // given
-        $cm = new CartManager();
-        $sm = new StockManager();
-        $cart = $cm->create(['cart_type' => 'shop']);
-
-        $article = EntityFactory::createArticle(['article_url' => 'free-item-test']);
-        $stock = EntityFactory::createStock(['article_id' => $article->get('id')]);
-        $stock->set('stock_selling_price', null);
-        $sm->update($stock);
-        $stock = $sm->reload($stock);
-
-        $this->carts = [$cart];
-        $this->stocks = [$stock];
-        $this->article = $article;
-
-        $imagesService = Mockery::mock(ImagesService::class);
-        $imagesService->shouldReceive('getImageUrlFor')->andReturn(null);
-
-        // when
-        $line = $cart->getLine($imagesService, $stock);
-
-        // then
-        $this->assertStringContainsString(
-            'data-price="0"',
-            $line,
-            "Free items should have a data-price of 0, not empty, to avoid NaN in the front-end JS total computation"
-        );
     }
 
     /**

--- a/tests/Command/CreateSeedsCommandTest.php
+++ b/tests/Command/CreateSeedsCommandTest.php
@@ -18,6 +18,7 @@
 
 namespace Command;
 
+use Biblys\Service\Slug\SlugService;
 use Model\ArticleQuery;
 use Model\BookCollectionQuery;
 use Model\CustomerQuery;
@@ -52,13 +53,25 @@ class CreateSeedsCommandTest extends TestCase
         OrderQuery::create()->deleteAll();
         CustomerQuery::create()->deleteAll();
 
-        $seededArticle = ArticleQuery::create()->findOneByTitle(self::SEEDED_ARTICLE_TITLE);
-        if ($seededArticle !== null) {
-            RoleQuery::create()->filterByArticle($seededArticle)->delete();
-            $seededArticle->delete();
+        $seededTitles = array_merge(
+            [self::SEEDED_ARTICLE_TITLE],
+            array_column(CreateSeedsCommand::CATALOG_ARTICLES, "title"),
+        );
+        foreach ($seededTitles as $seededTitle) {
+            $seededArticle = ArticleQuery::create()->findOneByTitle($seededTitle);
+            if ($seededArticle !== null) {
+                RoleQuery::create()->filterByArticle($seededArticle)->delete();
+                $seededArticle->delete();
+            }
         }
 
         PeopleQuery::create()->filterByUrl("aymeric-buvard")->delete();
+        foreach (CreateSeedsCommand::CATALOG_ARTICLES as $catalogArticle) {
+            PeopleQuery::create()
+                ->filterByFirstName($catalogArticle["firstName"])
+                ->filterByLastName($catalogArticle["lastName"])
+                ->delete();
+        }
         BookCollectionQuery::create()->filterByName("Lis tes ratures")->delete();
         PublisherQuery::create()->filterByName("Les Éditions Paronymie")->delete();
     }
@@ -79,16 +92,73 @@ class CreateSeedsCommandTest extends TestCase
         $this->assertStringContainsString("Seeds generated!", $commandTester->getDisplay());
 
         $stockItems = StockQuery::create()->orderById()->find();
-        $this->assertCount(2, $stockItems);
+        $expectedCount = 2 + count(CreateSeedsCommand::CATALOG_ARTICLES);
+        $this->assertCount($expectedCount, $stockItems);
 
         $availableItem = $stockItems[0];
         $this->assertEquals(self::SEEDED_ARTICLE_TITLE, $availableItem->getArticle()->getTitle());
         $this->assertEquals(999, $availableItem->getSellingPrice());
         $this->assertNull($availableItem->getOrderId());
 
-        $orderedItem = $stockItems[1];
+        $orderedItem = $stockItems[$expectedCount - 1];
         $this->assertEquals(self::SEEDED_ARTICLE_TITLE, $orderedItem->getArticle()->getTitle());
         $this->assertEquals(999, $orderedItem->getSellingPrice());
         $this->assertEquals(OrderQuery::create()->findOne()->getId(), $orderedItem->getOrderId());
+    }
+
+    /**
+     * @throws PropelException
+     */
+    public function testExecuteSeedsCatalogArticlesWithAuthorAndNewStockItem(): void
+    {
+        // given
+        $commandTester = new CommandTester(new CreateSeedsCommand());
+
+        // when
+        $commandTester->execute([]);
+
+        // then
+        foreach (CreateSeedsCommand::CATALOG_ARTICLES as $catalogArticle) {
+            $article = ArticleQuery::create()->findOneByTitle($catalogArticle["title"]);
+            $this->assertNotNull($article, "Article {$catalogArticle["title"]} should have been seeded");
+            $this->assertEquals($catalogArticle["ean"], $article->getEan());
+            $this->assertEquals(
+                "{$catalogArticle["firstName"]} {$catalogArticle["lastName"]}",
+                $article->getAuthors()
+            );
+
+            $stockItems = StockQuery::create()->filterByArticle($article)->find();
+            $this->assertCount(1, $stockItems, "Article {$catalogArticle["title"]} should have one stock item");
+            $this->assertEquals("Neuf", $stockItems[0]->getCondition());
+            $this->assertEquals($catalogArticle["price"], $stockItems[0]->getSellingPrice());
+        }
+    }
+
+    /**
+     * @throws PropelException
+     */
+    public function testExecuteSeedsCatalogArticlesWithDistinctEansAndSlugs(): void
+    {
+        // given
+        $commandTester = new CommandTester(new CreateSeedsCommand());
+
+        // when
+        $commandTester->execute([]);
+
+        // then
+        $titles = array_column(CreateSeedsCommand::CATALOG_ARTICLES, "title");
+        $articles = ArticleQuery::create()->filterByTitle($titles)->find();
+
+        $eans = array_map(fn($article) => $article->getEan(), $articles->getData());
+        $this->assertCount(count($titles), array_unique($eans), "Seeded EANs must be distinct");
+
+        $urls = array_map(fn($article) => $article->getUrl(), $articles->getData());
+        $this->assertCount(count($titles), array_unique($urls), "Seeded article slugs must be distinct");
+
+        $slugService = new SlugService();
+        foreach ($urls as $url) {
+            $slugService->validateArticleSlug($url);
+        }
+        $this->addToAssertionCount(count($urls));
     }
 }


### PR DESCRIPTION
Ferme #621.

Suite de la migration des managers legacy vers Propel côté caisse (#614, #620).

## Ce que fait cette PR

- `CartManager::getStock($cart)` est remplacé par `StockQuery::create()->filterByCartId($cartId)` dans `indexAction` et `addItemAction`.
- La ligne de panier, jusqu'ici produite par concaténation de HTML en PHP dans `Cart::getLine()`, est rendue par un nouveau partiel `PointOfSale/_cart_line.html.twig` consommant des modèles Propel.
- `indexAction` passe la collection `cart_stock_items` au template, qui boucle avec `{% include %}` à la place de `{{ cart_content|raw }}`.
- `addItemAction` rend le même partiel via `TemplateService::render()` pour la clé `line` de la réponse JSON : la ligne insérée en AJAX et celle rendue au chargement proviennent désormais d'une source unique.
- Le contrôle d'existence du panier dans `addItemAction` passe à `CartQuery`, comme dans les autres actions du contrôleur. `addItemAction` n'utilise plus `CartManager`.
- `Cart::getLine()` est supprimée.

## Équivalence de comportement

`StockManager::getAll(['cart_id' => X])` produit un `SELECT * FROM stock WHERE cart_id = X` sans `ORDER BY` ni filtre implicite (pas de `site_id`, pas de soft-delete ; la table `stock` ne porte que le behavior `timestampable`). La requête Propel est strictement équivalente, ordre des lignes compris.

Deux différences assumées, toutes deux dans le sens de la correction :

- Les titres d'article et noms d'éditeur sont maintenant échappés par Twig. Auparavant concaténés bruts, un titre contenant un guillemet cassait l'attribut `alt`.
- Le filtre Twig `authors` est appelé via `|default('')` : contrairement à la fonction globale `authors()`, il ne garde pas contre `null` et déclencherait une dépréciation PHP 8.1 sur un article sans auteurs.

Le contrat avec le front est inchangé : la réponse JSON porte toujours une chaîne HTML sous la clé `line`, consommée par `biblys-admin.js:477`. Aucune modification du JavaScript.

## Hors périmètre

`CartManager::get()` et `CartManager::updateFromStock()` restent en place dans `indexAction`. `CartManager::getStock()` n'est pas supprimée : elle conserve quatre appelants (`Cart::getStock`, `CartManager::vacuum`, `CartManager::updateFromStock`, `ClearPointOfSaleCartUsecase`).

## Tests

- Nouveau : `testIndexActionRendersCartLineForStockItemInCart`. Le rendu du contenu du panier en `indexAction` n'était couvert par aucune assertion — on pouvait remplacer intégralement le rendu sans faire échouer un test.
- Migré : `CartTest::testGetLineDataPriceIsZeroForFreeStockItem` devient `PointOfSaleControllerTest::testAddItemActionReturnsLineWithZeroDataPriceForFreeStockItem`. Il protège la même garantie — `data-price="0"` sur un exemplaire sans prix, sinon le total calculé côté JS devient `NaN` — mais à travers le chemin de rendu réel.
- Adaptés : les mocks `ImagesService` disparaissent des tests des deux actions, `TemplateService` instanciant le sien pour les filtres `imageUrl` / `hasImage`.

Suite complète verte : 1284 tests, 2736 assertions.

## Vérification manuelle restante

Afficher un panier en caisse et contrôler image, titre, auteurs, éditeur et prix ; ajouter un exemplaire via la recherche pour confirmer que la ligne insérée en AJAX est identique à celle du chargement initial.
