### PR TITLE
Paiement en espèces au retrait en magasin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 3.17.0 (DEV)
 
+### Améliorations
+
+- Un nouveau moyen de paiement en espèces peut être activé via l'option de
+  site `payment_cash`. Il n'est proposé que pour les commandes retirées en
+  magasin.
+
 ## 3.16.0 (2 septembre 2026)
 
 ### Améliorations

--- a/src/AppBundle/Controller/PaymentController.php
+++ b/src/AppBundle/Controller/PaymentController.php
@@ -358,6 +358,7 @@ class PaymentController extends Controller
                 "paymentIban" => $currentSite->getOption("payment_iban"),
                 "checkIsAvailable" => !!$currentSite->getOption("payment_check"),
                 "nameForCheckPayment" => $currentSite->getOption("name_for_check_payment"),
+                "cashIsAvailable" => !!$currentSite->getOption("payment_cash") && $orderWillBeCollected,
                 "orderWillBeShipped" => $orderWillBeShipped,
                 "orderWillBeCollected" => $orderWillBeCollected,
             ], isPrivate: true);

--- a/src/AppBundle/Resources/views/Payment/select-method.html.twig
+++ b/src/AppBundle/Resources/views/Payment/select-method.html.twig
@@ -273,6 +273,29 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
         </div>
       </div>
     {% endif %}
+
+    {% if cashIsAvailable %}
+      <div class="card payment-option">
+        <div class="card-header">
+          <h5 class="radio mb-0">
+            <a href="#collapse-cash" data-toggle="collapse" data-target="#collapse-cash" aria-expanded="false"
+               aria-controls="collapse-cash">
+              <i class="fa-solid fa-money-bill-wave"></i>&nbsp;
+              Espèces
+            </a>
+          </h5>
+        </div>
+
+        <div id="collapse-cash" class="collapse" aria-labelledby="headingTwo" data-parent="#payment-methods-accordion">
+          <div class="card-body">
+            <p class="alert alert-warning mb-0">
+              <i class="fa-solid fa-clock"></i>&nbsp;
+              Réglez en espèces lors du retrait de votre commande en magasin.
+            </p>
+          </div>
+        </div>
+      </div>
+    {% endif %}
   </div>
 
   {% if stripeIsAvailable %}

--- a/src/Command/CreateSeedsCommand.php
+++ b/src/Command/CreateSeedsCommand.php
@@ -79,6 +79,9 @@ class CreateSeedsCommand extends Command
         $currentSite->setOption("siren", "123 456 789");
         $output->writeln(["Inserted site option: siren"]);
 
+        $currentSite->setOption("payment_cash", "1");
+        $output->writeln(["Inserted site option: payment_cash"]);
+
         // Admin
         $admin = new User();
         $admin->setEmail("admin@paronymie.fr");
@@ -155,6 +158,7 @@ class CreateSeedsCommand extends Command
         // Catalog articles, each with its author and one new stock item
         $slugService = new SlugService();
         $orderedCatalogArticle = null;
