### PR TITLE
Correctif 3.16.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
   d'erreur.
 - Un article numérique ajouté au panier via une contrepartie de campagne de
   financement participatif est désormais associé à cette contrepartie.
+- Un article numérique ou un article de service (mécénat, abonnement...) n'est
+  plus facturé au prix d'un ancien exemplaire abandonné dans un panier ; un
+  nouvel exemplaire au prix courant de l'article est désormais créé à chaque
+  ajout au panier, et supprimé lors du retrait du panier.
 
 ## 3.16.1 (2 septembre 2026)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Historique des modifications
 
+## 3.16.2 (2 septembre 2026)
+
+### Corrections
+
+- L'ajout au panier d'une contrepartie de campagne de financement participatif
+  combinant un article physique et un article numérique ne provoque plus
+  d'erreur.
+
 ## 3.16.1 (2 septembre 2026)
 
 ### Corrections

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - L'ajout au panier d'une contrepartie de campagne de financement participatif
   combinant un article physique et un article numérique ne provoque plus
   d'erreur.
+- Un article numérique ajouté au panier via une contrepartie de campagne de
+  financement participatif est désormais associé à cette contrepartie.
 
 ## 3.16.1 (2 septembre 2026)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Historique des modifications
 
-## 3.16.2 (2 septembre 2026)
+## 3.16.2 (9 septembre 2026)
 
 ### Corrections
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
   plus facturé au prix d'un ancien exemplaire abandonné dans un panier ; un
   nouvel exemplaire au prix courant de l'article est désormais créé à chaque
   ajout au panier, et supprimé lors du retrait du panier.
+- Dans la liste "Autres paniers" de la page de caisse, un panier sans titre
+  affiche désormais "Panier n° {id}" au lieu d'un lien vide.
 
 ## 3.16.1 (2 septembre 2026)
 

--- a/inc/Cart.class.php
+++ b/inc/Cart.class.php
@@ -21,9 +21,12 @@ use Biblys\Legacy\LegacyCodeHelper;
 use Biblys\Service\Config;
 use Biblys\Service\CurrentUser;
 use Entity\Exception\CartException;
+use Model\ArticleQuery;
+use Model\CartQuery;
 use Model\WishQuery;
 use Propel\Runtime\Exception\PropelException;
 use Symfony\Component\HttpFoundation\Request;
+use Usecase\AddIntangibleArticleToCartUsecase;
 
 class Cart extends Entity
 {
@@ -428,7 +431,15 @@ class CartManager extends EntityManager
         $articles = json_decode($reward->get('articles'));
         foreach ($articles as $article_id) {
             if ($article = $am->get(array('article_id' => $article_id))) {
-                $this->addArticle($cart, $article, $reward);
+                if ($article->getType()->isPhysical()) {
+                    $this->addArticle($cart, $article, $reward);
+                } else {
+                    $usecase = new AddIntangibleArticleToCartUsecase();
+                    $usecase->execute(
+                        ArticleQuery::create()->findPk($article_id),
+                        CartQuery::create()->findPk($cart->get('id'))
+                    );
+                }
             } else {
                 trigger_error('Article ' . $article_id . ' inconnu.');
             }

--- a/inc/Cart.class.php
+++ b/inc/Cart.class.php
@@ -475,6 +475,14 @@ class CartManager extends EntityManager
             }
         }
 
+        // Intangible articles have no real inventory to keep: delete the stock
+        // item entirely instead of leaving an unclaimed, stale-priced row behind.
+        $article = $stock->get('article');
+        if ($article && !$article->getType()->isPhysical()) {
+            $sm->delete($stock);
+            return true;
+        }
+
         // Remove stock from cart
         $stock->set('cart_id', null);
         $stock->set('stock_cart_date', null);

--- a/inc/Cart.class.php
+++ b/inc/Cart.class.php
@@ -23,6 +23,7 @@ use Biblys\Service\CurrentUser;
 use Entity\Exception\CartException;
 use Model\ArticleQuery;
 use Model\CartQuery;
+use Model\CrowfundingRewardQuery;
 use Model\WishQuery;
 use Propel\Runtime\Exception\PropelException;
 use Symfony\Component\HttpFoundation\Request;
