### PR TITLE
Facture : allègement de l'affichage de la TVA et de l'état des articles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@
   Apple Pay lorsque ce moyen de paiement est activé sur le compte PayPlug.
 - La lisibilité de la page "Mon compte" a été améliorée.
 
+### Améliorations des factures
+
+- Le SIREN apparaît désormais dans l'en-tête de la facture. Il peut être défini
+  via l'option de site siren.
+- La date de la commande est désormais affichée sous le numéro de facture.
+- La colonne "État" est désormais masquée si tous les articles d'une commande
+  sont tous "neuf", en dérivant l'affichage des données réelles de la commande.
+- La colonne "TVA" (montant) du détail par article est désormais masquée.
+- Le tableau de répartition TVA et le bloc "Total TTC" ont été remplacés par une
+  liste unifiée en bas de facture (Sous-total HT, TVA par taux, Total TTC).
+
 ## 3.15.0 (12 août 2026)
 
 ### Conformité NF525
@@ -24,7 +35,8 @@
 ### Améliorations
 
 - La page de facture d'une commande a été refondue : elle s'affiche désormais
-  dans une présentation épurée dédiée à l'impression (sans le menu ni l'habillage
+  dans une présentation épurée dédiée à l'impression (sans le menu ni
+  l'habillage
   du site), plus lisible, avec un bouton de retour.
 - La facture affiche désormais le détail de la TVA : taux, prix HT et TVA pour
   chaque article, ainsi qu'un tableau de synthèse ventilant base HT, montant de
@@ -58,7 +70,8 @@
 ### Corrections
 
 - La page d'édition d'un article provoquait une erreur fatale lorsque le type
-  de l'article était introuvable (`type_id` invalide ou orphelin). C'est corrigé.
+  de l'article était introuvable (`type_id` invalide ou orphelin). C'est
+  corrigé.
 - Dans la caisse, choisir "=> Créer un nouveau client" dans les résultats de
   recherche du champ Client ouvrait une popup vide. Ce lien ouvre désormais
   la page de création d'un nouveau client dans un nouvel onglet.
@@ -86,8 +99,10 @@
 - Les pages de liste (collections, éditeurs, etc.) renvoyaient une erreur
   lorsqu'un paramètre de tri vide était présent dans l'URL (généralement via
   des robots). C'est corrigé.
-- La TVA n'était plus calculée lors de l'enregistrement d'une commande. C'est corrigé,
-  et la commande `orders:recalculate-tax` permet de recalculer la TVA des commandes
+- La TVA n'était plus calculée lors de l'enregistrement d'une commande. C'est
+  corrigé,
+  et la commande `orders:recalculate-tax` permet de recalculer la TVA des
+  commandes
   passées concernées.
 
 ### Sécurité
@@ -101,38 +116,51 @@
 ### Confirmité NF525
 
 - Les paiements effectués lors d'une vente en caisse sont désormais enregistrés.
-- Il est désormais possible de marquer un paiement comme remboursé depuis la page
-  de gestion des paiements. Un paiement négatif est créé en base pour la commande,
+- Il est désormais possible de marquer un paiement comme remboursé depuis la
+  page
+  de gestion des paiements. Un paiement négatif est créé en base pour la
+  commande,
   lié au paiement d'origine.
 - Une commande est automatiquement marquée comme non payée si la somme de ses
-  paiements exécutés devient inférieure à son total (ex. : après un remboursement).
-- L'annulation d'une commande est désormais bloquée si des paiements non remboursés
+  paiements exécutés devient inférieure à son total (ex. : après un
+  remboursement).
+- L'annulation d'une commande est désormais bloquée si des paiements non
+  remboursés
   existent pour cette commande. Un message indique le montant payé et invite à
   effectuer un remboursement préalable.
 
 ### Amélorations
 
-- Lors de la connexion avec Axys, si le compte utilisateur existe déjà sur le site,
-  le compte Axys sera lié au compte utilisateur existant. Sinon, un nouveau compte
+- Lors de la connexion avec Axys, si le compte utilisateur existe déjà sur le
+  site,
+  le compte Axys sera lié au compte utilisateur existant. Sinon, un nouveau
+  compte
   sera créé.
 
 ### Corrections
 
-- Lors du paiement par chèque d'une commande à retirer en magasin, le bloc chèque
-  affiche désormais un message indiquant que le chèque sera remis au retrait, au lieu
-  de rester sans indication (l'adresse d'expédition n'est plus attendue dans ce cas).
+- Lors du paiement par chèque d'une commande à retirer en magasin, le bloc
+  chèque
+  affiche désormais un message indiquant que le chèque sera remis au retrait, au
+  lieu
+  de rester sans indication (l'adresse d'expédition n'est plus attendue dans ce
+  cas).
 
 ### Maintenance
 
-- Plusieurs classes Entity legacy sans usage ont été supprimées (`Price`, `Redirection`,
-  `Signing`, `Subscription`, `Alert`, `Download`) au profit des modèles Propel équivalents.
-- L'adapter jQuery de CKEditor a été mis à jour vers la version CKEditor 4 LTS (2025),
+- Plusieurs classes Entity legacy sans usage ont été supprimées (`Price`,
+  `Redirection`,
+  `Signing`, `Subscription`, `Alert`, `Download`) au profit des modèles Propel
+  équivalents.
+- L'adapter jQuery de CKEditor a été mis à jour vers la version CKEditor 4 LTS (
+  2025),
   en préparation de la migration vers jQuery 4.
-- jQuery a été mis à jour de la version 1.12.4 (2016) vers la version 3.7.1 (LTS).
+- jQuery a été mis à jour de la version 1.12.4 (2016) vers la version 3.7.1 (
+  LTS).
 
 ## 3.13.3 (1er juillet 2026)
 
-- Les commandes contenant uniquement un abonnement n'étaient plus marquées 
+- Les commandes contenant uniquement un abonnement n'étaient plus marquées
   comme expédiée automatiquement. C'est corrigé.
 - Le fichier d'export pour Mondial Relay indiquait toujours la France comme
   pays du point relais de livraison, même pour une commande expédiée vers un
@@ -142,7 +170,8 @@
 
 ### Corrections
 
-- Une injection SQL dans la page d'administration des fournisseurs a été corrigée.
+- Une injection SQL dans la page d'administration des fournisseurs a été
+  corrigée.
 
 ## 3.13.1 (16 juin 2026)
 
@@ -176,7 +205,8 @@
 - Une erreur pouvait survenir sur la page de validation de commandes si une
   mailing list Brevo était configurée. C'est corrigé.
 - La page Clients affichait une erreur. C'est corrigé.