+        $catalogArticleModels = [];
         foreach (self::CATALOG_ARTICLES as $catalogArticle) {
             $author = ModelFactory::createContributor(
                 firstName: $catalogArticle["firstName"],
@@ -178,6 +182,8 @@ class CreateSeedsCommand extends Command
                 article: $catalogArticleModel,
                 sellingPrice: $catalogArticle["price"],
             );
+
+            $catalogArticleModels[$catalogArticle["title"]] = $catalogArticleModel;
 
             if ($catalogArticle["title"] === "Au-revoir Mao") {
                 $orderedCatalogArticle = $catalogArticleModel;
@@ -240,6 +246,27 @@ class CreateSeedsCommand extends Command
         $order->setAmountTobepaid(0);
         $order->save();
         $output->writeln(["Inserted payment for order"]);
+
+        // Order to be paid, picked up in-store so the cash payment option can be tested
+        $pickupShippingOption = new ShippingOption();
+        $pickupShippingOption->setMode("Retrait en magasin");
+        $pickupShippingOption->setType("magasin");
+        $pickupShippingOption->setShippingZoneId(1);
+        $pickupShippingOption->setFee(0);
+        $pickupShippingOption->save();
+        $output->writeln(["Inserted shipping option: Retrait en magasin"]);
+
+        $orderToBePaid = ModelFactory::createOrder(
+            shippingOption: $pickupShippingOption,
+            amount: 900,
+            amountToBePaid: 900,
+        );
+        ModelFactory::createStockItem(
+            article: $catalogArticleModels["Papeete"],
+            order: $orderToBePaid,
+            sellingPrice: 900,
+        );
+        $output->writeln(["Inserted order to be paid: {$orderToBePaid->getSlug()}"]);
 
         $output->writeln(["Seeds generated!"]);
         return 0;

--- a/src/Command/CreateSeedsCommand.php
+++ b/src/Command/CreateSeedsCommand.php
@@ -267,6 +267,7 @@ class CreateSeedsCommand extends Command
             shippingOption: $pickupShippingOption,
             amount: 900,
             amountToBePaid: 900,
+            slug: "order-to-pay",
             firstName: "Sacha",
             lastName: "Hutte",
             email: "sacha.hutte@paronymie.fr",

--- a/src/Command/CreateSeedsCommand.php
+++ b/src/Command/CreateSeedsCommand.php
@@ -256,11 +256,24 @@ class CreateSeedsCommand extends Command
         $pickupShippingOption->save();
         $output->writeln(["Inserted shipping option: Retrait en magasin"]);
 
+        $pickupCustomer = ModelFactory::createCustomer(
+            firstName: "Sacha",
+            lastName: "Hutte",
+            email: "sacha.hutte@paronymie.fr",
+        );
+
         $orderToBePaid = ModelFactory::createOrder(
+            customer: $pickupCustomer,
             shippingOption: $pickupShippingOption,
             amount: 900,
             amountToBePaid: 900,
+            firstName: "Sacha",
+            lastName: "Hutte",
+            email: "sacha.hutte@paronymie.fr",
         );
+        $orderToBePaid->setConfirmationDate(new DateTime());
+        $orderToBePaid->save();
+
         ModelFactory::createStockItem(
             article: $catalogArticleModels["Papeete"],
             order: $orderToBePaid,

--- a/tests/AppBundle/Controller/PaymentControllerTest.php
+++ b/tests/AppBundle/Controller/PaymentControllerTest.php
@@ -462,6 +462,7 @@ class PaymentControllerTest extends TestCase
         $currentSite = Mockery::mock(CurrentSite::class);
         $currentSite->shouldReceive("getOption")->with("payment_iban")->andReturn(null);
         $currentSite->shouldReceive("getOption")->with("payment_check")->andReturn(null);
+        $currentSite->shouldReceive("getOption")->with("payment_cash")->andReturn(null);
         $currentSite->shouldReceive("getOption")->with("name_for_check_payment")->andReturn(null);
         $templateService = Helpers::getTemplateService();
         $paymentService = Mockery::mock(PaymentService::class);
@@ -507,6 +508,7 @@ class PaymentControllerTest extends TestCase
         $currentSite = Mockery::mock(CurrentSite::class);
         $currentSite->shouldReceive("getOption")->with("payment_iban")->andReturn(null);
         $currentSite->shouldReceive("getOption")->with("payment_check")->andReturn(null);
+        $currentSite->shouldReceive("getOption")->with("payment_cash")->andReturn(null);
         $currentSite->shouldReceive("getOption")->with("name_for_check_payment")->andReturn(null);
         $templateService = Helpers::getTemplateService();
         $paymentService = Mockery::mock(PaymentService::class);
@@ -532,6 +534,7 @@ class PaymentControllerTest extends TestCase
         $currentSite = Mockery::mock(CurrentSite::class);
         $currentSite->shouldReceive("getOption")->with("payment_iban")->andReturn(null);
         $currentSite->shouldReceive("getOption")->with("payment_check")->andReturn(null);
+        $currentSite->shouldReceive("getOption")->with("payment_cash")->andReturn(null);
         $currentSite->shouldReceive("getOption")->with("name_for_check_payment")->andReturn(null);
         $templateService = Helpers::getTemplateService();
         $paymentService = Mockery::mock(PaymentService::class);
@@ -560,6 +563,7 @@ class PaymentControllerTest extends TestCase
         $currentSite = Mockery::mock(CurrentSite::class);
         $currentSite->shouldReceive("getOption")->with("payment_iban")->andReturn(null);
         $currentSite->shouldReceive("getOption")->with("payment_check")->andReturn(null);
+        $currentSite->shouldReceive("getOption")->with("payment_cash")->andReturn(null);
         $currentSite->shouldReceive("getOption")->with("name_for_check_payment")->andReturn(null);
         $templateService = Helpers::getTemplateService();
         $paymentService = Mockery::mock(PaymentService::class);
@@ -588,6 +592,7 @@ class PaymentControllerTest extends TestCase
         $currentSite = Mockery::mock(CurrentSite::class);
         $currentSite->shouldReceive("getOption")->with("payment_iban")->andReturn(null);
         $currentSite->shouldReceive("getOption")->with("payment_check")->andReturn(null);
+        $currentSite->shouldReceive("getOption")->with("payment_cash")->andReturn(null);
         $currentSite->shouldReceive("getOption")->with("name_for_check_payment")->andReturn(null);
         $templateService = Helpers::getTemplateService();
         $paymentService = Mockery::mock(PaymentService::class);
@@ -620,6 +625,7 @@ class PaymentControllerTest extends TestCase
         $currentSite = Mockery::mock(CurrentSite::class);
         $currentSite->shouldReceive("getOption")->with("payment_iban")->andReturn(null);
         $currentSite->shouldReceive("getOption")->with("payment_check")->andReturn(null);
+        $currentSite->shouldReceive("getOption")->with("payment_cash")->andReturn(null);
         $currentSite->shouldReceive("getOption")->with("name_for_check_payment")->andReturn(null);
         $templateService = Helpers::getTemplateService();
         $paymentService = Mockery::mock(PaymentService::class);
@@ -648,6 +654,7 @@ class PaymentControllerTest extends TestCase
         $currentSite = Mockery::mock(CurrentSite::class);
         $currentSite->shouldReceive("getOption")->with("payment_iban")->andReturn(null);
         $currentSite->shouldReceive("getOption")->with("payment_check")->andReturn(null);
+        $currentSite->shouldReceive("getOption")->with("payment_cash")->andReturn(null);
         $currentSite->shouldReceive("getOption")->with("name_for_check_payment")->andReturn(null);
         $templateService = Helpers::getTemplateService();
         $paymentService = Mockery::mock(PaymentService::class);
@@ -676,6 +683,7 @@ class PaymentControllerTest extends TestCase
         $currentSite = Mockery::mock(CurrentSite::class);
         $currentSite->shouldReceive("getOption")->with("payment_iban")->andReturn("PAYMENT_IBAN");
         $currentSite->shouldReceive("getOption")->with("payment_check")->andReturn(null);
+        $currentSite->shouldReceive("getOption")->with("payment_cash")->andReturn(null);
         $currentSite->shouldReceive("getOption")->with("name_for_check_payment")->andReturn(null);
         $templateService = Helpers::getTemplateService();
         $paymentService = Mockery::mock(PaymentService::class);
@@ -706,6 +714,7 @@ class PaymentControllerTest extends TestCase
         $currentSite = Mockery::mock(CurrentSite::class);
         $currentSite->shouldReceive("getOption")->with("payment_iban")->andReturn(null);
         $currentSite->shouldReceive("getOption")->with("payment_check")->andReturn(1);
+        $currentSite->shouldReceive("getOption")->with("payment_cash")->andReturn(null);
         $currentSite->shouldReceive("getOption")->with("name_for_check_payment")->andReturn("L’ordre");
         $templateService = Helpers::getTemplateService();
         $paymentService = Mockery::mock(PaymentService::class);
@@ -742,6 +751,7 @@ class PaymentControllerTest extends TestCase
         $currentSite = Mockery::mock(CurrentSite::class);
         $currentSite->shouldReceive("getOption")->with("payment_iban")->andReturn(null);
         $currentSite->shouldReceive("getOption")->with("payment_check")->andReturn(1);
+        $currentSite->shouldReceive("getOption")->with("payment_cash")->andReturn(null);
         $currentSite->shouldReceive("getOption")->with("name_for_check_payment")->andReturn("L’ordre");
         $templateService = Helpers::getTemplateService();
         $paymentService = Mockery::mock(PaymentService::class);
@@ -758,6 +768,72 @@ class PaymentControllerTest extends TestCase
             $response->getContent()
         );
         $this->assertStringNotContainsString("Envoyez votre chèque", $response->getContent());
+    }
+
+    /**
+     * @throws SyntaxError
+     * @throws RuntimeError
+     * @throws PropelException
+     * @throws LoaderError
+     * @throws Exception
+     */
+    public function testSelectMethodActionWithCashAndInStorePickup()
+    {
+        // given
+        $controller = new PaymentController();
+        $shippingOption = ModelFactory::createShippingOption(type: "magasin");
+        $order = ModelFactory::createOrder(shippingOption: $shippingOption);
+        $config = new Config();
+        $currentSite = Mockery::mock(CurrentSite::class);
+        $currentSite->shouldReceive("getOption")->with("payment_iban")->andReturn(null);
+        $currentSite->shouldReceive("getOption")->with("payment_check")->andReturn(null);
+        $currentSite->shouldReceive("getOption")->with("name_for_check_payment")->andReturn(null);
+        $currentSite->shouldReceive("getOption")->with("payment_cash")->andReturn(1);
+        $templateService = Helpers::getTemplateService();
+        $paymentService = Mockery::mock(PaymentService::class);
+        $paymentService->expects("getPayableOrderBySlug")->andReturn($order);
+
+        // when
+        $response = $controller->selectMethodAction($paymentService, $config, $currentSite, $templateService, $order->getSlug());
+
+        // then
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertStringContainsString("Espèces", $response->getContent());
+        $this->assertStringContainsString(
+            "Réglez en espèces lors du retrait de votre commande en magasin.",
+            $response->getContent()
+        );
+    }
+
+    /**
+     * @throws SyntaxError
+     * @throws RuntimeError
+     * @throws PropelException
+     * @throws LoaderError
+     * @throws Exception
+     */
+    public function testSelectMethodActionWithCashOptionEnabledButOrderShipped()
+    {
+        // given
+        $controller = new PaymentController();
+        $order = ModelFactory::createOrder();
+        $config = new Config();
+        $currentSite = Mockery::mock(CurrentSite::class);
+        $currentSite->shouldReceive("getOption")->with("payment_iban")->andReturn(null);
+        $currentSite->shouldReceive("getOption")->with("payment_check")->andReturn(null);
+        $currentSite->shouldReceive("getOption")->with("name_for_check_payment")->andReturn(null);
+        $currentSite->shouldReceive("getOption")->with("payment_cash")->andReturn(1);
+        $templateService = Helpers::getTemplateService();
+        $paymentService = Mockery::mock(PaymentService::class);
+        $paymentService->expects("getPayableOrderBySlug")->andReturn($order);
+
+        // when
+        $response = $controller->selectMethodAction($paymentService, $config, $currentSite, $templateService, $order->getSlug());
+
+        // then
+        $this->assertEquals(200, $response->getStatusCode());
+        $paymentMethodsSection = $this->extractPaymentMethodsSection($response->getContent());
+        $this->assertStringNotContainsString("Espèces", $paymentMethodsSection);
     }
 
     /** createPayplugPaymentAction */

--- a/tests/Command/CreateSeedsCommandTest.php
+++ b/tests/Command/CreateSeedsCommandTest.php
@@ -40,6 +40,7 @@ class CreateSeedsCommandTest extends TestCase
     private const SEEDED_ARTICLE_TITLE = "L'Ordure du jeu";
     private const SEEDED_ORDERED_CATALOG_TITLE = "Au-revoir Mao";
     private const SEEDED_GOODIES_TITLE = "Tote bag Paronymie";
+    private const SEEDED_TO_BE_PAID_CATALOG_TITLE = "Papeete";
 
     /**
      * The command is not idempotent: Publisher, BookCollection and People
@@ -96,7 +97,7 @@ class CreateSeedsCommandTest extends TestCase
         $this->assertStringContainsString("Seeds generated!", $commandTester->getDisplay());
 
         $stockItems = StockQuery::create()->orderById()->find();
-        $expectedCount = 3 + count(CreateSeedsCommand::CATALOG_ARTICLES);
+        $expectedCount = 4 + count(CreateSeedsCommand::CATALOG_ARTICLES);
         $this->assertCount($expectedCount, $stockItems);
 
         $availableItem = $stockItems[0];
@@ -104,17 +105,22 @@ class CreateSeedsCommandTest extends TestCase
         $this->assertEquals(999, $availableItem->getSellingPrice());
         $this->assertNull($availableItem->getOrderId());
 
-        $orderId = OrderQuery::create()->findOne()->getId();
+        $orderId = OrderQuery::create()->filterByShippingCost(300)->findOne()->getId();
 
-        $orderedItem = $stockItems[$expectedCount - 2];
+        $orderedItem = $stockItems[$expectedCount - 3];
         $this->assertEquals(self::SEEDED_ORDERED_CATALOG_TITLE, $orderedItem->getArticle()->getTitle());
         $this->assertEquals(1800, $orderedItem->getSellingPrice());
         $this->assertEquals($orderId, $orderedItem->getOrderId());
 
-        $orderedGoodiesItem = $stockItems[$expectedCount - 1];
+        $orderedGoodiesItem = $stockItems[$expectedCount - 2];
         $this->assertEquals(self::SEEDED_GOODIES_TITLE, $orderedGoodiesItem->getArticle()->getTitle());
         $this->assertEquals(500, $orderedGoodiesItem->getSellingPrice());
         $this->assertEquals($orderId, $orderedGoodiesItem->getOrderId());
+
+        $orderToBePaidItem = $stockItems[$expectedCount - 1];
+        $this->assertEquals(self::SEEDED_TO_BE_PAID_CATALOG_TITLE, $orderToBePaidItem->getArticle()->getTitle());
+        $this->assertEquals(900, $orderToBePaidItem->getSellingPrice());
+        $this->assertNotEquals($orderId, $orderToBePaidItem->getOrderId());
     }
 
     /**
@@ -132,7 +138,7 @@ class CreateSeedsCommandTest extends TestCase
         $commandTester->execute([]);
 
         // then
-        $order = OrderQuery::create()->findOne();
+        $order = OrderQuery::create()->filterByShippingCost(300)->findOne();
         $this->assertEquals(300, $order->getShippingCost());
         $this->assertNotNull($order->getShippingMode(), "Le mode d'expédition doit être renseigné pour la ligne de port");
 
@@ -155,7 +161,7 @@ class CreateSeedsCommandTest extends TestCase
         $commandTester->execute([]);
 
         // then
-        $order = OrderQuery::create()->findOne();
+        $order = OrderQuery::create()->filterByShippingCost(300)->findOne();
         $this->assertNotNull($order->getPaymentDate(), "La commande des seeds doit être marquée comme payée");
         $this->assertEquals("stripe", $order->getPaymentMode());
         $this->assertEquals(0, $order->getAmountTobepaid());


### PR DESCRIPTION
## Résumé

Closes #653

- Nouvelle option de site `payment_cash` : lorsqu'elle est activée, un moyen de paiement "Espèces" apparaît sur la page de paiement en ligne, uniquement pour les commandes retirées en magasin (jamais pour une commande expédiée).
- Ajout d'une commande à payer dans les seeds de développement (retrait en magasin, client "Sacha Hutte", slug `order-to-pay`) pour tester manuellement la page de paiement.

## Test plan

- [x] `composer test` (suite complète, 1304 tests)
- [x] `composer test:path tests/AppBundle/Controller/PaymentControllerTest.php`
- [x] `composer test:path tests/Command/CreateSeedsCommandTest.php`