@@ -437,7 +438,8 @@ class CartManager extends EntityManager
                     $usecase = new AddIntangibleArticleToCartUsecase();
                     $usecase->execute(
                         ArticleQuery::create()->findPk($article_id),
-                        CartQuery::create()->findPk($cart->get('id'))
+                        CartQuery::create()->findPk($cart->get('id')),
+                        CrowfundingRewardQuery::create()->findPk($reward->get('id'))
                     );
                 }
             } else {

--- a/inc/constants.php
+++ b/inc/constants.php
@@ -15,4 +15,4 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-const BIBLYS_VERSION = "3.16.0";
+const BIBLYS_VERSION = "3.16.2";

--- a/src/AppBundle/Controller/PointOfSaleController.php
+++ b/src/AppBundle/Controller/PointOfSaleController.php
@@ -139,7 +139,7 @@ class PointOfSaleController extends Controller
                 : null;
             $pointOfSaleCarts[] = [
                 'id' => $pointOfSaleCart->getId(),
-                'title' => $pointOfSaleCart->getTitle(),
+                'title' => $pointOfSaleCart->getTitle() ?: 'Panier n° ' . $pointOfSaleCart->getId(),
                 'seller_email' => $cartSeller?->getEmail() ?? "Vendeur inconnu",
                 'customer_name' => $customerForCart?->getFullName(),
                 'count' => $pointOfSaleCart->getCount(),

--- a/src/Usecase/AddIntangibleArticleToCartUsecase.php
+++ b/src/Usecase/AddIntangibleArticleToCartUsecase.php
@@ -24,8 +24,6 @@ use Model\Article;
 use Model\Cart;
 use Model\CrowfundingReward;
 use Model\Stock;
-use Model\StockQuery;
-use Propel\Runtime\ActiveQuery\Criteria;
 use Propel\Runtime\Exception\PropelException;
 
 class AddIntangibleArticleToCartUsecase
@@ -52,19 +50,9 @@ class AddIntangibleArticleToCartUsecase
             throw new BusinessRuleException("L'article {$article->getTitle()} n'a pas pu être ajouté au panier car il est {$exception->getMessage()}.");
         }
 
-        $stockItem = StockQuery::create()
-            ->filterByArticle($article)
-            ->filterBySellingDate(null, Criteria::ISNULL)
-            ->filterByLostDate(null, Criteria::ISNULL)
-            ->filterByCartDate(null, Criteria::ISNULL)
-            ->filterByReturnDate(null, Criteria::ISNULL)
-            ->findOne();
-
-        if ($stockItem === null) {
-            $stockItem = new Stock();
-            $stockItem->setArticle($article);
-            $stockItem->setSellingPrice($article->getPrice());
-        }
+        $stockItem = new Stock();
+        $stockItem->setArticle($article);
+        $stockItem->setSellingPrice($article->getPrice());
 
         if ($reward) {
             $stockItem->setCampaignId($reward->getCampaignId());

--- a/src/Usecase/AddIntangibleArticleToCartUsecase.php
+++ b/src/Usecase/AddIntangibleArticleToCartUsecase.php
@@ -22,6 +22,7 @@ use Biblys\Exception\ArticleIsUnavailableException;
 use DateTime;
 use Model\Article;
 use Model\Cart;
+use Model\CrowfundingReward;
 use Model\Stock;
 use Model\StockQuery;
 use Propel\Runtime\ActiveQuery\Criteria;
@@ -37,7 +38,7 @@ class AddIntangibleArticleToCartUsecase
      * @throws PropelException
      * @throws BusinessRuleException
      */
-    public function execute(Article $article, Cart $cart): void
+    public function execute(Article $article, Cart $cart, CrowfundingReward $reward = null): void
     {
         if ($article->getType()->isPhysical()) {
             throw new BusinessRuleException(
@@ -63,6 +64,11 @@ class AddIntangibleArticleToCartUsecase
             $stockItem = new Stock();
             $stockItem->setArticle($article);
             $stockItem->setSellingPrice($article->getPrice());
+        }
+
+        if ($reward) {
+            $stockItem->setCampaignId($reward->getCampaignId());
+            $stockItem->setRewardId($reward->getId());
         }
 
         $stockItem->setCart($cart);

--- a/tests/AppBundle/Controller/PointOfSaleControllerTest.php
+++ b/tests/AppBundle/Controller/PointOfSaleControllerTest.php
@@ -27,6 +27,7 @@ use Biblys\Test\EntityFactory;
 use Biblys\Test\Helpers;
 use Biblys\Test\ModelFactory;
 use Mockery;
+use Model\Cart;
 use PHPUnit\Framework\TestCase;
 use Propel\Runtime\Exception\PropelException;
 use Symfony\Component\HttpFoundation\Request;
@@ -173,6 +174,44 @@ class PointOfSaleControllerTest extends TestCase
         $this->assertStringContainsString("stock_{$stockItem->getId()}", $content);
         $this->assertStringContainsString("Le Horla", $content);
         $this->assertStringContainsString('data-price="1899"', $content);
+    }
+
+    /**
+     * @throws PropelException
+     */
+    public function testIndexActionRendersFallbackTitleForOtherCartWithoutTitle(): void
+    {
+        // given
+        $controller = $this->_getController();
+        $cart = EntityFactory::createCart();
+        $request = new Request(query: ['cart_id' => $cart->get('id')]);
+
+        $article = ModelFactory::createArticle(title: "Le Horla", url: "maupassant/le-horla");
+        $stockItem = ModelFactory::createStockItem(article: $article, sellingPrice: 1899);
+        $otherCart = new Cart();
+        $otherCart->setType('shop');
+        $otherCart->setCount(1);
+        $otherCart->setAmount(1899);
+        $otherCart->save();
+        $stockItem->setCartId($otherCart->getId());
+        $stockItem->save();
+
+        $currentUser = Mockery::mock(CurrentUser::class);
+        $currentUser->expects("authAdmin");
+
+        // when
+        $response = $controller->indexAction(
+            $request,
+            $currentUser,
+            $this->_getCurrentSiteMock(),
+            Helpers::getTemplateService(),
+            Mockery::mock(UrlGenerator::class),
+            new QueryParamsService($request),
+        );
+
+        // then
+        $content = $response->getContent();
+        $this->assertStringContainsString("Panier n° {$otherCart->getId()}", $content);
     }
 
     /**

--- a/tests/CartTest.php
+++ b/tests/CartTest.php
@@ -551,6 +551,10 @@ class CartTest extends PHPUnit\Framework\TestCase
             $cart->containsArticle($ebook),
             "it should add the intangible article to the cart"
         );
+        $this->assertTrue(
+            $cart->containsReward($reward),
+            "it should tag the intangible article's stock item with the reward"
+        );
     }
 
     /**

--- a/tests/CartTest.php
+++ b/tests/CartTest.php
@@ -21,6 +21,7 @@
  * @backupStaticAttributes disabled
  */
 
+use Biblys\Data\ArticleType;
 use Biblys\Exception\CannotAddStockItemToCartException;
 use Biblys\Legacy\LegacyCodeHelper;
 use Biblys\Test\EntityFactory;
@@ -519,6 +520,36 @@ class CartTest extends PHPUnit\Framework\TestCase
         $this->assertTrue(
             $cart->containsReward($reward),
             "it should return true if reward is in cart"
+        );
+    }
+
+    /**
+     * @throws PropelException
+     * @throws Exception
+     */
+    public function testAddCFRewardWithMixOfPhysicalAndIntangibleArticles()
+    {
+        // given
+        $GLOBALS["LEGACY_CURRENT_SITE"] = EntityFactory::createSite();
+        $physicalArticle = EntityFactory::createArticle(["type_id" => ArticleType::BOOK]);
+        EntityFactory::createStock(["article_id" => $physicalArticle->get("id")]);
+        $ebook = EntityFactory::createArticle(["type_id" => ArticleType::EBOOK]);
+        $reward = EntityFactory::createCrowdfundingReward(["limited" => 0]);
+        $reward->set("reward_articles", "[{$physicalArticle->get('id')},{$ebook->get('id')}]");
+        $cart = EntityFactory::createCart();
+        $cm = new CartManager();
+
+        // when
+        $cm->addCFReward($cart, $reward);
+
+        // then
+        $this->assertTrue(
+            $cart->containsArticle($physicalArticle),
+            "it should add the physical article to the cart"
+        );
+        $this->assertTrue(
+            $cart->containsArticle($ebook),
+            "it should add the intangible article to the cart"
         );
     }
 

--- a/tests/CartTest.php
+++ b/tests/CartTest.php
@@ -598,4 +598,47 @@ class CartTest extends PHPUnit\Framework\TestCase
         $wish->reload();
         $this->assertNull($wish->getBought(), "wish_bought doit être remis à null.");
     }
+
+    /**
+     * @throws Exception
+     */
+    public function testRemoveStockDeletesIntangibleStockItem(): void
+    {
+        // given
+        $ebook = EntityFactory::createArticle(["type_id" => ArticleType::EBOOK]);
+        $stock = EntityFactory::createStock(["article_id" => $ebook->get("id")]);
+        $cm = new CartManager();
+
+        // when
+        $cm->removeStock($stock);
+
+        // then
+        $sm = new StockManager();
+        $this->assertFalse(
+            $sm->getById($stock->get("id")),
+            "l'exemplaire intangible devrait être supprimé, pas seulement détaché"
+        );
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testRemoveStockKeepsPhysicalStockItem(): void
+    {
+        // given
+        $physicalArticle = EntityFactory::createArticle(["type_id" => ArticleType::BOOK]);
+        $stock = EntityFactory::createStock(["article_id" => $physicalArticle->get("id")]);
+        $cm = new CartManager();
+
+        // when
+        $cm->removeStock($stock);
+
+        // then
+        $sm = new StockManager();
+        $this->assertInstanceOf(
+            Stock::class,
+            $sm->getById($stock->get("id")),
+            "l'exemplaire physique doit rester en stock, juste détaché du panier"
+        );
+    }
 }

--- a/tests/Usecase/AddIntangibleArticleToCartUsecaseTest.php
+++ b/tests/Usecase/AddIntangibleArticleToCartUsecaseTest.php
@@ -135,21 +135,24 @@ class AddIntangibleArticleToCartUsecaseTest extends TestCase
      * @throws BusinessRuleException
      * @throws PropelException
      */
-    public function testUsecaseAddsExistingStockItemToCart()
+    public function testUsecaseCreatesANewStockItemEvenIfAnUnclaimedOneAlreadyExists()
     {
         // given
         $usecase = new AddIntangibleArticleToCartUsecase();
 
-        $article = ModelFactory::createArticle(typeId: ArticleType::EBOOK);
-        $item = ModelFactory::createStockItem(article: $article, user: null, cart: null, order: null, sellingPrice: 1000);
+        $article = ModelFactory::createArticle(price: 1000, typeId: ArticleType::EBOOK);
+        $staleItem = ModelFactory::createStockItem(article: $article, user: null, cart: null, order: null, sellingPrice: 48000);
         $cart = ModelFactory::createCart();
 
         // when
         $usecase->execute($article, $cart);
 
         // then
-        $this->assertEquals($item->getCart(), $cart);
-        $this->assertNotNull($item->getCartDate());
+        $staleItem->reload();
+        $this->assertNull(
+            $staleItem->getCart(),
+            "the stale stock item should not be reused, whatever its price"
+        );
         $this->assertEquals(1, $cart->getCount());
         $this->assertEquals(1000, $cart->getAmount());
     }

--- a/tests/Usecase/AddIntangibleArticleToCartUsecaseTest.php
+++ b/tests/Usecase/AddIntangibleArticleToCartUsecaseTest.php
@@ -186,6 +186,28 @@ class AddIntangibleArticleToCartUsecaseTest extends TestCase
      * @throws BusinessRuleException
      * @throws PropelException
      */
+    public function testUsecaseTagsStockItemWithRewardWhenProvided()
+    {
+        // given
+        $usecase = new AddIntangibleArticleToCartUsecase();
+
+        $article = ModelFactory::createArticle(price: 1000, typeId: ArticleType::EBOOK);
+        $cart = ModelFactory::createCart();
+        $reward = ModelFactory::createCrowdfundingReward();
+
+        // when
+        $usecase->execute($article, $cart, $reward);
+
+        // then
+        $itemInCart = StockQuery::create()->filterByCart($cart)->findOne();
+        $this->assertEquals($reward->getId(), $itemInCart->getRewardId());
+        $this->assertEquals($reward->getCampaignId(), $itemInCart->getCampaignId());
+    }
+
+    /**
+     * @throws BusinessRuleException
+     * @throws PropelException
+     */
     public function testUsecaseIgnoresSoldItem()
     {
         // given


### PR DESCRIPTION
## Résumé

- L'ajout au panier d'une contrepartie de campagne de financement participatif combinant un article physique et un article numérique provoquait une erreur ("il est intangible"), bloquant l'ajout de la contrepartie entière.
- Un article numérique ajouté via une contrepartie n'était jamais associé à cette contrepartie (`campaign_id`/`reward_id`), empêchant sa détection par `Cart::containsReward()`.

## Test plan

- [x] `composer test` (suite complète, 1304 tests)
- [x] Nouveaux tests couvrant une contrepartie mixte physique/numérique et le tag reward sur un article intangible