-- Les fichiers téléchargeables associés à un article pouvaient ne pas s'afficher.
+- Les fichiers téléchargeables associés à un article pouvaient ne pas
+  s'afficher.
   C'est corrigé.
 
 ## 3.12.1 (9 avril 2026)

--- a/generated-migrations/PropelMigration_1783278001.php
+++ b/generated-migrations/PropelMigration_1783278001.php
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-use DateTime;
 use Model\PaymentHash;
 use Propel\Generator\Manager\MigrationManager;
 

--- a/src/AppBundle/Controller/OrderController.php
+++ b/src/AppBundle/Controller/OrderController.php
@@ -282,7 +282,6 @@ class OrderController extends Controller
         $stocks = StockQuery::create()->filterByOrderId($order->getId())->find();
 
         $lines = [];
-        $totalHt = 0;
         $totalVat = 0;
         $vatBreakdown = [];
         foreach ($stocks as $stock) {
@@ -290,7 +289,6 @@ class OrderController extends Controller
             $priceHt = (int) $stock->getSellingPriceHt();
             $priceVat = (int) $stock->getSellingPriceTva();
             $vatRate = $stock->getTvaRate();
-            $totalHt += $priceHt;
             $totalVat += $priceVat;
 
             $breakdownKey = $vatRate !== null ? (string) $vatRate : "unknown";
@@ -326,7 +324,6 @@ class OrderController extends Controller
             $htByRate = array_map(fn($group) => $group["ht"], $vatBreakdown);
             $shippingParts = ShippingVatAllocationService::allocate($htByRate, (int) $order->getShippingCost());
             $vatBreakdown = ShippingVatAllocationService::mergeIntoBreakdown($vatBreakdown, $shippingParts);
-            $totalHt += array_sum(array_column($shippingParts, "ht"));
             $totalVat += array_sum(array_column($shippingParts, "vat"));
         }
 
@@ -362,7 +359,6 @@ class OrderController extends Controller
             "page_title" => $pageTitle,
             "order" => $order,
             "lines" => $lines,
-            "total_ht" => $totalHt,
             "total_vat" => $totalVat,
             "vat_breakdown" => $vatBreakdown,
             "shipping_vat" => $shippingVat,

--- a/src/AppBundle/Controller/OrderController.php
+++ b/src/AppBundle/Controller/OrderController.php
@@ -369,6 +369,7 @@ class OrderController extends Controller
             "has_vat" => (bool) $currentSite->getSite()->getTva(),
             "payment" => $payment,
             "invoice_notice" => $currentSite->getOption("invoice_notice"),
+            "siren" => $currentSite->getOption("siren"),
             "site_title" => $currentSite->getTitle(),
             "site_address" => $currentSite->getSite()->getAddress(),
         ], isPrivate: true);

--- a/src/AppBundle/Controller/OrderController.php
+++ b/src/AppBundle/Controller/OrderController.php
@@ -327,6 +327,8 @@ class OrderController extends Controller
             $totalVat += array_sum(array_column($shippingParts, "vat"));
         }
 
