### PR TITLE
Correctif 3.16.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Historique des modifications
 
+## 3.16.1 (2 septembre 2026)
+
+### Corrections
+
+- La recherche d'articles avec le filtre "Articles en stock uniquement" ne
+  provoque plus d'erreur.
+- Le bouton "Copier l'URL" du gestionnaire de médias copie l'URL dans le
+  presse-papiers.
+
 ## 3.16.0 (2 septembre 2026)
 
 ### Améliorations

--- a/controllers/common/php/adm_media.php
+++ b/controllers/common/php/adm_media.php
@@ -236,7 +236,7 @@ function _displayMediaFile(string $getDir, CurrentSite $currentSite, string $fil
 
 <form class="my-4">
   <div class="input-group">
-    <input class="form-control search- mt-0" value="$mediaUrl" readonly>
+    <input id="media-url" class="form-control search- mt-0" value="$mediaUrl" readonly>
     <div class="input-group-append">
       <button id="copy-button" type="button" class="btn btn-info" title="Copier l’URL">
         <span class="fa-solid fa-copy"></span>
@@ -252,6 +252,20 @@ function _displayMediaFile(string $getDir, CurrentSite $currentSite, string $fil
         insertImageButton.addEventListener('click', function() {
             window.opener.CKEDITOR.tools.callFunction('$CKEditorFuncNum', '$mediaUrl');
             window.close();
+        });
+    }
+
+    const copyButton = document.getElementById('copy-button');
+    const mediaUrlInput = document.getElementById('media-url');
+    if (copyButton && mediaUrlInput) {
+        copyButton.addEventListener('click', function() {
+            navigator.clipboard.writeText(mediaUrlInput.value).then(function() {
+                const icon = copyButton.querySelector('span');
+                icon.classList.replace('fa-copy', 'fa-check');
+                setTimeout(function() {
+                    icon.classList.replace('fa-check', 'fa-copy');
+                }, 2000);
+            });
         });
     }
 </script>

--- a/inc/Article.class.php
+++ b/inc/Article.class.php
@@ -1343,7 +1343,7 @@ class ArticleManager extends EntityManager
         $searchCriteria = implode(" AND ", $queryWithParams["query"]);
         $stockCriteria = " AND `stock_selling_date` IS NULL AND `stock_return_date` IS NULL AND `stock_lost_date` IS NULL";
 
-        $options["fields"] = "`articles`.`article_id`, `article_url`, `article_title`, `article_authors`, `publisher_id`, `collection_id`, `cycle_id`, `article_tome`";
+        $options["fields"] = "`articles`.`article_id`, `article_url`, `article_title`, `article_authors`, `publisher_id`, `collection_id`, `cycle_id`, `article_tome`, `type_id`, `article_price`";
         $options["join"] = [["table" => "stock", "key" => "article_id"]];
         $options["group-by"] = "article_id";
 

--- a/tests/ArticleTest.php
+++ b/tests/ArticleTest.php
@@ -1027,5 +1027,15 @@ class ArticleTest extends PHPUnit\Framework\TestCase
             $results[0]->get("id"),
             "returns all articles with available stock"
         );
+        $this->assertEquals(
+            $articleWithStock->getTypeId(),
+            $results[0]->getModel()->getTypeId(),
+            "loads the article's type id, needed to render its cart button"
+        );
+        $this->assertEquals(
+            $articleWithStock->getPrice(),
+            $results[0]->getModel()->getPrice(),
+            "loads the article's price, needed to render its cart button"
+        );
     }
 }


### PR DESCRIPTION
## Résumé

- La recherche d'articles avec le filtre « en stock uniquement » (`in-stock=1`) omettait `type_id` et `article_price` dans les colonnes chargées, ce qui faisait planter le bouton panier (`_cartButton.html.twig`) dès qu'un résultat matchait.
- Ajoute un test de régression sur `ArticleManager::searchWithAvailableStock`.
- Corrige au passage le bouton « Copier l'URL » du gestionnaire de médias, qui n'avait aucun gestionnaire de clic.

## Plan de test

- [x] `composer test:path tests/ArticleTest.php`
- [x] Reproduit et vérifié en local via `http://localhost:8088/articles/search?sort=pubdate|desc&in-stock=1&q=infernus`