### PR TITLE
Ajouter un filtre Twig pour récupérer une liste d'articles par IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
   moyens de paiement acceptés (CB, Visa, Mastercard), ainsi que le logo
   Apple Pay lorsque ce moyen de paiement est activé sur le compte PayPlug.
 - La lisibilité de la page "Mon compte" a été améliorée.
+- Un nouveau filtre Twig `articles` permet à un thème de résoudre, directement
+  dans un template, une liste d'identifiants d'articles séparés par des
+  virgules en objets Article.
 
 ### Améliorations des factures
 

--- a/inc/constants.php
+++ b/inc/constants.php
@@ -15,4 +15,4 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-const BIBLYS_VERSION = "3.16.0-dev";
+const BIBLYS_VERSION = "3.16.0-dev.1";

--- a/src/Biblys/Service/TemplateService.php
+++ b/src/Biblys/Service/TemplateService.php
@@ -26,6 +26,7 @@ use Cart;
 use Exception;
 use Framework\TemplateLoader;
 use Model\Article;
+use Model\ArticleQuery;
 use Model\Event;
 use Model\People;
 use Model\Post;
@@ -332,6 +333,23 @@ class TemplateService
 
         $filters[] = new TwigFilter('currency', function ($amount, $cents = false) {
             return currency($amount, $cents);
+        });
+
+        // resolve a comma-separated list of article ids into an array of articles
+        $filters[] = new TwigFilter('articles', function (?string $ids) {
+            if (!$ids) {
+                return [];
+            }
+
+            $articles = [];
+            foreach (explode(',', $ids) as $id) {
+                $article = ArticleQuery::create()->findPk((int) trim($id));
+                if ($article) {
+                    $articles[] = $article;
+                }
+            }
+
+            return $articles;
         });
 
         $filters[] = new TwigFilter('date', function ($date, $format = 'd/m/Y') {

--- a/tests/AppBundle/Controller/MainControllerTest.php
+++ b/tests/AppBundle/Controller/MainControllerTest.php
@@ -161,6 +161,49 @@ class MainControllerTest extends TestCase
     }
 
     /**
+     * @throws PropelException
+     * @throws Exception|\PHPUnit\Framework\MockObject\Exception
+     */
+    public function testHomeWithPostsAndNoBooksConfigured()
+    {
+        // given
+        $controller = new MainController();
+        $request = new Request();
+        $site = EntityFactory::createSite();
+        $site->setOpt("home", "posts");
+        $config = new Config();
+        $config->set("site", $site->get("site_id"));
+        $config->set("environment", "test");
+        $mailer = Mockery::mock(Mailer::class);
+        $session = new Session();
+        $currentSite = CurrentSite::buildFromConfig($config);
+        $urlGenerator = $this->createMock(UrlGenerator::class);
+        $currentUser = CurrentUser::buildFromRequestAndConfig($request, $config);
+        $metaTagsService = $this->createMock(MetaTagsService::class);
+        $templateService = Helpers::getTemplateService();
+
+        // when
+        $response = $controller->homeAction(
+            request: $request,
+            session: $session,
+            mailer: $mailer,
+            config: $config,
+            currentSite: $currentSite,
+            currentUser: $currentUser,
+            urlGenerator: $urlGenerator,
+            templateService: $templateService,
+            metaTagsService: $metaTagsService,
+        );
+
+        // then
+        $this->assertEquals(
+            200,
+            $response->getStatusCode(),
+            "it should return HTTP 200 even without any book configured"
+        );
+    }
+
+    /**
      * @throws LoaderError
      * @throws RuntimeError
      * @throws SyntaxError

--- a/tests/Biblys/Service/TemplateServiceTest.php
+++ b/tests/Biblys/Service/TemplateServiceTest.php
@@ -18,6 +18,7 @@
 
 namespace Biblys\Service;
 
+use Biblys\Test\EntityFactory;
 use Biblys\Test\Helpers;
 use PHPUnit\Framework\MockObject\Exception;
 use PHPUnit\Framework\TestCase;
@@ -154,5 +155,73 @@ class TemplateServiceTest extends TestCase
         $this->assertInstanceOf(Response::class, $response);
         $this->assertEquals("no-store, private", $response->headers->get("Cache-Control"));
         $this->assertEquals("Hello <b>World</b>!", $response->getContent());
+    }
+
+    /** articles filter */
+
+    /**
+     * @throws PropelException
+     * @throws \Exception
+     */
+    public function testArticlesFilterResolvesIdsToArticles()
+    {
+        // given
+        EntityFactory::createSite();
+        $article = EntityFactory::createArticle(title: "Les Ombres de Septembre");
+        $templateService = Helpers::getTemplateService();
+
+        // when
+        $response = $templateService->renderResponseFromString(
+            "{% for article in ids|articles %}{{ article.title }}{% endfor %}",
+            ["ids" => (string) $article->get("id")]
+        );
+
+        // then
+        $this->assertStringContainsString("Les Ombres de Septembre", $response->getContent());
+    }
+
+    /**
+     * @throws PropelException
+     * @throws \Exception
+     */
+    public function testArticlesFilterResolvesSeveralCommaSeparatedIds()
+    {
+        // given
+        EntityFactory::createSite();
+        $first = EntityFactory::createArticle(title: "Le Premier Tome");
+        $second = EntityFactory::createArticle(title: "Le Second Tome");
+        $templateService = Helpers::getTemplateService();
+
+        // when
+        $response = $templateService->renderResponseFromString(
+            "{% for article in ids|articles %}{{ article.title }};{% endfor %}",
+            ["ids" => $first->get("id").",".$second->get("id")]
+        );
+
+        // then
+        $this->assertEquals(
+            "Le Premier Tome;Le Second Tome;",
+            $response->getContent()
+        );
+    }
+
+    /**
+     * @throws PropelException
+     * @throws \Exception
+     */
+    public function testArticlesFilterReturnsEmptyArrayForNull()
+    {
+        // given
+        EntityFactory::createSite();
+        $templateService = Helpers::getTemplateService();
+
+        // when
+        $response = $templateService->renderResponseFromString(
+            "{% for article in ids|articles %}{{ article.title }}{% endfor %}empty",
+            ["ids" => null]
+        );
+
+        // then
+        $this->assertEquals("empty", $response->getContent());
     }
 }


### PR DESCRIPTION
## Résumé

- Ajoute un filtre Twig générique `articles` (`src/Biblys/Service/TemplateService.php`) : transforme une chaîne d'IDs d'articles séparés par des virgules en tableau d'entités Article, directement depuis un template de thème.
- Objectif : permettre à un thème de composer librement des listes de livres (ex. sur la page d'accueil) sans dépendre d'une logique spécifique côté contrôleur cœur.

## Test plan

- [x] `composer test:path tests/Biblys/Service/TemplateServiceTest.php` (nouveaux tests : un ID, plusieurs IDs séparés par des virgules, valeur nulle)
- [x] `composer test:path tests/AppBundle/Controller/MainControllerTest.php`
- [x] Vérifié manuellement sur le thème Flatland (page d'accueil affichant plusieurs livres par colonne, IDs configurés via une option de site)