+        $totalHt = array_sum(array_column($vatBreakdown, "ht"));
+
         uasort($vatBreakdown, function ($a, $b) {
             if ($a["rate"] === null) {
                 return 1;
@@ -359,6 +361,7 @@ class OrderController extends Controller
             "page_title" => $pageTitle,
             "order" => $order,
             "lines" => $lines,
+            "total_ht" => $totalHt,
             "total_vat" => $totalVat,
             "vat_breakdown" => $vatBreakdown,
             "shipping_vat" => $shippingVat,

--- a/src/AppBundle/Controller/OrderController.php
+++ b/src/AppBundle/Controller/OrderController.php
@@ -343,6 +343,14 @@ class OrderController extends Controller
 
         $shippingVat = ShippingVatAllocationService::summarizeForDisplay($shippingParts, $vatBreakdown);
 
+        $hasNonNewCondition = false;
+        foreach ($lines as $line) {
+            if ($line["condition"] !== "Neuf") {
+                $hasNonNewCondition = true;
+                break;
+            }
+        }
+
         $payment = null;
         if ($order->getPaymentDate()) {
             $payment = [
@@ -360,6 +368,7 @@ class OrderController extends Controller
             "vat_breakdown" => $vatBreakdown,
             "shipping_vat" => $shippingVat,
             "is_shop" => (bool) $currentSite->getSite()->getShop(),
+            "show_condition" => $hasNonNewCondition,
             "has_vat" => (bool) $currentSite->getSite()->getTva(),
             "payment" => $payment,
             "invoice_notice" => $currentSite->getOption("invoice_notice"),

--- a/src/AppBundle/Controller/OrderController.php
+++ b/src/AppBundle/Controller/OrderController.php
@@ -367,7 +367,6 @@ class OrderController extends Controller
             "total_vat" => $totalVat,
             "vat_breakdown" => $vatBreakdown,
             "shipping_vat" => $shippingVat,
-            "is_shop" => (bool) $currentSite->getSite()->getShop(),
             "show_condition" => $hasNonNewCondition,
             "has_vat" => (bool) $currentSite->getSite()->getTva(),
             "payment" => $payment,

--- a/src/AppBundle/Controller/OrderController.php
+++ b/src/AppBundle/Controller/OrderController.php
@@ -317,7 +317,6 @@ class OrderController extends Controller
                 "condition" => $stock->getCondition(),
                 "price" => (int) $stock->getSellingPrice(),
                 "priceHt" => $priceHt,
-                "priceVat" => $priceVat,
                 "vatRate" => $vatRate,
             ];
         }

--- a/src/AppBundle/Resources/views/Order/invoice.html.twig
+++ b/src/AppBundle/Resources/views/Order/invoice.html.twig
@@ -180,7 +180,6 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
                         <th colspan="{{ vatBreakdownColspan }}" class="text-right">Taux</th>
                         <th class="text-right">Base HT</th>
                         <th class="text-right">TVA</th>
-                        <th class="text-right">Total TTC</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -191,14 +190,12 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
                             </td>
                             <td class="text-right">{{ group.ht|currency(true)|raw }}</td>
                             <td class="text-right">{{ group.vat|currency(true)|raw }}</td>
-                            <td class="text-right">{{ group.ttc|currency(true)|raw }}</td>
                         </tr>
                     {% endfor %}
                     <tr>
                         <td colspan="{{ vatBreakdownColspan }}" class="text-right">Total</td>
                         <td class="text-right">{{ total_ht|currency(true)|raw }}</td>
                         <td class="text-right">{{ total_vat|currency(true)|raw }}</td>
-                        <td class="text-right">{{ (total_ht + total_vat)|currency(true)|raw }}</td>
                     </tr>
                 </tbody>
             </table>

--- a/src/AppBundle/Resources/views/Order/invoice.html.twig
+++ b/src/AppBundle/Resources/views/Order/invoice.html.twig
@@ -120,7 +120,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
                 <tr>
                     <th>Article</th>
                     {% if show_condition %}<th>État</th>{% endif %}
-                    {% if has_vat %}
+                    {% if total_vat %}
                         <th class="text-right">Taux</th>
                         <th class="text-right">Prix HT</th>
                     {% endif %}
@@ -142,7 +142,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
                             </p>
                         </td>
                         {% if show_condition %}<td class="text-center align">{{ line.condition }}</td>{% endif %}
-                        {% if has_vat %}
+                        {% if total_vat %}
                             <td class="text-right align">{{ line.vatRate is not null ? (line.vatRate|replace({'.': ','}) ~ ' %') : '—' }}</td>
                             <td class="text-right align">{{ line.vatRate is not null ? line.priceHt|currency(true)|raw : '—' }}</td>
                         {% endif %}
@@ -159,7 +159,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
                             </p>
                         </td>
                         {% if show_condition %}<td></td>{% endif %}
-                        {% if has_vat %}
+                        {% if total_vat %}
                             <td class="text-right align">
                                 {{ shipping_vat is not null and shipping_vat.rate is not null ? (shipping_vat.rate|replace({'.': ','}) ~ ' %') : (shipping_vat is not null ? 'Taux inconnu' : '—') }}{% if shipping_vat is not null and shipping_vat.recalculated %}*{% endif %}
                             </td>

--- a/src/AppBundle/Resources/views/Order/invoice.html.twig
+++ b/src/AppBundle/Resources/views/Order/invoice.html.twig
@@ -95,6 +95,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
             <div>
                 <h3>{{ site_title }}</h3>
                 <p>{{ site_address|replace({'|': '<br>'})|raw }}</p>
+                {% if siren %}<p>SIREN : {{ siren }}</p>{% endif %}
             </div>
             <div>
                 <h3>{{ order.title }} {{ order.firstname }} {{ order.lastname }}</h3>

--- a/src/AppBundle/Resources/views/Order/invoice.html.twig
+++ b/src/AppBundle/Resources/views/Order/invoice.html.twig
@@ -192,11 +192,6 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
                             <td class="text-right">{{ group.vat|currency(true)|raw }}</td>
                         </tr>
                     {% endfor %}
-                    <tr>
-                        <td colspan="{{ vatBreakdownColspan }}" class="text-right">Total</td>
-                        <td class="text-right">{{ total_ht|currency(true)|raw }}</td>
-                        <td class="text-right">{{ total_vat|currency(true)|raw }}</td>
-                    </tr>
                 </tbody>
             </table>
         {% endif %}

--- a/src/AppBundle/Resources/views/Order/invoice.html.twig
+++ b/src/AppBundle/Resources/views/Order/invoice.html.twig
@@ -110,6 +110,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
         </header>
 
         <h1>Facture n° {{ order.id }}</h1>
+        <p class="text-muted">{{ order.createdAt|date }}</p>
 
         <table class="table article-list mt-4">
             <thead>

--- a/src/AppBundle/Resources/views/Order/invoice.html.twig
+++ b/src/AppBundle/Resources/views/Order/invoice.html.twig
@@ -50,29 +50,26 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
             font-weight: normal;
         }
 
-        .invoice-document .total {
-          background: rgba(0, 0, 0, 0.03);
-          display: flex;
-          font-size: 20pt;
-          justify-content: space-between;
-          padding: 10pt 20pt;
-        }
-
-        .invoice-document .vat-breakdown {
+        .invoice-document .totals {
             margin-left: auto;
             margin-right: 0;
+            margin-top: 20pt;
             width: auto;
         }
 
-        .invoice-document .vat-breakdown th,
-        .invoice-document .vat-breakdown td {
-            background: rgba(0, 0, 0, 0.03);
-            border-color: rgba(0, 0, 0, 0.08);
-            padding: 8pt 12pt;
+        .invoice-document .totals-row {
+            display: flex;
+            gap: 40pt;
+            justify-content: space-between;
+            padding: 4pt 20pt;
         }
 
-        .invoice-document .vat-breakdown th {
+        .invoice-document .totals-row-final {
+            background: rgba(0, 0, 0, 0.03);
+            font-size: 20pt;
             font-weight: bold;
+            margin-top: 8pt;
+            padding: 10pt 20pt;
         }
 
         .invoice-document .text-right { 
@@ -90,8 +87,6 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 {% endblock %}
 
 {% block main %}
-    {% set vatBreakdownColspan = 3 %}
-
     <a href="javascript:history.back()" class="btn btn-secondary d-print-none mb-3">← Retour</a>
 
     <div class="invoice-document">
@@ -173,37 +168,23 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
             </tbody>
         </table>
 
-        {% if total_vat %}
-            <table class="table vat-breakdown mt-4">
-                <thead>
-                    <tr>
-                        <th colspan="{{ vatBreakdownColspan }}" class="text-right">Taux</th>
-                        <th class="text-right">Base HT</th>
-                        <th class="text-right">TVA</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {% for group in vat_breakdown %}
-                        <tr>
-                            <td colspan="{{ vatBreakdownColspan }}" class="text-right">
-                                {{ group.rate is not null ? (group.rate|replace({'.': ','}) ~ ' %') : 'Taux inconnu' }}
-                            </td>
-                            <td class="text-right">{{ group.ht|currency(true)|raw }}</td>
-                            <td class="text-right">{{ group.vat|currency(true)|raw }}</td>
-                        </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
-        {% endif %}
-
-
-        <div class="total">
-          <div class="">
-              Total TTC
-          </div>
-          <div>
-            {{ (order.amount + order.shippingCost)|currency(true)|raw }}
-          </div>
+        <div class="totals">
+            {% if total_vat %}
+                <div class="totals-row">
+                    <div>Sous-total HT</div>
+                    <div>{{ total_ht|currency(true)|raw }}</div>
+                </div>
+                {% for group in vat_breakdown %}
+                    <div class="totals-row">
+                        <div>TVA {{ group.rate is not null ? (group.rate|replace({'.': ','}) ~ '%') : 'Taux inconnu' }} de {{ group.ht|currency(true)|raw }}</div>
+                        <div>{{ group.vat|currency(true)|raw }}</div>
+                    </div>
+                {% endfor %}
+            {% endif %}
+            <div class="totals-row totals-row-final">
+                <div>Total TTC</div>
+                <div>{{ (order.amount + order.shippingCost)|currency(true)|raw }}</div>
+            </div>
         </div>
 
         <footer class="mt-4">

--- a/src/AppBundle/Resources/views/Order/invoice.html.twig
+++ b/src/AppBundle/Resources/views/Order/invoice.html.twig
@@ -141,7 +141,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
                                 coll. {{ line.collectionName }}{% if line.number %} n° {{ line.number }}{% endif %}
                             </p>
                         </td>
-                        {% if show_condition %}<td class="text-center align">{{ line.condition }}</td>{% endif %}
+                        {% if show_condition %}<td class="text-left align">{{ line.condition }}</td>{% endif %}
                         {% if total_vat %}
                             <td class="text-right align">{{ line.vatRate is not null ? line.priceHt|currency(true)|raw : '—' }}</td>
                             <td class="text-right align">{{ line.vatRate is not null ? (line.vatRate|replace({'.': ','}) ~ ' %') : '—' }}</td>

--- a/src/AppBundle/Resources/views/Order/invoice.html.twig
+++ b/src/AppBundle/Resources/views/Order/invoice.html.twig
@@ -119,7 +119,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
             <thead>
                 <tr>
                     <th>Article</th>
-                    {% if is_shop %}<th>État</th>{% endif %}
+                    {% if is_shop and show_condition %}<th>État</th>{% endif %}
                     {% if has_vat %}
                         <th class="text-right">Taux</th>
                         <th class="text-right">Prix HT</th>
@@ -142,7 +142,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
                                 coll. {{ line.collectionName }}{% if line.number %} n° {{ line.number }}{% endif %}
                             </p>
                         </td>
-                        {% if is_shop %}<td class="text-center align">{{ line.condition }}</td>{% endif %}
+                        {% if is_shop and show_condition %}<td class="text-center align">{{ line.condition }}</td>{% endif %}
                         {% if has_vat %}
                             <td class="text-right align">{{ line.vatRate is not null ? (line.vatRate|replace({'.': ','}) ~ ' %') : '—' }}</td>
                             <td class="text-right align">{{ line.vatRate is not null ? line.priceHt|currency(true)|raw : '—' }}</td>
@@ -160,7 +160,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
                                 <small class="text-muted">({{ order.shippingMode }})</small>
                             </p>
                         </td>
-                        {% if is_shop %}<td></td>{% endif %}
+                        {% if is_shop and show_condition %}<td></td>{% endif %}
                         {% if has_vat %}
                             <td class="text-right align">
                                 {{ shipping_vat is not null and shipping_vat.rate is not null ? (shipping_vat.rate|replace({'.': ','}) ~ ' %') : (shipping_vat is not null ? 'Taux inconnu' : '—') }}{% if shipping_vat is not null and shipping_vat.recalculated %}*{% endif %}

--- a/src/AppBundle/Resources/views/Order/invoice.html.twig
+++ b/src/AppBundle/Resources/views/Order/invoice.html.twig
@@ -123,7 +123,6 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
                     {% if has_vat %}
                         <th class="text-right">Taux</th>
                         <th class="text-right">Prix HT</th>
-                        <th class="text-right">TVA</th>
                     {% endif %}
                     <th class="text-right">Prix TTC</th>
                 </tr>
@@ -146,7 +145,6 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
                         {% if has_vat %}
                             <td class="text-right align">{{ line.vatRate is not null ? (line.vatRate|replace({'.': ','}) ~ ' %') : '—' }}</td>
                             <td class="text-right align">{{ line.vatRate is not null ? line.priceHt|currency(true)|raw : '—' }}</td>
-                            <td class="text-right align">{{ line.vatRate is not null ? line.priceVat|currency(true)|raw : '—' }}</td>
                         {% endif %}
                         <td class="text-right align">{{ line.price|currency(true)|raw }}</td>
                     </tr>
@@ -166,7 +164,6 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
                                 {{ shipping_vat is not null and shipping_vat.rate is not null ? (shipping_vat.rate|replace({'.': ','}) ~ ' %') : (shipping_vat is not null ? 'Taux inconnu' : '—') }}{% if shipping_vat is not null and shipping_vat.recalculated %}*{% endif %}
                             </td>
                             <td class="text-right align">{{ shipping_vat is not null ? shipping_vat.ht|currency(true)|raw : '—' }}</td>
-                            <td class="text-right align">{{ shipping_vat is not null ? shipping_vat.vat|currency(true)|raw : '—' }}</td>
                         {% endif %}
                         <td class="text-right align">
                             {{ order.shippingCost|currency(true)|raw }}

--- a/src/AppBundle/Resources/views/Order/invoice.html.twig
+++ b/src/AppBundle/Resources/views/Order/invoice.html.twig
@@ -119,7 +119,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
             <thead>
                 <tr>
                     <th>Article</th>
-                    {% if is_shop and show_condition %}<th>État</th>{% endif %}
+                    {% if show_condition %}<th>État</th>{% endif %}
                     {% if has_vat %}
                         <th class="text-right">Taux</th>
                         <th class="text-right">Prix HT</th>
@@ -142,7 +142,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
                                 coll. {{ line.collectionName }}{% if line.number %} n° {{ line.number }}{% endif %}
                             </p>
                         </td>
-                        {% if is_shop and show_condition %}<td class="text-center align">{{ line.condition }}</td>{% endif %}
+                        {% if show_condition %}<td class="text-center align">{{ line.condition }}</td>{% endif %}
                         {% if has_vat %}
                             <td class="text-right align">{{ line.vatRate is not null ? (line.vatRate|replace({'.': ','}) ~ ' %') : '—' }}</td>
                             <td class="text-right align">{{ line.vatRate is not null ? line.priceHt|currency(true)|raw : '—' }}</td>
@@ -160,7 +160,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
                                 <small class="text-muted">({{ order.shippingMode }})</small>
                             </p>
                         </td>
-                        {% if is_shop and show_condition %}<td></td>{% endif %}
+                        {% if show_condition %}<td></td>{% endif %}
                         {% if has_vat %}
                             <td class="text-right align">
                                 {{ shipping_vat is not null and shipping_vat.rate is not null ? (shipping_vat.rate|replace({'.': ','}) ~ ' %') : (shipping_vat is not null ? 'Taux inconnu' : '—') }}{% if shipping_vat is not null and shipping_vat.recalculated %}*{% endif %}

--- a/src/AppBundle/Resources/views/Order/invoice.html.twig
+++ b/src/AppBundle/Resources/views/Order/invoice.html.twig
@@ -121,8 +121,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
                     <th>Article</th>
                     {% if show_condition %}<th>État</th>{% endif %}
                     {% if total_vat %}
-                        <th class="text-right">Taux</th>
                         <th class="text-right">Prix HT</th>
+                        <th class="text-right">Taux</th>
                     {% endif %}
                     <th class="text-right">Prix TTC</th>
                 </tr>
@@ -143,8 +143,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
                         </td>
                         {% if show_condition %}<td class="text-center align">{{ line.condition }}</td>{% endif %}
                         {% if total_vat %}
-                            <td class="text-right align">{{ line.vatRate is not null ? (line.vatRate|replace({'.': ','}) ~ ' %') : '—' }}</td>
                             <td class="text-right align">{{ line.vatRate is not null ? line.priceHt|currency(true)|raw : '—' }}</td>
+                            <td class="text-right align">{{ line.vatRate is not null ? (line.vatRate|replace({'.': ','}) ~ ' %') : '—' }}</td>
                         {% endif %}
                         <td class="text-right align">{{ line.price|currency(true)|raw }}</td>
                     </tr>
@@ -160,10 +160,10 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
                         </td>
                         {% if show_condition %}<td></td>{% endif %}
                         {% if total_vat %}
+                            <td class="text-right align">{{ shipping_vat is not null ? shipping_vat.ht|currency(true)|raw : '—' }}</td>
                             <td class="text-right align">
                                 {{ shipping_vat is not null and shipping_vat.rate is not null ? (shipping_vat.rate|replace({'.': ','}) ~ ' %') : (shipping_vat is not null ? 'Taux inconnu' : '—') }}{% if shipping_vat is not null and shipping_vat.recalculated %}*{% endif %}
                             </td>
-                            <td class="text-right align">{{ shipping_vat is not null ? shipping_vat.ht|currency(true)|raw : '—' }}</td>
                         {% endif %}
                         <td class="text-right align">
                             {{ order.shippingCost|currency(true)|raw }}

--- a/src/Command/CreateSeedsCommand.php
+++ b/src/Command/CreateSeedsCommand.php
@@ -18,10 +18,14 @@
 
 namespace Command;
 
+use Biblys\Data\ArticleType;
 use Biblys\Database\Connection;
 use Biblys\Service\Config;
+use Biblys\Service\CurrentSite;
 use Biblys\Service\Slug\SlugService;
 use Biblys\Test\ModelFactory;
+use DateTime;
+use Model\Payment;
 use Model\Publisher;
 use Model\Right;
 use Model\ShippingOption;
@@ -67,8 +71,13 @@ class CreateSeedsCommand extends Command
         $site->setDomain("paronymie.fr");
         $site->setContact("contact@paronymie.fr");
         $site->setTva("fr");
+        $site->setAddress("12 rue des Paronymes|75011 Paris");
         $site->save();
         $output->writeln(["Inserted site: Éditions Paronymie"]);
+
+        $currentSite = new CurrentSite($site);
+        $currentSite->setOption("siren", "123 456 789");
+        $output->writeln(["Inserted site option: siren"]);
 
         // Admin
         $admin = new User();
@@ -145,6 +154,7 @@ class CreateSeedsCommand extends Command
 
         // Catalog articles, each with its author and one new stock item
         $slugService = new SlugService();
+        $orderedCatalogArticle = null;
         foreach (self::CATALOG_ARTICLES as $catalogArticle) {
             $author = ModelFactory::createContributor(
                 firstName: $catalogArticle["firstName"],
@@ -169,33 +179,67 @@ class CreateSeedsCommand extends Command
                 sellingPrice: $catalogArticle["price"],
             );
 
+            if ($catalogArticle["title"] === "Au-revoir Mao") {
+                $orderedCatalogArticle = $catalogArticleModel;
+            }
+
             $output->writeln(["Inserted article with stock item: {$catalogArticle["title"]}"]);
         }
+
+        // Goodies article
+        $goodiesArticle = ModelFactory::createArticle(
+            title: "Tote bag Paronymie",
+            typeId: ArticleType::GOODIES,
+            url: "paronymie/tote-bag-paronymie",
+            price: 500,
+            publisher: $publisher,
+            collection: $collection,
+        );
+        $output->writeln(["Inserted article: Tote bag Paronymie"]);
 
         // Order, shipped with the seeded shipping option so the invoice shows a shipping line
         $order = ModelFactory::createOrder(
             shippingOption: $shippingFee,
-            amount: 999,
-            amountToBePaid: 1299,
+            amount: 1800 + 500,
+            amountToBePaid: 1800 + 500 + 300,
             shippingCost: 300,
         );
 
-        // Stock Item, weighed so the invoice shows a total weight
+        // Stock items, main item weighed so the invoice shows a total weight
         $orderedStockItem = ModelFactory::createStockItem(
-            article: $article,
+            article: $orderedCatalogArticle,
             order: $order,
-            sellingPrice: 999,
+            sellingPrice: 1800,
             weight: 450,
         );
+        $orderedGoodiesStockItem = ModelFactory::createStockItem(
+            article: $goodiesArticle,
+            order: $order,
+            sellingPrice: 500,
+        );
 
-        // Compute and persist VAT on the sold stock item, mirroring what happens on a real sale
+        // Compute and persist VAT on the sold stock items, mirroring what happens on a real sale
         require_once __DIR__ . "/../../inc/autoload-entity.php";
         if (!isset($GLOBALS["_SQL"])) {
             Connection::init(Config::load());
         }
         $stockManager = new StockManager();
-        $stock = $stockManager->calculateTax($stockManager->getById($orderedStockItem->getId()));
-        $stockManager->update($stock);
+        foreach ([$orderedStockItem, $orderedGoodiesStockItem] as $orderedItem) {
+            $stock = $stockManager->calculateTax($stockManager->getById($orderedItem->getId()));
+            $stockManager->update($stock);
+        }
+
+        // Payment, mirroring AddPaymentToOrderAndExecuteUsecase + MarkOrderAsPaidUsecase
+        ModelFactory::createPayment(
+            order: $order,
+            amount: 1800 + 500 + 300,
+            mode: Payment::MODE_STRIPE,
+        );
+        $order->setPaymentMode(Payment::MODE_STRIPE);
+        $order->setPaymentDate(new DateTime());
+        $order->setAmountTobepaid(0);
+        $order->save();
+        $output->writeln(["Inserted payment for order"]);
 
         $output->writeln(["Seeds generated!"]);
         return 0;

--- a/tests/AppBundle/Controller/OrderControllerTest.php
+++ b/tests/AppBundle/Controller/OrderControllerTest.php
@@ -327,10 +327,9 @@ class OrderControllerTest extends TestCase
         $this->assertNotNull($updatedOrder->getCancelDate());
     }
 
-    private function _mockCurrentSiteForInvoice(bool $isShop = false): CurrentSite
+    private function _mockCurrentSiteForInvoice(): CurrentSite
     {
         $site = Mockery::mock(Site::class);
-        $site->shouldReceive("getShop")->andReturn($isShop);
         $site->shouldReceive("getTva")->andReturn(1);
         $site->shouldReceive("getAddress")->andReturn("1 rue du Livre|33000 Bordeaux");
 
@@ -414,7 +413,7 @@ class OrderControllerTest extends TestCase
         $currentUser = Mockery::mock(CurrentUser::class);
         $currentUser->shouldReceive("isAuthenticated")->andReturn(false);
         $currentUser->shouldReceive("isAdmin")->andReturn(false);
-        $currentSite = $this->_mockCurrentSiteForInvoice(isShop: true);
+        $currentSite = $this->_mockCurrentSiteForInvoice();
         $templateService = Helpers::getTemplateService();
 
         // when
@@ -440,7 +439,7 @@ class OrderControllerTest extends TestCase
         $currentUser = Mockery::mock(CurrentUser::class);
         $currentUser->shouldReceive("isAuthenticated")->andReturn(false);
         $currentUser->shouldReceive("isAdmin")->andReturn(false);
-        $currentSite = $this->_mockCurrentSiteForInvoice(isShop: true);
+        $currentSite = $this->_mockCurrentSiteForInvoice();
         $templateService = Helpers::getTemplateService();
 
         // when

--- a/tests/AppBundle/Controller/OrderControllerTest.php
+++ b/tests/AppBundle/Controller/OrderControllerTest.php
@@ -400,6 +400,11 @@ class OrderControllerTest extends TestCase
         $this->assertStringNotContainsString("OverallMenu", $content, "La facture doit utiliser un layout minimal, sans le chrome du site");
         $this->assertStringNotContainsString("Ref.", $content, "La colonne Ref. doit avoir été supprimée");
         $this->assertStringContainsString("Port", $content, "La ligne de port doit être affichée quand des frais existent (500 c)");
+        $this->assertMatchesRegularExpression(
+            "/\d{2}\/\d{2}\/\d{4}/",
+            $content,
+            "La date de la commande doit être affichée sur la facture"
+        );
     }
 
     public function testInvoiceActionDisplaysSirenWhenSiteOptionIsSet(): void

--- a/tests/AppBundle/Controller/OrderControllerTest.php
+++ b/tests/AppBundle/Controller/OrderControllerTest.php
@@ -666,6 +666,39 @@ class OrderControllerTest extends TestCase
         );
     }
 
+    public function testInvoiceActionHidesVatColumnsWhenOrderHasNoVatEvenOnVatLiableSite(): void
+    {
+        // given : site assujetti à la TVA (getTva() = 1), mais commande sans aucune TVA
+        // (ex. articles à taux 0) — les colonnes doivent se baser sur la commande, pas sur
+        // le site, tandis que la mention 293B (statut fiscal du vendeur) ne doit pas apparaître
+        $controller = new OrderController();
+        $request = new Request();
+        $order = ModelFactory::createOrder(slug: "invoice-0-vat", amount: 2000, shippingCost: 0);
+        $article = ModelFactory::createArticle(title: "Le Livre Test");
+        $stock = ModelFactory::createStockItem(article: $article, order: $order, sellingPrice: 2000);
+        $stock->setSellingPriceHt(2000)->setSellingPriceTva(0)->setTvaRate(null)->save();
+
+        $currentUser = Mockery::mock(CurrentUser::class);
+        $currentUser->shouldReceive("isAuthenticated")->andReturn(false);
+        $currentUser->shouldReceive("isAdmin")->andReturn(false);
+        $currentSite = $this->_mockCurrentSiteForInvoice();
+        $templateService = Helpers::getTemplateService();
+
+        // when
+        $response = $controller->invoiceAction($request, $currentUser, $currentSite, $templateService, "invoice-0-vat");
+        $content = $response->getContent();
+
+        // then
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertStringNotContainsString('<th class="text-right">Taux</th>', $content, "Les colonnes TVA doivent être masquées car la commande n'a aucune TVA");
+        $this->assertStringNotContainsString('<th class="text-right">Prix HT</th>', $content);
+        $this->assertStringNotContainsString(
+            "TVA non applicable en application de l'article 293 B du CGI.",
+            $content,
+            "Le site est assujetti à la TVA : la mention 293B ne doit pas apparaître malgré une commande sans TVA"
+        );
+    }
+
     public function testInvoiceActionRendersPaidOrderWithoutPaymentMode(): void
     {
         // given : commande réglée (date de paiement) mais sans mode de paiement

--- a/tests/AppBundle/Controller/OrderControllerTest.php
+++ b/tests/AppBundle/Controller/OrderControllerTest.php
@@ -620,7 +620,6 @@ class OrderControllerTest extends TestCase
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertStringContainsString("9,5 %*", $content, "Le taux recalculé du port doit être marqué d'une étoile");
         $this->assertStringContainsString("5,48&nbsp;&euro;", $content, "HT agrégé du port (395 + 153 c)");
-        $this->assertStringContainsString("0,52&nbsp;&euro;", $content, "TVA agrégée du port (22 + 30 c)");
         $this->assertStringContainsString(
             "les frais de port ont été",
             $content,

--- a/tests/AppBundle/Controller/OrderControllerTest.php
+++ b/tests/AppBundle/Controller/OrderControllerTest.php
@@ -337,6 +337,7 @@ class OrderControllerTest extends TestCase
         $currentSite->shouldReceive("getSite")->andReturn($site);
         $currentSite->shouldReceive("getTitle")->andReturn("Ma librairie");
         $currentSite->shouldReceive("getOption")->with("invoice_notice")->andReturn(null);
+        $currentSite->shouldReceive("getOption")->with("siren")->andReturn(null);
         return $currentSite;
     }
 
@@ -399,6 +400,62 @@ class OrderControllerTest extends TestCase
         $this->assertStringNotContainsString("OverallMenu", $content, "La facture doit utiliser un layout minimal, sans le chrome du site");
         $this->assertStringNotContainsString("Ref.", $content, "La colonne Ref. doit avoir été supprimée");
         $this->assertStringContainsString("Port", $content, "La ligne de port doit être affichée quand des frais existent (500 c)");
+    }
+
+    public function testInvoiceActionDisplaysSirenWhenSiteOptionIsSet(): void
+    {
+        // given
+        $controller = new OrderController();
+        $request = new Request();
+        $order = ModelFactory::createOrder(slug: "invoice-siren", amount: 2000, shippingCost: 0);
+        $article = ModelFactory::createArticle(title: "Le Livre Test");
+        ModelFactory::createStockItem(article: $article, order: $order, sellingPrice: 2000);
+
+        $site = Mockery::mock(Site::class);
+        $site->shouldReceive("getTva")->andReturn(1);
+        $site->shouldReceive("getAddress")->andReturn("1 rue du Livre|33000 Bordeaux");
+        $currentSite = Mockery::mock(CurrentSite::class);
+        $currentSite->shouldReceive("getSite")->andReturn($site);
+        $currentSite->shouldReceive("getTitle")->andReturn("Ma librairie");
+        $currentSite->shouldReceive("getOption")->with("invoice_notice")->andReturn(null);
+        $currentSite->shouldReceive("getOption")->with("siren")->andReturn("123 456 789");
+
+        $currentUser = Mockery::mock(CurrentUser::class);
+        $currentUser->shouldReceive("isAuthenticated")->andReturn(false);
+        $currentUser->shouldReceive("isAdmin")->andReturn(false);
+        $templateService = Helpers::getTemplateService();
+
+        // when
+        $response = $controller->invoiceAction($request, $currentUser, $currentSite, $templateService, "invoice-siren");
+        $content = $response->getContent();
+
+        // then
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertStringContainsString("SIREN : 123 456 789", $content);
+    }
+
+    public function testInvoiceActionHidesSirenWhenSiteOptionIsNotSet(): void
+    {
+        // given
+        $controller = new OrderController();
+        $request = new Request();
+        $order = ModelFactory::createOrder(slug: "invoice-no-siren", amount: 2000, shippingCost: 0);
+        $article = ModelFactory::createArticle(title: "Le Livre Test");
+        ModelFactory::createStockItem(article: $article, order: $order, sellingPrice: 2000);
+
+        $currentUser = Mockery::mock(CurrentUser::class);
+        $currentUser->shouldReceive("isAuthenticated")->andReturn(false);
+        $currentUser->shouldReceive("isAdmin")->andReturn(false);
+        $currentSite = $this->_mockCurrentSiteForInvoice();
+        $templateService = Helpers::getTemplateService();
+
+        // when
+        $response = $controller->invoiceAction($request, $currentUser, $currentSite, $templateService, "invoice-no-siren");
+        $content = $response->getContent();
+
+        // then
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertStringNotContainsString("SIREN", $content);
     }
 
     public function testInvoiceActionHidesConditionColumnWhenAllArticlesAreNew(): void
@@ -645,6 +702,7 @@ class OrderControllerTest extends TestCase
         $currentSite->shouldReceive("getSite")->andReturn($site);
         $currentSite->shouldReceive("getTitle")->andReturn("Ma librairie");
         $currentSite->shouldReceive("getOption")->with("invoice_notice")->andReturn(null);
+        $currentSite->shouldReceive("getOption")->with("siren")->andReturn(null);
 
         $currentUser = Mockery::mock(CurrentUser::class);
         $currentUser->shouldReceive("isAuthenticated")->andReturn(false);

--- a/tests/AppBundle/Controller/OrderControllerTest.php
+++ b/tests/AppBundle/Controller/OrderControllerTest.php
@@ -327,10 +327,10 @@ class OrderControllerTest extends TestCase
         $this->assertNotNull($updatedOrder->getCancelDate());
     }
 
-    private function _mockCurrentSiteForInvoice(): CurrentSite
+    private function _mockCurrentSiteForInvoice(bool $isShop = false): CurrentSite
     {
         $site = Mockery::mock(Site::class);
-        $site->shouldReceive("getShop")->andReturn(false);
+        $site->shouldReceive("getShop")->andReturn($isShop);
         $site->shouldReceive("getTva")->andReturn(1);
         $site->shouldReceive("getAddress")->andReturn("1 rue du Livre|33000 Bordeaux");
 
@@ -400,6 +400,56 @@ class OrderControllerTest extends TestCase
         $this->assertStringNotContainsString("OverallMenu", $content, "La facture doit utiliser un layout minimal, sans le chrome du site");
         $this->assertStringNotContainsString("Ref.", $content, "La colonne Ref. doit avoir été supprimée");
         $this->assertStringContainsString("Port", $content, "La ligne de port doit être affichée quand des frais existent (500 c)");
+    }
+
+    public function testInvoiceActionHidesConditionColumnWhenAllArticlesAreNew(): void
+    {
+        // given
+        $controller = new OrderController();
+        $request = new Request();
+        $order = ModelFactory::createOrder(slug: "invoice-all-new", amount: 2000, shippingCost: 0);
+        $article = ModelFactory::createArticle(title: "Le Livre Test");
+        ModelFactory::createStockItem(article: $article, order: $order, sellingPrice: 2000);
+
+        $currentUser = Mockery::mock(CurrentUser::class);
+        $currentUser->shouldReceive("isAuthenticated")->andReturn(false);
+        $currentUser->shouldReceive("isAdmin")->andReturn(false);
+        $currentSite = $this->_mockCurrentSiteForInvoice(isShop: true);
+        $templateService = Helpers::getTemplateService();
+
+        // when
+        $response = $controller->invoiceAction($request, $currentUser, $currentSite, $templateService, "invoice-all-new");
+        $content = $response->getContent();
+
+        // then
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertStringNotContainsString("État", $content, "La colonne État doit être masquée quand tous les articles sont Neuf");
+    }
+
+    public function testInvoiceActionShowsConditionColumnWhenAnArticleIsNotNew(): void
+    {
+        // given
+        $controller = new OrderController();
+        $request = new Request();
+        $order = ModelFactory::createOrder(slug: "invoice-mixed-1", amount: 2000, shippingCost: 0);
+        $article = ModelFactory::createArticle(title: "Le Livre Test");
+        $stock = ModelFactory::createStockItem(article: $article, order: $order, sellingPrice: 2000);
+        $stock->setCondition("Occasion");
+        $stock->save();
+
+        $currentUser = Mockery::mock(CurrentUser::class);
+        $currentUser->shouldReceive("isAuthenticated")->andReturn(false);
+        $currentUser->shouldReceive("isAdmin")->andReturn(false);
+        $currentSite = $this->_mockCurrentSiteForInvoice(isShop: true);
+        $templateService = Helpers::getTemplateService();
+
+        // when
+        $response = $controller->invoiceAction($request, $currentUser, $currentSite, $templateService, "invoice-mixed-1");
+        $content = $response->getContent();
+
+        // then
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertStringContainsString("État", $content, "La colonne État doit être affichée quand un article n'est pas Neuf");
     }
 
     public function testInvoiceActionHidesShippingLineWhenFree(): void

--- a/tests/Command/CreateSeedsCommandTest.php
+++ b/tests/Command/CreateSeedsCommandTest.php
@@ -23,6 +23,7 @@ use Model\ArticleQuery;
 use Model\BookCollectionQuery;
 use Model\CustomerQuery;
 use Model\OrderQuery;
+use Model\PaymentQuery;
 use Model\PeopleQuery;
 use Model\PublisherQuery;
 use Model\RoleQuery;
@@ -37,6 +38,8 @@ require_once __DIR__ . "/../setUp.php";
 class CreateSeedsCommandTest extends TestCase
 {
     private const SEEDED_ARTICLE_TITLE = "L'Ordure du jeu";
+    private const SEEDED_ORDERED_CATALOG_TITLE = "Au-revoir Mao";
+    private const SEEDED_GOODIES_TITLE = "Tote bag Paronymie";
 
     /**
      * The command is not idempotent: Publisher, BookCollection and People
@@ -49,12 +52,13 @@ class CreateSeedsCommandTest extends TestCase
      */
     protected function setUp(): void
     {
+        PaymentQuery::create()->deleteAll();
         StockQuery::create()->deleteAll();
         OrderQuery::create()->deleteAll();
         CustomerQuery::create()->deleteAll();
 
         $seededTitles = array_merge(
-            [self::SEEDED_ARTICLE_TITLE],
+            [self::SEEDED_ARTICLE_TITLE, self::SEEDED_GOODIES_TITLE],
             array_column(CreateSeedsCommand::CATALOG_ARTICLES, "title"),
         );
         foreach ($seededTitles as $seededTitle) {
@@ -92,7 +96,7 @@ class CreateSeedsCommandTest extends TestCase
         $this->assertStringContainsString("Seeds generated!", $commandTester->getDisplay());
 
         $stockItems = StockQuery::create()->orderById()->find();
-        $expectedCount = 2 + count(CreateSeedsCommand::CATALOG_ARTICLES);
+        $expectedCount = 3 + count(CreateSeedsCommand::CATALOG_ARTICLES);
         $this->assertCount($expectedCount, $stockItems);
 
         $availableItem = $stockItems[0];
@@ -100,10 +104,17 @@ class CreateSeedsCommandTest extends TestCase
         $this->assertEquals(999, $availableItem->getSellingPrice());
         $this->assertNull($availableItem->getOrderId());
 
-        $orderedItem = $stockItems[$expectedCount - 1];
-        $this->assertEquals(self::SEEDED_ARTICLE_TITLE, $orderedItem->getArticle()->getTitle());
-        $this->assertEquals(999, $orderedItem->getSellingPrice());
-        $this->assertEquals(OrderQuery::create()->findOne()->getId(), $orderedItem->getOrderId());
+        $orderId = OrderQuery::create()->findOne()->getId();
+
+        $orderedItem = $stockItems[$expectedCount - 2];
+        $this->assertEquals(self::SEEDED_ORDERED_CATALOG_TITLE, $orderedItem->getArticle()->getTitle());
+        $this->assertEquals(1800, $orderedItem->getSellingPrice());
+        $this->assertEquals($orderId, $orderedItem->getOrderId());
+
+        $orderedGoodiesItem = $stockItems[$expectedCount - 1];
+        $this->assertEquals(self::SEEDED_GOODIES_TITLE, $orderedGoodiesItem->getArticle()->getTitle());
+        $this->assertEquals(500, $orderedGoodiesItem->getSellingPrice());
+        $this->assertEquals($orderId, $orderedGoodiesItem->getOrderId());
     }
 
     /**
@@ -130,6 +141,33 @@ class CreateSeedsCommandTest extends TestCase
     }
 
     /**
+     * The seeded order is fully paid so that the invoice page shows the
+     * "Règlement effectué le… par…" notice.
+     *
+     * @throws PropelException
+     */
+    public function testExecuteSeedsAPaidOrder(): void
+    {
+        // given
+        $commandTester = new CommandTester(new CreateSeedsCommand());
+
+        // when
+        $commandTester->execute([]);
+
+        // then
+        $order = OrderQuery::create()->findOne();
+        $this->assertNotNull($order->getPaymentDate(), "La commande des seeds doit être marquée comme payée");
+        $this->assertEquals("stripe", $order->getPaymentMode());
+        $this->assertEquals(0, $order->getAmountTobepaid());
+
+        $payment = PaymentQuery::create()->filterByOrderId($order->getId())->findOne();
+        $this->assertNotNull($payment, "Un paiement doit être rattaché à la commande des seeds");
+        $this->assertEquals(1800 + 500 + 300, $payment->getAmount());
+        $this->assertEquals("stripe", $payment->getMode());
+        $this->assertNotNull($payment->getExecuted());
+    }
+
+    /**
      * @throws PropelException
      */
     public function testExecuteSeedsCatalogArticlesWithAuthorAndNewStockItem(): void
@@ -150,8 +188,8 @@ class CreateSeedsCommandTest extends TestCase
                 $article->getAuthors()
             );
 
-            $stockItems = StockQuery::create()->filterByArticle($article)->find();
-            $this->assertCount(1, $stockItems, "Article {$catalogArticle["title"]} should have one stock item");
+            $stockItems = StockQuery::create()->filterByArticle($article)->filterByOrderId(null)->find();
+            $this->assertCount(1, $stockItems, "Article {$catalogArticle["title"]} should have one unordered stock item");
             $this->assertEquals("Neuf", $stockItems[0]->getCondition());
             $this->assertEquals($catalogArticle["price"], $stockItems[0]->getSellingPrice());
         }


### PR DESCRIPTION
## Changes

- Le SIREN apparaît désormais dans l'en-tête de la facture. Il peut être défini
  via l'option de site siren.
- La date de la commande est désormais affichée sous le numéro de facture.
- La colonne "État" est désormais masquée si tous les articles d'une commande sont tous "neuf", en dérivant l'affichage des données réelles de la commande.
- La colonne "TVA" (montant) du détail par article est désormais masquée.
- Le tableau de répartition TVA et le bloc "Total TTC" ont été remplacés par une liste unifiée en bas de facture (Sous-total HT, TVA par taux, Total TTC).

## Test plan

- [x] `composer test:path tests/AppBundle/Controller/OrderControllerTest.php` — 25 tests, tous verts
- [x] `composer test:path tests/Command/CreateSeedsCommandTest.php` — 3 tests, tous verts
- [x] `composer test` — suite complète (1292 tests), plus de warning de migration
- [x] Vérifier visuellement une facture avec un seul taux de TVA
- [x] Vérifier visuellement une facture avec plusieurs taux de TVA (répartition port comprise)
- [x] Vérifier visuellement une facture sans TVA (mention 293B)
- [x] Vérifier visuellement une facture avec des articles d'occasion (colonne État)
- [x] Vérifier que `composer db:seed` insère bien l'article Goodies, la commande mixte, l'adresse et le SIREN
- [x] Vérifier l'affichage de la date, de l'adresse expéditeur et du SIREN sur une facture générée en dev