### PR TITLE
Correctif 3.15.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Historique des modifications
 
+## 3.15.2 (26 août 2026)
+
+### Corrections
+
+- La vignette de couverture affichée dans le résultat d'ajout d'un exemplaire
+  à une liste n'est plus surdimensionnée.
+- La liste de résultats d'ajout d'un exemplaire à une liste est plus lisible :
+  fond opaque, vignettes de taille homogène, séparation entre les résultats.
+
 ## 3.15.1 (19 août 2026)
 
 ### Corrections

--- a/controllers/common/php/adm_list.php
+++ b/controllers/common/php/adm_list.php
@@ -152,10 +152,10 @@ return function (
             /** @noinspection JSVoidFunctionReturnValueUsed */
             $articles_in_list .= '
                 <tr id="link_' . $a['link_id'] . '">
-                    <td class="right">
+                    <td class="right align-middle">
                         ' . $copy->getAvailabilityDot() . '
                     </td>
-                    <td><a href="/a/' . $a['article_url'] . '">' . $a['article_title'] . '</a></td>
+                    <td class="align-middle"><a href="/a/' . $a['article_url'] . '">' . $a['article_title'] . '</a></td>
                     <td>' . $a['article_collection'] . '</td>
                     <td data-price=' . $a['stock_selling_price'] . ' data-stock_id=' . $a['stock_id'] . ' data-article_id=' . $a['article_id'] . ' data-article_title="' . $a['article_title'] . '" class="right pointer changePriceInList e">' . price($a['stock_selling_price'], 'EUR') . '</td>
                     <td class="text-right">' . $a['count'] . '</td>

--- a/controllers/common/php/list_xhr.php
+++ b/controllers/common/php/list_xhr.php
@@ -75,6 +75,7 @@ return function (Request $request, CurrentUser $currentUser, ImagesService $imag
         // EXEMPLAIRES
         $num = 0;
         $multiple = null;
+        $sm = new StockManager();
         $articles = EntityManager::prepareAndExecute($req, $params);
         while ($a = $articles->fetch(PDO::FETCH_ASSOC)) {
             $article = ArticleQuery::create()->findPk($a["article_id"]);
@@ -84,32 +85,29 @@ return function (Request $request, CurrentUser $currentUser, ImagesService $imag
                 $a["article_cover"] = null;
             }
 
-            if (!empty($a["stock_cart_date"])) {
-                $a["led"] = "square_gray";
-                $a["led_title"] = "En panier";
-            } else {
-                $a["led"] = "square_green";
-                $a["led_title"] = "En stock";
-            }
-
             // If the item is already in a list, skip it
             $listed = $lm->get(["list_id" => $listId, "stock_id" => $a["stock_id"]]);
             if ($listed) {
                 continue;
             }
 
+            /** @var Stock $stock */
+            $stock = $sm->getById($a["stock_id"]);
+
             $content .= '
-                <li class="choose clearL" onClick="addToList(\'' . $a["stock_id"] . '\',\'' . addslashes($a["article_title"]) . '\')">
-                    ' . $a["article_cover"] . '
-                    <img src="/common/img/' . $a["led"] . '.png" width="8" height="8" title="' . $a["led_title"] . '" alt="' . $a["led_title"] . '" /> 
-                      <strong>' . $a["article_title"] . '</strong>
-                      <br />
-                    ' . $a["article_authors"] . '<br />
-                    ' . $a["article_collection"] . ' ' . numero($a["article_number"]) . '<br />
-                    ' . price($a["stock_selling_price"], 'EUR') . ' (' . $a["stock_condition"] . ')<br />
-                    Ref. ' . $a["stock_id"] . '<br />
-                    Empl. : ' . $a["stock_stockage"] . '<br />
-                    <div class="clearL"></div>
+                <li class="choose" onClick="addToList(\'' . $a["stock_id"] . '\',\'' . addslashes($a["article_title"]) . '\')">
+                    <div class="autocomplete-cover">' . $a["article_cover"] . '</div>
+                    <div class="autocomplete-info">
+                        <div class="autocomplete-title">
+                            ' . $stock->getAvailabilityDot() . '
+                            <strong>' . $a["article_title"] . '</strong>
+                        </div>
+                        ' . $a["article_authors"] . '<br />
+                        ' . $a["article_collection"] . ' ' . numero($a["article_number"]) . '<br />
+                        ' . price($a["stock_selling_price"], 'EUR') . ' (' . $a["stock_condition"] . ')<br />
+                        Ref. ' . $a["stock_id"] . '<br />
+                        Empl. : ' . $a["stock_stockage"] . '<br />
+                    </div>
                 </li>
             ';
             $num++;
@@ -139,30 +137,12 @@ return function (Request $request, CurrentUser $currentUser, ImagesService $imag
                     ["list_id" => $listId, "stock_id" => $stockId]
                 );
 
-                if (!empty($stock->get("return_date"))) {
-                    $led = "square_orange";
-                    $ledTitle = "Retourné";
-                } elseif (!empty($stock->get("selling_date"))) {
-                    $led = "square_blue";
-                    $ledTitle = "Vendu";
-                } elseif (!empty($stock->get("lost_date"))) {
-                    $led = "square_purple";
-                    $ledTitle = "Perdu";
-                } elseif (!empty($stock->get("cart_date"))) {
-                    $led = "square_gray";
-                    $ledTitle = "En panier";
-                } else {
-                    $led = "square_green";
-                    $ledTitle = "En stock";
-                }
-
                 $article = $stock->getArticle();
 
                 $content .= '
                     <tr id="link_' . $link->get("id") . '">
                         <td>
-                            <img src="/common/img/' . $led . '.png" width="8" height="8"
-                                title="' . $ledTitle . '" alt="' . $ledTitle . '">
+                            ' . $stock->getAvailabilityDot() . '
                         </td>
                         <td>
                             <a href="/' . $article->get("url") . '">

--- a/controllers/common/php/list_xhr.php
+++ b/controllers/common/php/list_xhr.php
@@ -79,7 +79,7 @@ return function (Request $request, CurrentUser $currentUser, ImagesService $imag
         while ($a = $articles->fetch(PDO::FETCH_ASSOC)) {
             $article = ArticleQuery::create()->findPk($a["article_id"]);
             if ($imagesService->imageExistsFor($article)) {
-                $a["article_cover"] = '<img src="' . $imagesService->getImageUrlFor($article, height: 60) . '" />';
+                $a["article_cover"] = '<img src="' . $imagesService->getImageUrlFor($article, height: 60) . '" height="60" />';
             } else {
                 $a["article_cover"] = null;
             }

--- a/inc/constants.php
+++ b/inc/constants.php
@@ -15,4 +15,4 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-const BIBLYS_VERSION = "3.15.1";
+const BIBLYS_VERSION = "3.15.2";

--- a/public/common/css/common.css
+++ b/public/common/css/common.css
@@ -597,18 +597,26 @@ progress {
   padding: 0;
   margin: 0;
   background: white;
-  background: rgba(255, 255, 255, 0.9);
   border: 1px solid black;
   list-style-type: none;
   margin-left: 157px;
+  max-width: 500px;
   position: absolute;
 }
 
 .autocompleteResults li {
+  display: flex;
+  align-items: flex-start;
+  gap: 15px;
   font-family: sans-serif;
   padding: 5px 10px;
   cursor: pointer;
   color: black;
+  border-bottom: 1px solid #ddd;
+}
+
+.autocompleteResults li:last-child {
+  border-bottom: none;
 }
 
 .autocompleteResults li:hover {
@@ -616,9 +624,21 @@ progress {
   color: white;
 }
 
-.autocompleteResults li img {
-  float: left;
-  margin-right: 15px;
+.autocompleteResults .autocomplete-cover img {
+  display: block;
+  width: 60px;
+  height: 60px;
+  object-fit: cover;
+}
+
+.autocompleteResults .autocomplete-info {
+  min-width: 0;
+}
+
+.autocompleteResults .autocomplete-title {
+  display: flex;
+  align-items: center;
+  gap: 6px;
 }
 
 /* Not full screen overlay fix */
@@ -1428,8 +1448,9 @@ table.unfold tbody {
 .availability-dot {
   align-items: center;
   background: black;
-  border-radius: 50%;
+  border-radius: 4px;
   display: flex;
+  font-size: 12px;
   font-weight: bold;
   justify-content: center;
   color: white;


### PR DESCRIPTION
## Résumé
- La vignette de couverture affichée dans le résultat d'ajout d'un exemplaire à une liste n'est plus surdimensionnée.
- La liste de résultats d'ajout d'un exemplaire à une liste est plus lisible : fond opaque, vignettes de taille homogène, séparation entre les résultats.

## Plan de test
- [x] Ajouter un exemplaire à une liste depuis l'administration et vérifier que la vignette de couverture s'affiche à une taille raisonnable et homogène dans les résultats d'autocomplétion.
- [x] Vérifier que le popup de résultats est lisible (fond opaque, résultats séparés).