### PR TITLE
Seeds : port et poids sur la commande d'exemple

### DIFF
--- a/src/Command/CreateSeedsCommand.php
+++ b/src/Command/CreateSeedsCommand.php
@@ -172,17 +172,20 @@ class CreateSeedsCommand extends Command
             $output->writeln(["Inserted article with stock item: {$catalogArticle["title"]}"]);
         }
 
-        // Order
+        // Order, shipped with the seeded shipping option so the invoice shows a shipping line
         $order = ModelFactory::createOrder(
+            shippingOption: $shippingFee,
             amount: 999,
-            amountToBePaid: 999,
+            amountToBePaid: 1299,
+            shippingCost: 300,
         );
 
-        // Stock Item
+        // Stock Item, weighed so the invoice shows a total weight
         $orderedStockItem = ModelFactory::createStockItem(
             article: $article,
             order: $order,
             sellingPrice: 999,
+            weight: 450,
         );
 
         // Compute and persist VAT on the sold stock item, mirroring what happens on a real sale

--- a/tests/Command/CreateSeedsCommandTest.php
+++ b/tests/Command/CreateSeedsCommandTest.php
@@ -107,6 +107,29 @@ class CreateSeedsCommandTest extends TestCase
     }
 
     /**
+     * The seeded order carries a shipping cost and a weighed stock item so that
+     * the invoice page shows both a shipping line and a total weight.
+     *
+     * @throws PropelException
+     */
+    public function testExecuteSeedsAnOrderWithShippingCostAndWeight(): void
+    {
+        // given
+        $commandTester = new CommandTester(new CreateSeedsCommand());
+
+        // when
+        $commandTester->execute([]);
+
+        // then
+        $order = OrderQuery::create()->findOne();
+        $this->assertEquals(300, $order->getShippingCost());
+        $this->assertNotNull($order->getShippingMode(), "Le mode d'expédition doit être renseigné pour la ligne de port");
+
+        $orderedItem = StockQuery::create()->filterByOrderId($order->getId())->findOne();
+        $this->assertEquals(450, $orderedItem->getWeight());
+    }
+
+    /**
      * @throws PropelException
      */
     public function testExecuteSeedsCatalogArticlesWithAuthorAndNewStockItem(): void


### PR DESCRIPTION
Met à jour `db:seed` pour que la commande seedée porte des frais de port et un exemplaire pesé, afin que la page de facture affiche une ligne de port et un poids total.

- La commande est rattachée au `ShippingOption` déjà créé par les seeds (300 c, type `normal`) plutôt qu'à un port inventé : la ligne « Port » de la facture affiche ainsi un mode d'expédition cohérent.
- `amountToBePaid` passe à 1299 pour rester égal au montant des articles plus le port.
- L'exemplaire vendu pèse 450 g.

Test ajouté : `testExecuteSeedsAnOrderWithShippingCostAndWeight` vérifie le montant du port, la présence du mode d'expédition et le poids de l'exemplaire.

Complète le correctif d'affichage de la facture (#622), qui a besoin de ces données pour être vérifié à la main.
