### PR TITLE
Offres spéciales : condition de montant minimum de panier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 - Un nouveau moyen de paiement en espèces peut être activé via l'option de
   site `payment_cash`. Il n'est proposé que pour les commandes retirées en
   magasin.
+- Une offre spéciale peut désormais exiger un montant minimum de panier (hors
+  frais de port), en plus ou à la place de la condition de quantité minimum
+  dans une collection.
 
 ## 3.16.2 (9 septembre 2026)
 

--- a/controllers/common/php/cart.php
+++ b/controllers/common/php/cart.php
@@ -377,7 +377,6 @@ return function (
             $imagesService,
             $templateService,
             $cart,
-            $Total
         );
 
         // Pre-order books

--- a/controllers/common/php/cart.php
+++ b/controllers/common/php/cart.php
@@ -376,7 +376,8 @@ return function (
             $urlGenerator,
             $imagesService,
             $templateService,
-            $cart
+            $cart,
+            $Total
         );
 
         // Pre-order books

--- a/generated-migrations/PropelMigration_1788942469.php
+++ b/generated-migrations/PropelMigration_1788942469.php
@@ -1,0 +1,99 @@
+<?php
+/*
+ * Copyright (C) 2024 Clément Latzarus
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+use Propel\Generator\Manager\MigrationManager;
+
+/**
+ * Data object containing the SQL and PHP code to migrate the database
+ * up to version 1788942469.
+ * Generated on 2026-09-09 by clement
+ */
+class PropelMigration_1788942469
+{
+    public $comment = 'Make target_collection_id and target_quantity nullable and add target_amount, '
+        . 'so a special offer can require a minimum cart amount instead of (or in addition to) '
+        . 'a minimum quantity in a collection.';
+
+    public function preUp(MigrationManager $manager)
+    {
+        // add the pre-migration code here
+    }
+
+    public function postUp(MigrationManager $manager)
+    {
+        // add the post-migration code here
+    }
+
+    public function preDown(MigrationManager $manager)
+    {
+        // add the pre-migration code here
+    }
+
+    public function postDown(MigrationManager $manager)
+    {
+        // add the post-migration code here
+    }
+
+    /**
+     * Get the SQL statements for the Up migration
+     *
+     * @return array list of the SQL strings to execute for the Up migration
+     *               the keys being the datasources
+     */
+    public function getUpSQL()
+    {
+        $connection_default = <<< 'EOT'
+
+ALTER TABLE `special_offers`
+
+  CHANGE `target_collection_id` `target_collection_id` INTEGER,
+
+  CHANGE `target_quantity` `target_quantity` INTEGER,
+
+  ADD `target_amount` int unsigned AFTER `target_quantity`;
+EOT;
+
+        return array(
+            'default' => $connection_default,
+        );
+    }
+
+    /**
+     * Get the SQL statements for the Down migration
+     *
+     * @return array list of the SQL strings to execute for the Down migration
+     *               the keys being the datasources
+     */
+    public function getDownSQL()
+    {
+        $connection_default = <<< 'EOT'
+
+ALTER TABLE `special_offers`
+
+  CHANGE `target_collection_id` `target_collection_id` INTEGER NOT NULL,
+
+  CHANGE `target_quantity` `target_quantity` INTEGER NOT NULL,
+
+  DROP `target_amount`;
+EOT;
+
+        return array(
+            'default' => $connection_default,
+        );
+    }
+
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,15 @@
+<phpunit bootstrap="tests/setUp.php"
+         displayDetailsOnTestsThatTriggerDeprecations="true"
+         failOnDeprecation="false"
+         failOnWarning="false">
+    <source>
+        <include>
+            <directory>src</directory>
+        </include>
+    </source>
+    <testsuites>
+        <testsuite name="default">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/schema.xml
+++ b/schema.xml
@@ -1386,11 +1386,12 @@
     </foreign-key>
     <column name="name" required="true" type="VARCHAR" size="128"/>
     <column name="description" type="LONGVARCHAR" />
-    <column name="target_collection_id" required="true" type="INTEGER"/>
+    <column name="target_collection_id" type="INTEGER"/>
     <foreign-key foreignTable="collections" phpName="TargetCollection" skipSql="true">
       <reference local="target_collection_id" foreign="collection_id"/>
     </foreign-key>
-    <column name="target_quantity" required="true" type="INTEGER"/>
+    <column name="target_quantity" type="INTEGER"/>
+    <column name="target_amount" type="INTEGER" sqlType="int unsigned"/>
     <column name="free_article_id" required="true" type="INTEGER"/>
     <foreign-key foreignTable="articles" phpName="FreeArticle" skipSql="true">
       <reference local="free_article_id" foreign="article_id"/>

--- a/src/AppBundle/Controller/SpecialOfferController.php
+++ b/src/AppBundle/Controller/SpecialOfferController.php
@@ -118,12 +118,27 @@ class SpecialOfferController extends Controller
             throw new NotFoundHttpException("Special offer not found");
         }
 
+        $targetAmountEnabled = (bool) $request->request->get("target_amount_enabled");
+        $targetQuantityEnabled = (bool) $request->request->get("target_quantity_enabled");
+
+        if (!$targetAmountEnabled && !$targetQuantityEnabled) {
+            $session->getFlashBag()->add(
+                "error",
+                "Vous devez activer au moins une condition (montant ou quantité)."
+            );
+            $editUrl = $urlGenerator->generate("special_offer_edit", ["id" => $offer->getId()]);
+            return new RedirectResponse($editUrl);
+        }
+
         $offer->setName($request->request->get("name"));
         $offer->setDescription($request->request->get("description"));
         $offer->setStartDate($request->request->get("start_date"));
         $offer->setEndDate($request->request->get("end_date"));
-        $offer->setTargetQuantity($request->request->get("target_quantity"));
-        $offer->setTargetCollectionId($request->request->get("target_collection_id"));
+        $offer->setTargetAmount(
+            $targetAmountEnabled ? (int) round(((float) $request->request->get("target_amount")) * 100) : null
+        );
+        $offer->setTargetQuantity($targetQuantityEnabled ? (int) $request->request->get("target_quantity") : null);
+        $offer->setTargetCollectionId($targetQuantityEnabled ? (int) $request->request->get("target_collection_id") : null);
         $offer->setFreeArticleId($request->request->get("free_article_id"));
         $offer->save();
 

--- a/src/AppBundle/Resources/layout/admin.html.twig
+++ b/src/AppBundle/Resources/layout/admin.html.twig
@@ -44,7 +44,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
       {% include "layout:_flash_messages.html.twig" %}
 
-      <main class="mt-4">
+      <main class="mt-4 mb-5">
         {% block main %}{% endblock %}
       </main>
     </div>

--- a/src/AppBundle/Resources/views/SpecialOffer/edit.html.twig
+++ b/src/AppBundle/Resources/views/SpecialOffer/edit.html.twig
@@ -54,29 +54,56 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
                value="{{ offer.endDate|date('Y-m-d') }}" required>
       </div>
 
-      <div class="form-group row">
-        <label for="target_quantity" class="col-md-3 col-form-label text-md-right">pour</label>
-        <input type="number" class="form-control col-md-7" id="target_quantity" name="target_quantity"
-               value="{{ offer.targetQuantity }}" required>
-        <span class="col-md-2 col-form-label">
-          articles achetés
-        </span>
+      <p class="font-weight-bold mb-2">Si :</p>
+
+      <div class="card mb-3">
+        <div class="card-body">
+          <div class="form-check d-flex align-items-center flex-wrap">
+            <input type="checkbox" class="form-check-input" id="target_amount_enabled" name="target_amount_enabled" value="1"
+                   onchange="document.getElementById('target_amount').disabled = !this.checked"
+                   {% if offer.targetAmount is not null %}checked{% endif %}>
+            <label class="form-check-label d-flex align-items-center flex-wrap mb-0" for="target_amount_enabled">
+              <span class="mr-2">le montant du panier est au minimum de</span>
+              <input type="number" step="0.01" class="form-control d-inline-block mr-2" style="width: 6em"
+                     id="target_amount" name="target_amount"
+                     value="{{ offer.targetAmount is not null ? offer.targetAmount / 100 : '' }}"
+                     {% if offer.targetAmount is null %}disabled{% endif %}>
+              <span>&euro;</span>
+            </label>
+          </div>
+        </div>
       </div>
 
-      <div class="form-group row">
-        <label for="target_collection_id" class="col-md-3 col-form-label text-md-right">dans la collection</label>
-        <select id="target_collection_id" class="form-control col-md-7" name="target_collection_id" required>
-          {% for collection in collections %}
-            <option value="{{ collection.id }}" {% if collection.id == offer.targetCollectionId %}selected{% endif %}>
-              {{ collection.name }}
-            </option>
-          {% endfor %}
-        </select>
+      <div class="card mb-3">
+        <div class="card-body">
+          <div class="form-check d-flex align-items-center flex-wrap">
+            <input type="checkbox" class="form-check-input" id="target_quantity_enabled" name="target_quantity_enabled" value="1"
+                   onchange="document.getElementById('target_quantity').disabled = document.getElementById('target_collection_id').disabled = !this.checked"
+                   {% if offer.targetQuantity is not null %}checked{% endif %}>
+            <label class="form-check-label d-flex align-items-center flex-wrap mb-0" for="target_quantity_enabled">
+              <span class="mr-2">le panier contient au moins</span>
+              <input type="number" class="form-control d-inline-block mr-2" style="width: 5em"
+                     id="target_quantity" name="target_quantity" value="{{ offer.targetQuantity }}"
+                     {% if offer.targetQuantity is null %}disabled{% endif %}>
+              <span class="mr-2">article{{ offer.targetQuantity != 1 ? 's' }} de la collection</span>
+              <select id="target_collection_id" class="form-control d-inline-block" style="width: auto"
+                      name="target_collection_id" {% if offer.targetQuantity is null %}disabled{% endif %}>
+                {% for collection in collections %}
+                  <option value="{{ collection.id }}" {% if collection.id == offer.targetCollectionId %}selected{% endif %}>
+                    {{ collection.name }}
+                  </option>
+                {% endfor %}
+              </select>
+            </label>
+          </div>
+        </div>
       </div>
 
-      <div class="form-group row">
-        <label for="free_article_id" class="col-md-3 col-form-label text-md-right">l'article</label>
-        <div class="col-md-7 p-0">
+      <p class="font-weight-bold mb-2">Alors :</p>
+
+      <div class="d-flex align-items-center flex-wrap">
+        <span class="mr-2">l'article</span>
+        <div class="mr-2" style="min-width: 280px; max-width: 400px">
           {% include "AppBundle:Utils:_entity-search-field.html.twig" with {
             query_url: "/pages/adm_article_search",
             label: "Choisir un article…",
@@ -87,9 +114,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
             autoload: true,
           } %}
         </div>
-        <span class="col-md-2 col-form-label">
-          est offert
-        </span>
+        <span>peut être ajouté au panier</span>
       </div>
     </fieldset>
 

--- a/src/Biblys/Legacy/CartHelpers.php
+++ b/src/Biblys/Legacy/CartHelpers.php
@@ -182,7 +182,8 @@ class CartHelpers
         UrlGenerator    $urlGenerator,
         ImagesService   $imagesService,
         TemplateService $templateService,
-        Cart            $cart
+        Cart            $cart,
+        int             $cartTotal,
     ): string
     {
         $specialOffers = SpecialOfferQuery::create()
@@ -200,6 +201,7 @@ class CartHelpers
                 $imagesService,
                 $templateService,
                 $cart,
+                $cartTotal,
             );
         }
 
@@ -215,13 +217,12 @@ class CartHelpers
         ImagesService   $imagesService,
         TemplateService $templateService,
         Cart            $cart,
+        int             $cartTotal,
     ): string
     {
-        $targetQuantity = $specialOffer->getTargetQuantity();
         $freeArticle = $specialOffer->getFreeArticle();
-        $targetCollection = $specialOffer->getTargetCollection();
 
-        if (!$targetCollection || !$freeArticle) {
+        if (!$freeArticle) {
             return "";
         }
 
@@ -233,37 +234,94 @@ class CartHelpers
             return "";
         }
 
-        $am = new ArticleManager();
+        $conditionsAreMet = true;
+        $conditionItems = [];
 
-        $copies = StockQuery::create()
-            ->filterByCart($cart)
-            ->filterByArticle($freeArticle, Criteria::NOT_EQUAL)
-            ->find();
+        $targetQuantity = $specialOffer->getTargetQuantity();
+        $targetCollection = $specialOffer->getTargetCollection();
+        if ($targetQuantity !== null && $targetCollection !== null) {
+            $copies = StockQuery::create()
+                ->filterByCart($cart)
+                ->filterByArticle($freeArticle, Criteria::NOT_EQUAL)
+                ->find();
 
-        // Count copies in offer's collection
-        $copiesInCollection = array_reduce($copies->getArrayCopy(), function ($total, $copy) use ($targetCollection) {
-            /** @var Article $article */
-            $article = $copy->getArticle();
+            // Count copies in offer's collection
+            $copiesInCollection = array_reduce($copies->getArrayCopy(), function ($total, $copy) use ($targetCollection) {
+                /** @var Article $article */
+                $article = $copy->getArticle();
 
-            if ($article->getCollectionId() === $targetCollection->getId()) {
-                $total++;
+                if ($article->getCollectionId() === $targetCollection->getId()) {
+                    $total++;
+                }
+
+                return $total;
+            }, 0);
+
+            $missingItems = $targetQuantity - $copiesInCollection;
+            $quantityConditionIsMet = $missingItems <= 0;
+
+            $collectionUrl = $urlGenerator->generate(
+                "collection_show", ["slug" => $targetCollection->getUrl()]
+            );
+            $collectionLink = '<a href="' . $collectionUrl . '">' . $targetCollection->getName() . '</a>';
+
+            if ($quantityConditionIsMet) {
+                $conditionItems[] = [
+                    "met" => true,
+                    "label" => $targetQuantity . ' titre' . s($targetQuantity) . ' de la collection ' .
+                        $collectionLink . ' acheté' . s($targetQuantity),
+                ];
+            } else {
+                $conditionsAreMet = false;
+                $conditionItems[] = [
+                    "met" => false,
+                    "label" => 'Ajoutez encore ' . $missingItems . ' titre' . s($missingItems) .
+                        ' de la collection ' . $collectionLink,
+                ];
             }
+        }
 
-            return $total;
-        }, 0);
+        $targetAmount = $specialOffer->getTargetAmount();
+        if ($targetAmount !== null) {
+            $missingAmount = $targetAmount - $cartTotal;
+            $amountConditionIsMet = $missingAmount <= 0;
 
-        $missingItems = $targetQuantity - $copiesInCollection;
+            if ($amountConditionIsMet) {
+                $conditionItems[] = [
+                    "met" => true,
+                    "label" => currency($targetAmount / 100) . ' d’achat atteints',
+                ];
+            } else {
+                $conditionsAreMet = false;
+                $conditionItems[] = [
+                    "met" => false,
+                    "label" => 'Ajoutez encore ' . currency($missingAmount / 100) .
+                        ' à votre panier <small>(minimum ' . currency($targetAmount / 100) . ')</small>',
+                ];
+            }
+        }
+
+        if (!$conditionItems) {
+            return "";
+        }
 
         /** @var \Article $freeArticleEntity */
+        $am = new ArticleManager();
         $freeArticleEntity = $am->getById($freeArticle->getId());
-        $sentence = '<span class="text-info"><span class="fa fa-plus-circle"></span> Ajoutez encore ' .
-            $missingItems . ' titre' . s($missingItems) . ' 
-            à votre panier pour en profiter.</span>';
+
+        $conditionsHtml = "";
+        foreach ($conditionItems as $conditionItem) {
+            $icon = $conditionItem["met"] ? "fa-check-circle" : "fa-plus-circle";
+            $class = $conditionItem["met"] ? "text-success" : "text-info";
+            $conditionsHtml .= '<li class="' . $class . '"><span class="fa ' . $icon . '"></span> ' .
+                $conditionItem["label"] . '</li>';
+        }
+
+        $statusLine = '';
         $cartButton = '<button class="btn btn-outline-secondary" disabled>Ajouter au panier</button>';
 
-
-        if ($missingItems <= 0) {
-            $sentence = '<span class="text-success"><span class="fa fa-check-circle"></span> Vous pouvez bénéficier de l’offre.</span>';
+        if ($conditionsAreMet) {
+            $statusLine = '<span class="text-success"><span class="fa fa-check-circle"></span> Vous pouvez bénéficier de l’offre.</span>';
             $cartButtonUrl = $urlGenerator->generate(
                 "cart_add_article", ["articleId" => $freeArticle->getId()]
             );
@@ -276,7 +334,7 @@ class CartHelpers
             ->filterByCart($cart)->findOneByArticleId($freeArticle->getId());
         if ($freeArticleIsInCart) {
             $cartButton = "";
-            $sentence = '<span class="text-success"><span class="fa fa-check-circle"></span> Vous bénéficiez de l’offre.</span>';
+            $statusLine = '<span class="text-success"><span class="fa fa-check-circle"></span> Vous bénéficiez de l’offre.</span>';
         }
 
         $cover = null;
@@ -290,10 +348,6 @@ class CartHelpers
             );
         }
 
-        $collectionUrl = $urlGenerator->generate(
-            "collection_show", ["slug" => $targetCollection->getUrl()]
-        );
-
         return '
             <div class="SpecialOfferNotice">
                 <h2 class="SpecialOfferNotice-title">' . $specialOffer->getName() . '</h2>
@@ -302,18 +356,15 @@ class CartHelpers
                 </div>
                 <div class="SpecialOfferNotice-infos">
                     <p>
-                    
+
                         <a href="/' . $freeArticleEntity->get('url') . '">' . $freeArticleEntity->get('title') . '</a><br />
                         de ' . authors($freeArticleEntity->get('authors')) . '<br />
                         coll. ' . $freeArticleEntity->get('collection')->get('name') . ' ' . numero($freeArticleEntity->get('number')) . '<br />
                     </p>
                     <p>
-                        <strong>
-                            Offert pour ' . $targetQuantity . ' titre'.s($targetQuantity).' de la collection 
-                            <a href="' . $collectionUrl . '">' . $targetCollection->getName() . '</a> 
-                            acheté'.s($targetQuantity).'&nbsp;!<br />
-                            <small>' . $sentence . '</small>
-                        </strong>
+                        <strong>Offert si :</strong>
+                        <ul class="SpecialOfferNotice-conditions list-unstyled mb-2">' . $conditionsHtml . '</ul>
+                        <small>' . $statusLine . '</small>
                     </p>
                     ' . $cartButton . '
                 </div>

--- a/src/Biblys/Legacy/CartHelpers.php
+++ b/src/Biblys/Legacy/CartHelpers.php
@@ -21,6 +21,7 @@ namespace Biblys\Legacy;
 use ArticleManager;
 use Biblys\Service\CurrentSite;
 use Biblys\Service\Images\ImagesService;
+use Biblys\Service\SpecialOffers\SpecialOfferEvaluator;
 use Biblys\Service\TemplateService;
 use DateTime;
 use Exception;
@@ -33,7 +34,6 @@ use Model\SpecialOffer;
 use Model\SpecialOfferQuery;
 use Model\Stock;
 use Model\StockQuery;
-use Propel\Runtime\ActiveQuery\Criteria;
 use Propel\Runtime\Exception\PropelException;
 use Symfony\Component\Routing\Generator\UrlGenerator;
 
@@ -183,7 +183,6 @@ class CartHelpers
         ImagesService   $imagesService,
         TemplateService $templateService,
         Cart            $cart,
-        int             $cartTotal,
     ): string
     {
         $specialOffers = SpecialOfferQuery::create()
@@ -201,7 +200,6 @@ class CartHelpers
                 $imagesService,
                 $templateService,
                 $cart,
-                $cartTotal,
             );
         }
 
@@ -217,7 +215,6 @@ class CartHelpers
         ImagesService   $imagesService,
         TemplateService $templateService,
         Cart            $cart,
-        int             $cartTotal,
     ): string
     {
         $freeArticle = $specialOffer->getFreeArticle();
@@ -234,45 +231,25 @@ class CartHelpers
             return "";
         }
 
-        $conditionsAreMet = true;
+        $evaluation = SpecialOfferEvaluator::evaluate($specialOffer, $cart);
         $conditionItems = [];
 
-        $targetQuantity = $specialOffer->getTargetQuantity();
-        $targetCollection = $specialOffer->getTargetCollection();
-        if ($targetQuantity !== null && $targetCollection !== null) {
-            $copies = StockQuery::create()
-                ->filterByCart($cart)
-                ->filterByArticle($freeArticle, Criteria::NOT_EQUAL)
-                ->find();
-
-            // Count copies in offer's collection
-            $copiesInCollection = array_reduce($copies->getArrayCopy(), function ($total, $copy) use ($targetCollection) {
-                /** @var Article $article */
-                $article = $copy->getArticle();
-
-                if ($article->getCollectionId() === $targetCollection->getId()) {
-                    $total++;
-                }
-
-                return $total;
-            }, 0);
-
-            $missingItems = $targetQuantity - $copiesInCollection;
-            $quantityConditionIsMet = $missingItems <= 0;
-
+        if ($evaluation->quantity !== null) {
+            $targetCollection = $specialOffer->getTargetCollection();
             $collectionUrl = $urlGenerator->generate(
                 "collection_show", ["slug" => $targetCollection->getUrl()]
             );
             $collectionLink = '<a href="' . $collectionUrl . '">' . $targetCollection->getName() . '</a>';
+            $target = $evaluation->quantity->target;
 
-            if ($quantityConditionIsMet) {
+            if ($evaluation->quantity->isMet) {
                 $conditionItems[] = [
                     "met" => true,
-                    "label" => $targetQuantity . ' titre' . s($targetQuantity) . ' de la collection ' .
-                        $collectionLink . ' acheté' . s($targetQuantity),
+                    "label" => $target . ' titre' . s($target) . ' de la collection ' .
+                        $collectionLink . ' acheté' . s($target),
                 ];
             } else {
-                $conditionsAreMet = false;
+                $missingItems = $target - $evaluation->quantity->current;
                 $conditionItems[] = [
                     "met" => false,
                     "label" => 'Ajoutez encore ' . $missingItems . ' titre' . s($missingItems) .
@@ -281,22 +258,20 @@ class CartHelpers
             }
         }
 
-        $targetAmount = $specialOffer->getTargetAmount();
-        if ($targetAmount !== null) {
-            $missingAmount = $targetAmount - $cartTotal;
-            $amountConditionIsMet = $missingAmount <= 0;
+        if ($evaluation->amount !== null) {
+            $target = $evaluation->amount->target;
 
-            if ($amountConditionIsMet) {
+            if ($evaluation->amount->isMet) {
                 $conditionItems[] = [
                     "met" => true,
-                    "label" => currency($targetAmount / 100) . ' d’achat atteints',
+                    "label" => currency($target / 100) . ' d’achat atteints',
                 ];
             } else {
-                $conditionsAreMet = false;
+                $missingAmount = $target - $evaluation->amount->current;
                 $conditionItems[] = [
                     "met" => false,
                     "label" => 'Ajoutez encore ' . currency($missingAmount / 100) .
-                        ' à votre panier <small>(minimum ' . currency($targetAmount / 100) . ')</small>',
+                        ' à votre panier <small>(minimum ' . currency($target / 100) . ')</small>',
                 ];
             }
         }
@@ -320,7 +295,7 @@ class CartHelpers
         $statusLine = '';
         $cartButton = '<button class="btn btn-outline-secondary" disabled>Ajouter au panier</button>';
 
-        if ($conditionsAreMet) {
+        if ($evaluation->isMet()) {
             $statusLine = '<span class="text-success"><span class="fa fa-check-circle"></span> Vous pouvez bénéficier de l’offre.</span>';
             $cartButtonUrl = $urlGenerator->generate(
                 "cart_add_article", ["articleId" => $freeArticle->getId()]

--- a/src/Biblys/Legacy/OrderDeliveryHelpers.php
+++ b/src/Biblys/Legacy/OrderDeliveryHelpers.php
@@ -25,6 +25,7 @@ use Biblys\Exception\OrderDetailsValidationException;
 use Biblys\Service\CurrentSite;
 use Biblys\Service\CurrentUser;
 use Biblys\Service\Mailer;
+use Biblys\Service\SpecialOffers\SpecialOfferEvaluator;
 use CountryManager;
 use Egulias\EmailValidator\EmailValidator;
 use Egulias\EmailValidator\Validation\DNSCheckValidation;
@@ -37,7 +38,6 @@ use Model\Cart;
 use Model\Order;
 use Model\OrderQuery;
 use Model\Page;
-use Model\SpecialOffer;
 use Model\SpecialOfferQuery;
 use Model\Stock;
 use Model\StockQuery;
@@ -443,51 +443,11 @@ class OrderDeliveryHelpers
                 throw new CartException("Un panier ne peut pas contenir plusieurs articles offerts");
             }
 
-            if (!self::_cartMeetsSpecialOfferConditions($cart, $specialOfferForArticle)) {
+            if (!SpecialOfferEvaluator::evaluate($specialOfferForArticle, $cart)->isMet()) {
                 throw new CartException(
                     "Votre panier ne remplit pas les conditions pour bénéficier de l'offre spéciale {$specialOfferForArticle->getName()}."
                 );
             }
         }
-    }
-
-    /**
-     * @throws PropelException
-     */
-    private static function _cartMeetsSpecialOfferConditions(
-        Cart         $cart,
-        SpecialOffer $specialOffer
-    ): bool
-    {
-        $targetAmount = $specialOffer->getTargetAmount();
-        $amountConditionIsMet = $targetAmount === null || $cart->getSubtotal() >= $targetAmount;
-
-        $targetQuantity = $specialOffer->getTargetQuantity();
-        $quantityConditionIsMet = $targetQuantity === null
-            || self::_countCartItemsInCollection($cart, $specialOffer) >= $targetQuantity;
-
-        return $amountConditionIsMet && $quantityConditionIsMet;
-    }
-
-    /**
-     * @throws PropelException
-     */
-    private static function _countCartItemsInCollection(Cart $cart, SpecialOffer $specialOffer): int
-    {
-        $cartItems = $cart->getStocks()->getArrayCopy();
-        return array_reduce($cartItems, function ($total, $copy) use ($specialOffer) {
-            /** @var Article $article */
-            $article = $copy->getArticle();
-
-            if ($article === $specialOffer->getFreeArticle()) {
-                return $total;
-            }
-
-            if ($article->getCollectionId() === $specialOffer->getTargetCollectionId()) {
-                $total++;
-            }
-
-            return $total;
-        }, 0);
     }
 }

--- a/src/Biblys/Legacy/OrderDeliveryHelpers.php
+++ b/src/Biblys/Legacy/OrderDeliveryHelpers.php
@@ -459,8 +459,23 @@ class OrderDeliveryHelpers
         SpecialOffer $specialOffer
     ): bool
     {
+        $targetAmount = $specialOffer->getTargetAmount();
+        $amountConditionIsMet = $targetAmount === null || $cart->getSubtotal() >= $targetAmount;
+
+        $targetQuantity = $specialOffer->getTargetQuantity();
+        $quantityConditionIsMet = $targetQuantity === null
+            || self::_countCartItemsInCollection($cart, $specialOffer) >= $targetQuantity;
+
+        return $amountConditionIsMet && $quantityConditionIsMet;
+    }
+
+    /**
+     * @throws PropelException
+     */
+    private static function _countCartItemsInCollection(Cart $cart, SpecialOffer $specialOffer): int
+    {
         $cartItems = $cart->getStocks()->getArrayCopy();
-        $itemsInTargetCollectionCount = array_reduce($cartItems, function ($total, $copy) use ($specialOffer) {
+        return array_reduce($cartItems, function ($total, $copy) use ($specialOffer) {
             /** @var Article $article */
             $article = $copy->getArticle();
 
@@ -474,7 +489,5 @@ class OrderDeliveryHelpers
 
             return $total;
         }, 0);
-
-        return $itemsInTargetCollectionCount >= $specialOffer->getTargetQuantity();
     }
 }

--- a/src/Biblys/Service/SpecialOffers/SpecialOfferConditionEvaluation.php
+++ b/src/Biblys/Service/SpecialOffers/SpecialOfferConditionEvaluation.php
@@ -1,0 +1,30 @@
+<?php
+/*
+ * Copyright (C) 2026 Clément Latzarus
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+
+namespace Biblys\Service\SpecialOffers;
+
+final class SpecialOfferConditionEvaluation
+{
+    public function __construct(
+        public readonly bool $isMet,
+        public readonly int  $target,
+        public readonly int  $current,
+    )
+    {
+    }
+}

--- a/src/Biblys/Service/SpecialOffers/SpecialOfferEvaluation.php
+++ b/src/Biblys/Service/SpecialOffers/SpecialOfferEvaluation.php
@@ -1,0 +1,35 @@
+<?php
+/*
+ * Copyright (C) 2026 Clément Latzarus
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+
+namespace Biblys\Service\SpecialOffers;
+
+final class SpecialOfferEvaluation
+{
+    public function __construct(
+        public readonly ?SpecialOfferConditionEvaluation $amount,
+        public readonly ?SpecialOfferConditionEvaluation $quantity,
+    )
+    {
+    }
+
+    public function isMet(): bool
+    {
+        return ($this->amount === null || $this->amount->isMet)
+            && ($this->quantity === null || $this->quantity->isMet);
+    }
+}

--- a/src/Biblys/Service/SpecialOffers/SpecialOfferEvaluator.php
+++ b/src/Biblys/Service/SpecialOffers/SpecialOfferEvaluator.php
@@ -1,0 +1,65 @@
+<?php
+/*
+ * Copyright (C) 2026 Clément Latzarus
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+
+namespace Biblys\Service\SpecialOffers;
+
+use Model\Cart;
+use Model\SpecialOffer;
+use Model\StockQuery;
+use Propel\Runtime\ActiveQuery\Criteria;
+use Propel\Runtime\Exception\PropelException;
+
+final class SpecialOfferEvaluator
+{
+    /**
+     * @throws PropelException
+     */
+    public static function evaluate(SpecialOffer $specialOffer, Cart $cart): SpecialOfferEvaluation
+    {
+        $amount = null;
+        $targetAmount = $specialOffer->getTargetAmount();
+        if ($targetAmount !== null) {
+            $current = $cart->getSubtotal();
+            $amount = new SpecialOfferConditionEvaluation(
+                isMet: $current >= $targetAmount,
+                target: $targetAmount,
+                current: $current,
+            );
+        }
+
+        $quantity = null;
+        $targetQuantity = $specialOffer->getTargetQuantity();
+        $targetCollection = $specialOffer->getTargetCollection();
+        if ($targetQuantity !== null && $targetCollection !== null) {
+            $current = StockQuery::create()
+                ->filterByCart($cart)
+                ->filterByArticle($specialOffer->getFreeArticle(), Criteria::NOT_EQUAL)
+                ->useArticleQuery()
+                ->filterByCollectionId($targetCollection->getId())
+                ->endUse()
+                ->count();
+            $quantity = new SpecialOfferConditionEvaluation(
+                isMet: $current >= $targetQuantity,
+                target: $targetQuantity,
+                current: $current,
+            );
+        }
+
+        return new SpecialOfferEvaluation($amount, $quantity);
+    }
+}

--- a/src/Biblys/Test/ModelFactory.php
+++ b/src/Biblys/Test/ModelFactory.php
@@ -902,7 +902,8 @@ class ModelFactory
         string          $name = "Offre spéciale",
         ?BookCollection $targetCollection = null,
         ?Article        $freeArticle = null,
-        int             $targetQuantity = 2,
+        ?int            $targetQuantity = 2,
+        ?int            $targetAmount = null,
         DateTime        $startDate = new DateTime("- 1 day"),
         DateTime        $endDate = new DateTime("+ 1 day"),
     ): SpecialOffer
@@ -910,8 +911,11 @@ class ModelFactory
         $specialOffer = new SpecialOffer();
         $specialOffer->setName($name);
         $specialOffer->setFreeArticle($freeArticle ?? ModelFactory::createArticle());
-        $specialOffer->setTargetCollection($targetCollection ?? self::createCollection());
-        $specialOffer->setTargetQuantity($targetQuantity);
+        if ($targetCollection !== null || $targetQuantity !== null) {
+            $specialOffer->setTargetCollection($targetCollection ?? self::createCollection());
+            $specialOffer->setTargetQuantity($targetQuantity ?? 2);
+        }
+        $specialOffer->setTargetAmount($targetAmount);
         $specialOffer->setStartDate($startDate);
         $specialOffer->setEndDate($endDate);
         $specialOffer->save();

--- a/src/Model/Base/SpecialOffer.php
+++ b/src/Model/Base/SpecialOffer.php
@@ -100,16 +100,23 @@ abstract class SpecialOffer implements ActiveRecordInterface
     /**
      * The value for the target_collection_id field.
      *
-     * @var        int
+     * @var        int|null
      */
     protected $target_collection_id;
 
     /**
      * The value for the target_quantity field.
      *
-     * @var        int
+     * @var        int|null
      */
     protected $target_quantity;
+
+    /**
+     * The value for the target_amount field.
+     *
+     * @var        int|null
+     */
+    protected $target_amount;
 
     /**
      * The value for the free_article_id field.
@@ -438,7 +445,7 @@ abstract class SpecialOffer implements ActiveRecordInterface
     /**
      * Get the [target_collection_id] column value.
      *
-     * @return int
+     * @return int|null
      */
     public function getTargetCollectionId()
     {
@@ -448,11 +455,21 @@ abstract class SpecialOffer implements ActiveRecordInterface
     /**
      * Get the [target_quantity] column value.
      *
-     * @return int
+     * @return int|null
      */
     public function getTargetQuantity()
     {
         return $this->target_quantity;
+    }
+
+    /**
+     * Get the [target_amount] column value.
+     *
+     * @return int|null
+     */
+    public function getTargetAmount()
+    {
+        return $this->target_amount;
     }
 
     /**
@@ -640,7 +657,7 @@ abstract class SpecialOffer implements ActiveRecordInterface
     /**
      * Set the value of [target_collection_id] column.
      *
-     * @param int $v New value
+     * @param int|null $v New value
      * @return $this The current object (for fluent API support)
      */
     public function setTargetCollectionId($v)
@@ -664,7 +681,7 @@ abstract class SpecialOffer implements ActiveRecordInterface
     /**
      * Set the value of [target_quantity] column.
      *
-     * @param int $v New value
+     * @param int|null $v New value
      * @return $this The current object (for fluent API support)
      */
     public function setTargetQuantity($v)
@@ -676,6 +693,26 @@ abstract class SpecialOffer implements ActiveRecordInterface
         if ($this->target_quantity !== $v) {
             $this->target_quantity = $v;
             $this->modifiedColumns[SpecialOfferTableMap::COL_TARGET_QUANTITY] = true;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Set the value of [target_amount] column.
+     *
+     * @param int|null $v New value
+     * @return $this The current object (for fluent API support)
+     */
+    public function setTargetAmount($v)
+    {
+        if ($v !== null) {
+            $v = (int) $v;
+        }
+
+        if ($this->target_amount !== $v) {
+            $this->target_amount = $v;
+            $this->modifiedColumns[SpecialOfferTableMap::COL_TARGET_AMOUNT] = true;
         }
 
         return $this;
@@ -839,28 +876,31 @@ abstract class SpecialOffer implements ActiveRecordInterface
             $col = $row[TableMap::TYPE_NUM == $indexType ? 5 + $startcol : SpecialOfferTableMap::translateFieldName('TargetQuantity', TableMap::TYPE_PHPNAME, $indexType)];
             $this->target_quantity = (null !== $col) ? (int) $col : null;
 
-            $col = $row[TableMap::TYPE_NUM == $indexType ? 6 + $startcol : SpecialOfferTableMap::translateFieldName('FreeArticleId', TableMap::TYPE_PHPNAME, $indexType)];
+            $col = $row[TableMap::TYPE_NUM == $indexType ? 6 + $startcol : SpecialOfferTableMap::translateFieldName('TargetAmount', TableMap::TYPE_PHPNAME, $indexType)];
+            $this->target_amount = (null !== $col) ? (int) $col : null;
+
+            $col = $row[TableMap::TYPE_NUM == $indexType ? 7 + $startcol : SpecialOfferTableMap::translateFieldName('FreeArticleId', TableMap::TYPE_PHPNAME, $indexType)];
             $this->free_article_id = (null !== $col) ? (int) $col : null;
 
-            $col = $row[TableMap::TYPE_NUM == $indexType ? 7 + $startcol : SpecialOfferTableMap::translateFieldName('StartDate', TableMap::TYPE_PHPNAME, $indexType)];
+            $col = $row[TableMap::TYPE_NUM == $indexType ? 8 + $startcol : SpecialOfferTableMap::translateFieldName('StartDate', TableMap::TYPE_PHPNAME, $indexType)];
             if ($col === '0000-00-00 00:00:00') {
                 $col = null;
             }
             $this->start_date = (null !== $col) ? PropelDateTime::newInstance($col, null, 'DateTime') : null;
 
-            $col = $row[TableMap::TYPE_NUM == $indexType ? 8 + $startcol : SpecialOfferTableMap::translateFieldName('EndDate', TableMap::TYPE_PHPNAME, $indexType)];
+            $col = $row[TableMap::TYPE_NUM == $indexType ? 9 + $startcol : SpecialOfferTableMap::translateFieldName('EndDate', TableMap::TYPE_PHPNAME, $indexType)];
             if ($col === '0000-00-00 00:00:00') {
                 $col = null;
             }
             $this->end_date = (null !== $col) ? PropelDateTime::newInstance($col, null, 'DateTime') : null;
 
-            $col = $row[TableMap::TYPE_NUM == $indexType ? 9 + $startcol : SpecialOfferTableMap::translateFieldName('CreatedAt', TableMap::TYPE_PHPNAME, $indexType)];
+            $col = $row[TableMap::TYPE_NUM == $indexType ? 10 + $startcol : SpecialOfferTableMap::translateFieldName('CreatedAt', TableMap::TYPE_PHPNAME, $indexType)];
             if ($col === '0000-00-00 00:00:00') {
                 $col = null;
             }
             $this->created_at = (null !== $col) ? PropelDateTime::newInstance($col, null, 'DateTime') : null;
 
-            $col = $row[TableMap::TYPE_NUM == $indexType ? 10 + $startcol : SpecialOfferTableMap::translateFieldName('UpdatedAt', TableMap::TYPE_PHPNAME, $indexType)];
+            $col = $row[TableMap::TYPE_NUM == $indexType ? 11 + $startcol : SpecialOfferTableMap::translateFieldName('UpdatedAt', TableMap::TYPE_PHPNAME, $indexType)];
             if ($col === '0000-00-00 00:00:00') {
                 $col = null;
             }
@@ -873,7 +913,7 @@ abstract class SpecialOffer implements ActiveRecordInterface
                 $this->ensureConsistency();
             }
 
-            return $startcol + 11; // 11 = SpecialOfferTableMap::NUM_HYDRATE_COLUMNS.
+            return $startcol + 12; // 12 = SpecialOfferTableMap::NUM_HYDRATE_COLUMNS.
 
         } catch (Exception $e) {
             throw new PropelException(sprintf('Error populating %s object', '\\Model\\SpecialOffer'), 0, $e);
@@ -1144,6 +1184,9 @@ abstract class SpecialOffer implements ActiveRecordInterface
         if ($this->isColumnModified(SpecialOfferTableMap::COL_TARGET_QUANTITY)) {
             $modifiedColumns[':p' . $index++]  = 'target_quantity';
         }
+        if ($this->isColumnModified(SpecialOfferTableMap::COL_TARGET_AMOUNT)) {
+            $modifiedColumns[':p' . $index++]  = 'target_amount';
+        }
         if ($this->isColumnModified(SpecialOfferTableMap::COL_FREE_ARTICLE_ID)) {
             $modifiedColumns[':p' . $index++]  = 'free_article_id';
         }
@@ -1192,6 +1235,10 @@ abstract class SpecialOffer implements ActiveRecordInterface
                         break;
                     case 'target_quantity':
                         $stmt->bindValue($identifier, $this->target_quantity, PDO::PARAM_INT);
+
+                        break;
+                    case 'target_amount':
+                        $stmt->bindValue($identifier, $this->target_amount, PDO::PARAM_INT);
 
                         break;
                     case 'free_article_id':
@@ -1295,18 +1342,21 @@ abstract class SpecialOffer implements ActiveRecordInterface
                 return $this->getTargetQuantity();
 
             case 6:
-                return $this->getFreeArticleId();
+                return $this->getTargetAmount();
 
             case 7:
-                return $this->getStartDate();
+                return $this->getFreeArticleId();
 
             case 8:
-                return $this->getEndDate();
+                return $this->getStartDate();
 
             case 9:
-                return $this->getCreatedAt();
+                return $this->getEndDate();
 
             case 10:
+                return $this->getCreatedAt();
+
+            case 11:
                 return $this->getUpdatedAt();
 
             default:
@@ -1343,16 +1393,13 @@ abstract class SpecialOffer implements ActiveRecordInterface
             $keys[3] => $this->getDescription(),
             $keys[4] => $this->getTargetCollectionId(),
             $keys[5] => $this->getTargetQuantity(),
-            $keys[6] => $this->getFreeArticleId(),
-            $keys[7] => $this->getStartDate(),
-            $keys[8] => $this->getEndDate(),
-            $keys[9] => $this->getCreatedAt(),
-            $keys[10] => $this->getUpdatedAt(),
+            $keys[6] => $this->getTargetAmount(),
+            $keys[7] => $this->getFreeArticleId(),
+            $keys[8] => $this->getStartDate(),
+            $keys[9] => $this->getEndDate(),
+            $keys[10] => $this->getCreatedAt(),
+            $keys[11] => $this->getUpdatedAt(),
         ];
-        if ($result[$keys[7]] instanceof \DateTimeInterface) {
-            $result[$keys[7]] = $result[$keys[7]]->format('Y-m-d H:i:s.u');
-        }
-
         if ($result[$keys[8]] instanceof \DateTimeInterface) {
             $result[$keys[8]] = $result[$keys[8]]->format('Y-m-d H:i:s.u');
         }
@@ -1363,6 +1410,10 @@ abstract class SpecialOffer implements ActiveRecordInterface
 
         if ($result[$keys[10]] instanceof \DateTimeInterface) {
             $result[$keys[10]] = $result[$keys[10]]->format('Y-m-d H:i:s.u');
+        }
+
+        if ($result[$keys[11]] instanceof \DateTimeInterface) {
+            $result[$keys[11]] = $result[$keys[11]]->format('Y-m-d H:i:s.u');
         }
 
         $virtualColumns = $this->virtualColumns;
@@ -1471,18 +1522,21 @@ abstract class SpecialOffer implements ActiveRecordInterface
                 $this->setTargetQuantity($value);
                 break;
             case 6:
-                $this->setFreeArticleId($value);
+                $this->setTargetAmount($value);
                 break;
             case 7:
-                $this->setStartDate($value);
+                $this->setFreeArticleId($value);
                 break;
             case 8:
-                $this->setEndDate($value);
+                $this->setStartDate($value);
                 break;
             case 9:
-                $this->setCreatedAt($value);
+                $this->setEndDate($value);
                 break;
             case 10:
+                $this->setCreatedAt($value);
+                break;
+            case 11:
                 $this->setUpdatedAt($value);
                 break;
         } // switch()
@@ -1530,19 +1584,22 @@ abstract class SpecialOffer implements ActiveRecordInterface
             $this->setTargetQuantity($arr[$keys[5]]);
         }
         if (array_key_exists($keys[6], $arr)) {
-            $this->setFreeArticleId($arr[$keys[6]]);
+            $this->setTargetAmount($arr[$keys[6]]);
         }
         if (array_key_exists($keys[7], $arr)) {
-            $this->setStartDate($arr[$keys[7]]);
+            $this->setFreeArticleId($arr[$keys[7]]);
         }
         if (array_key_exists($keys[8], $arr)) {
-            $this->setEndDate($arr[$keys[8]]);
+            $this->setStartDate($arr[$keys[8]]);
         }
         if (array_key_exists($keys[9], $arr)) {
-            $this->setCreatedAt($arr[$keys[9]]);
+            $this->setEndDate($arr[$keys[9]]);
         }
         if (array_key_exists($keys[10], $arr)) {
-            $this->setUpdatedAt($arr[$keys[10]]);
+            $this->setCreatedAt($arr[$keys[10]]);
+        }
+        if (array_key_exists($keys[11], $arr)) {
+            $this->setUpdatedAt($arr[$keys[11]]);
         }
 
         return $this;
@@ -1604,6 +1661,9 @@ abstract class SpecialOffer implements ActiveRecordInterface
         }
         if ($this->isColumnModified(SpecialOfferTableMap::COL_TARGET_QUANTITY)) {
             $criteria->add(SpecialOfferTableMap::COL_TARGET_QUANTITY, $this->target_quantity);
+        }
+        if ($this->isColumnModified(SpecialOfferTableMap::COL_TARGET_AMOUNT)) {
+            $criteria->add(SpecialOfferTableMap::COL_TARGET_AMOUNT, $this->target_amount);
         }
         if ($this->isColumnModified(SpecialOfferTableMap::COL_FREE_ARTICLE_ID)) {
             $criteria->add(SpecialOfferTableMap::COL_FREE_ARTICLE_ID, $this->free_article_id);
@@ -1713,6 +1773,7 @@ abstract class SpecialOffer implements ActiveRecordInterface
         $copyObj->setDescription($this->getDescription());
         $copyObj->setTargetCollectionId($this->getTargetCollectionId());
         $copyObj->setTargetQuantity($this->getTargetQuantity());
+        $copyObj->setTargetAmount($this->getTargetAmount());
         $copyObj->setFreeArticleId($this->getFreeArticleId());
         $copyObj->setStartDate($this->getStartDate());
         $copyObj->setEndDate($this->getEndDate());
@@ -1923,6 +1984,7 @@ abstract class SpecialOffer implements ActiveRecordInterface
         $this->description = null;
         $this->target_collection_id = null;
         $this->target_quantity = null;
+        $this->target_amount = null;
         $this->free_article_id = null;
         $this->start_date = null;
         $this->end_date = null;

--- a/src/Model/Cart.php
+++ b/src/Model/Cart.php
@@ -84,4 +84,18 @@ class Cart extends BaseCart
     {
         return $this->getPhysicalArticleCount();
     }
+
+    /**
+     * @throws PropelException
+     */
+    public function getSubtotal(): int
+    {
+        $stocks = StockQuery::create()
+            ->filterByCart($this)
+            ->find();
+
+        return array_reduce($stocks->getArrayCopy(), function (int $total, Stock $stock) {
+            return $total + $stock->getSellingPrice();
+        }, 0);
+    }
 }

--- a/src/Model/Map/SpecialOfferTableMap.php
+++ b/src/Model/Map/SpecialOfferTableMap.php
@@ -63,7 +63,7 @@ class SpecialOfferTableMap extends TableMap
     /**
      * The total number of columns
      */
-    public const NUM_COLUMNS = 11;
+    public const NUM_COLUMNS = 12;
 
     /**
      * The number of lazy-loaded columns
@@ -73,7 +73,7 @@ class SpecialOfferTableMap extends TableMap
     /**
      * The number of columns to hydrate (NUM_COLUMNS - NUM_LAZY_LOAD_COLUMNS)
      */
-    public const NUM_HYDRATE_COLUMNS = 11;
+    public const NUM_HYDRATE_COLUMNS = 12;
 
     /**
      * the column name for the id field
@@ -104,6 +104,11 @@ class SpecialOfferTableMap extends TableMap
      * the column name for the target_quantity field
      */
     public const COL_TARGET_QUANTITY = 'special_offers.target_quantity';
+
+    /**
+     * the column name for the target_amount field
+     */
+    public const COL_TARGET_AMOUNT = 'special_offers.target_amount';
 
     /**
      * the column name for the free_article_id field
@@ -144,11 +149,11 @@ class SpecialOfferTableMap extends TableMap
      * @var array<string, mixed>
      */
     protected static $fieldNames = [
-        self::TYPE_PHPNAME       => ['Id', 'SiteId', 'Name', 'Description', 'TargetCollectionId', 'TargetQuantity', 'FreeArticleId', 'StartDate', 'EndDate', 'CreatedAt', 'UpdatedAt', ],
-        self::TYPE_CAMELNAME     => ['id', 'siteId', 'name', 'description', 'targetCollectionId', 'targetQuantity', 'freeArticleId', 'startDate', 'endDate', 'createdAt', 'updatedAt', ],
-        self::TYPE_COLNAME       => [SpecialOfferTableMap::COL_ID, SpecialOfferTableMap::COL_SITE_ID, SpecialOfferTableMap::COL_NAME, SpecialOfferTableMap::COL_DESCRIPTION, SpecialOfferTableMap::COL_TARGET_COLLECTION_ID, SpecialOfferTableMap::COL_TARGET_QUANTITY, SpecialOfferTableMap::COL_FREE_ARTICLE_ID, SpecialOfferTableMap::COL_START_DATE, SpecialOfferTableMap::COL_END_DATE, SpecialOfferTableMap::COL_CREATED_AT, SpecialOfferTableMap::COL_UPDATED_AT, ],
-        self::TYPE_FIELDNAME     => ['id', 'site_id', 'name', 'description', 'target_collection_id', 'target_quantity', 'free_article_id', 'start_date', 'end_date', 'created_at', 'updated_at', ],
-        self::TYPE_NUM           => [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, ]
+        self::TYPE_PHPNAME       => ['Id', 'SiteId', 'Name', 'Description', 'TargetCollectionId', 'TargetQuantity', 'TargetAmount', 'FreeArticleId', 'StartDate', 'EndDate', 'CreatedAt', 'UpdatedAt', ],
+        self::TYPE_CAMELNAME     => ['id', 'siteId', 'name', 'description', 'targetCollectionId', 'targetQuantity', 'targetAmount', 'freeArticleId', 'startDate', 'endDate', 'createdAt', 'updatedAt', ],
+        self::TYPE_COLNAME       => [SpecialOfferTableMap::COL_ID, SpecialOfferTableMap::COL_SITE_ID, SpecialOfferTableMap::COL_NAME, SpecialOfferTableMap::COL_DESCRIPTION, SpecialOfferTableMap::COL_TARGET_COLLECTION_ID, SpecialOfferTableMap::COL_TARGET_QUANTITY, SpecialOfferTableMap::COL_TARGET_AMOUNT, SpecialOfferTableMap::COL_FREE_ARTICLE_ID, SpecialOfferTableMap::COL_START_DATE, SpecialOfferTableMap::COL_END_DATE, SpecialOfferTableMap::COL_CREATED_AT, SpecialOfferTableMap::COL_UPDATED_AT, ],
+        self::TYPE_FIELDNAME     => ['id', 'site_id', 'name', 'description', 'target_collection_id', 'target_quantity', 'target_amount', 'free_article_id', 'start_date', 'end_date', 'created_at', 'updated_at', ],
+        self::TYPE_NUM           => [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, ]
     ];
 
     /**
@@ -160,11 +165,11 @@ class SpecialOfferTableMap extends TableMap
      * @var array<string, mixed>
      */
     protected static $fieldKeys = [
-        self::TYPE_PHPNAME       => ['Id' => 0, 'SiteId' => 1, 'Name' => 2, 'Description' => 3, 'TargetCollectionId' => 4, 'TargetQuantity' => 5, 'FreeArticleId' => 6, 'StartDate' => 7, 'EndDate' => 8, 'CreatedAt' => 9, 'UpdatedAt' => 10, ],
-        self::TYPE_CAMELNAME     => ['id' => 0, 'siteId' => 1, 'name' => 2, 'description' => 3, 'targetCollectionId' => 4, 'targetQuantity' => 5, 'freeArticleId' => 6, 'startDate' => 7, 'endDate' => 8, 'createdAt' => 9, 'updatedAt' => 10, ],
-        self::TYPE_COLNAME       => [SpecialOfferTableMap::COL_ID => 0, SpecialOfferTableMap::COL_SITE_ID => 1, SpecialOfferTableMap::COL_NAME => 2, SpecialOfferTableMap::COL_DESCRIPTION => 3, SpecialOfferTableMap::COL_TARGET_COLLECTION_ID => 4, SpecialOfferTableMap::COL_TARGET_QUANTITY => 5, SpecialOfferTableMap::COL_FREE_ARTICLE_ID => 6, SpecialOfferTableMap::COL_START_DATE => 7, SpecialOfferTableMap::COL_END_DATE => 8, SpecialOfferTableMap::COL_CREATED_AT => 9, SpecialOfferTableMap::COL_UPDATED_AT => 10, ],
-        self::TYPE_FIELDNAME     => ['id' => 0, 'site_id' => 1, 'name' => 2, 'description' => 3, 'target_collection_id' => 4, 'target_quantity' => 5, 'free_article_id' => 6, 'start_date' => 7, 'end_date' => 8, 'created_at' => 9, 'updated_at' => 10, ],
-        self::TYPE_NUM           => [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, ]
+        self::TYPE_PHPNAME       => ['Id' => 0, 'SiteId' => 1, 'Name' => 2, 'Description' => 3, 'TargetCollectionId' => 4, 'TargetQuantity' => 5, 'TargetAmount' => 6, 'FreeArticleId' => 7, 'StartDate' => 8, 'EndDate' => 9, 'CreatedAt' => 10, 'UpdatedAt' => 11, ],
+        self::TYPE_CAMELNAME     => ['id' => 0, 'siteId' => 1, 'name' => 2, 'description' => 3, 'targetCollectionId' => 4, 'targetQuantity' => 5, 'targetAmount' => 6, 'freeArticleId' => 7, 'startDate' => 8, 'endDate' => 9, 'createdAt' => 10, 'updatedAt' => 11, ],
+        self::TYPE_COLNAME       => [SpecialOfferTableMap::COL_ID => 0, SpecialOfferTableMap::COL_SITE_ID => 1, SpecialOfferTableMap::COL_NAME => 2, SpecialOfferTableMap::COL_DESCRIPTION => 3, SpecialOfferTableMap::COL_TARGET_COLLECTION_ID => 4, SpecialOfferTableMap::COL_TARGET_QUANTITY => 5, SpecialOfferTableMap::COL_TARGET_AMOUNT => 6, SpecialOfferTableMap::COL_FREE_ARTICLE_ID => 7, SpecialOfferTableMap::COL_START_DATE => 8, SpecialOfferTableMap::COL_END_DATE => 9, SpecialOfferTableMap::COL_CREATED_AT => 10, SpecialOfferTableMap::COL_UPDATED_AT => 11, ],
+        self::TYPE_FIELDNAME     => ['id' => 0, 'site_id' => 1, 'name' => 2, 'description' => 3, 'target_collection_id' => 4, 'target_quantity' => 5, 'target_amount' => 6, 'free_article_id' => 7, 'start_date' => 8, 'end_date' => 9, 'created_at' => 10, 'updated_at' => 11, ],
+        self::TYPE_NUM           => [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, ]
     ];
 
     /**
@@ -218,6 +223,14 @@ class SpecialOfferTableMap extends TableMap
         'COL_TARGET_QUANTITY' => 'TARGET_QUANTITY',
         'target_quantity' => 'TARGET_QUANTITY',
         'special_offers.target_quantity' => 'TARGET_QUANTITY',
+        'TargetAmount' => 'TARGET_AMOUNT',
+        'SpecialOffer.TargetAmount' => 'TARGET_AMOUNT',
+        'targetAmount' => 'TARGET_AMOUNT',
+        'specialOffer.targetAmount' => 'TARGET_AMOUNT',
+        'SpecialOfferTableMap::COL_TARGET_AMOUNT' => 'TARGET_AMOUNT',
+        'COL_TARGET_AMOUNT' => 'TARGET_AMOUNT',
+        'target_amount' => 'TARGET_AMOUNT',
+        'special_offers.target_amount' => 'TARGET_AMOUNT',
         'FreeArticleId' => 'FREE_ARTICLE_ID',
         'SpecialOffer.FreeArticleId' => 'FREE_ARTICLE_ID',
         'freeArticleId' => 'FREE_ARTICLE_ID',
@@ -281,8 +294,9 @@ class SpecialOfferTableMap extends TableMap
         $this->addForeignKey('site_id', 'SiteId', 'INTEGER', 'sites', 'site_id', false, null, null);
         $this->addColumn('name', 'Name', 'VARCHAR', true, 128, null);
         $this->addColumn('description', 'Description', 'LONGVARCHAR', false, null, null);
-        $this->addForeignKey('target_collection_id', 'TargetCollectionId', 'INTEGER', 'collections', 'collection_id', true, null, null);
-        $this->addColumn('target_quantity', 'TargetQuantity', 'INTEGER', true, null, null);
+        $this->addForeignKey('target_collection_id', 'TargetCollectionId', 'INTEGER', 'collections', 'collection_id', false, null, null);
+        $this->addColumn('target_quantity', 'TargetQuantity', 'INTEGER', false, null, null);
+        $this->addColumn('target_amount', 'TargetAmount', 'INTEGER', false, null, null);
         $this->addForeignKey('free_article_id', 'FreeArticleId', 'INTEGER', 'articles', 'article_id', true, null, null);
         $this->addColumn('start_date', 'StartDate', 'TIMESTAMP', true, null, null);
         $this->addColumn('end_date', 'EndDate', 'TIMESTAMP', true, null, null);
@@ -481,6 +495,7 @@ class SpecialOfferTableMap extends TableMap
             $criteria->addSelectColumn(SpecialOfferTableMap::COL_DESCRIPTION);
             $criteria->addSelectColumn(SpecialOfferTableMap::COL_TARGET_COLLECTION_ID);
             $criteria->addSelectColumn(SpecialOfferTableMap::COL_TARGET_QUANTITY);
+            $criteria->addSelectColumn(SpecialOfferTableMap::COL_TARGET_AMOUNT);
             $criteria->addSelectColumn(SpecialOfferTableMap::COL_FREE_ARTICLE_ID);
             $criteria->addSelectColumn(SpecialOfferTableMap::COL_START_DATE);
             $criteria->addSelectColumn(SpecialOfferTableMap::COL_END_DATE);
@@ -493,6 +508,7 @@ class SpecialOfferTableMap extends TableMap
             $criteria->addSelectColumn($alias . '.description');
             $criteria->addSelectColumn($alias . '.target_collection_id');
             $criteria->addSelectColumn($alias . '.target_quantity');
+            $criteria->addSelectColumn($alias . '.target_amount');
             $criteria->addSelectColumn($alias . '.free_article_id');
             $criteria->addSelectColumn($alias . '.start_date');
             $criteria->addSelectColumn($alias . '.end_date');
@@ -522,6 +538,7 @@ class SpecialOfferTableMap extends TableMap
             $criteria->removeSelectColumn(SpecialOfferTableMap::COL_DESCRIPTION);
             $criteria->removeSelectColumn(SpecialOfferTableMap::COL_TARGET_COLLECTION_ID);
             $criteria->removeSelectColumn(SpecialOfferTableMap::COL_TARGET_QUANTITY);
+            $criteria->removeSelectColumn(SpecialOfferTableMap::COL_TARGET_AMOUNT);
             $criteria->removeSelectColumn(SpecialOfferTableMap::COL_FREE_ARTICLE_ID);
             $criteria->removeSelectColumn(SpecialOfferTableMap::COL_START_DATE);
             $criteria->removeSelectColumn(SpecialOfferTableMap::COL_END_DATE);
@@ -534,6 +551,7 @@ class SpecialOfferTableMap extends TableMap
             $criteria->removeSelectColumn($alias . '.description');
             $criteria->removeSelectColumn($alias . '.target_collection_id');
             $criteria->removeSelectColumn($alias . '.target_quantity');
+            $criteria->removeSelectColumn($alias . '.target_amount');
             $criteria->removeSelectColumn($alias . '.free_article_id');
             $criteria->removeSelectColumn($alias . '.start_date');
             $criteria->removeSelectColumn($alias . '.end_date');

--- a/tests/AppBundle/Controller/SpecialOfferControllerTest.php
+++ b/tests/AppBundle/Controller/SpecialOfferControllerTest.php
@@ -234,6 +234,7 @@ class SpecialOfferControllerTest extends TestCase
         $request->request->set("description", "Description de la nouvelle offre");
         $request->request->set("start_date", "2021-01-01");
         $request->request->set("end_date", "2021-01-31");
+        $request->request->set("target_quantity_enabled", "1");
         $request->request->set("target_quantity", "3");
         $request->request->set("target_collection_id", "999");
         $request->request->set("free_article_id", "9999");
@@ -255,7 +256,116 @@ class SpecialOfferControllerTest extends TestCase
         $this->assertEquals("Description de la nouvelle offre", $offer->getDescription());
         $this->assertEquals("2021-01-01", $offer->getStartDate()->format("Y-m-d"));
         $this->assertEquals("2021-01-31", $offer->getEndDate()->format("Y-m-d"));
+        $this->assertEquals(3, $offer->getTargetQuantity());
         $this->assertEquals(999, $offer->getTargetCollectionId());
+        $this->assertNull($offer->getTargetAmount());
         $this->assertEquals(9999, $offer->getFreeArticleId());
+    }
+
+    /**
+     * @throws PropelException
+     */
+    public function testUpdateActionUpdatesOfferWithAmountConditionOnly(): void
+    {
+        // given
+        $specialOfferController = new SpecialOfferController();
+
+        $site = ModelFactory::createSite();
+        $offer = ModelFactory::createSpecialOffer(
+            name: "Super offre", targetCollection: null, targetQuantity: null, targetAmount: 1000,
+        );
+
+        $request = new Request();
+        $currentSite = Mockery::mock(CurrentSite::class);
+
+        $currentUser = Mockery::mock(CurrentUser::class);
+        $currentUser->shouldReceive("authAdmin")->andReturn();
+        $flashBag = Mockery::mock(FlashBag::class);
+        $flashBag->shouldReceive("add")
+            ->with("success", "Offre spéciale « Nouvelle offre » mise à jour avec succès")
+            ->andReturn();
+        $session = Mockery::mock(Session::class);
+        $session->shouldReceive("getFlashBag")
+            ->andReturn($flashBag);
+        $urlGenerator = Mockery::mock(UrlGenerator::class);
+        $urlGenerator->shouldReceive("generate")
+            ->with("special_offer_edit", ["id" => $offer->getId()])
+            ->andReturn("/special_offer_edit");
+
+        // when
+        $request->request->set("name", "Nouvelle offre");
+        $request->request->set("description", "Description de la nouvelle offre");
+        $request->request->set("start_date", "2021-01-01");
+        $request->request->set("end_date", "2021-01-31");
+        $request->request->set("target_amount_enabled", "1");
+        $request->request->set("target_amount", "30");
+        $request->request->set("free_article_id", "9999");
+        $response = $specialOfferController->updateAction(
+            $request,
+            $currentSite,
+            $currentUser,
+            $session,
+            $urlGenerator,
+            id: $offer->getId()
+        );
+
+        // then
+        $this->assertEquals(302, $response->getStatusCode());
+
+        $offer->reload();
+        $this->assertEquals(3000, $offer->getTargetAmount());
+        $this->assertNull($offer->getTargetQuantity());
+        $this->assertNull($offer->getTargetCollectionId());
+    }
+
+    /**
+     * @throws PropelException
+     */
+    public function testUpdateActionRejectsWhenNoConditionIsEnabled(): void
+    {
+        // given
+        $specialOfferController = new SpecialOfferController();
+
+        $site = ModelFactory::createSite();
+        $offer = ModelFactory::createSpecialOffer(name: "Super offre");
+
+        $request = new Request();
+        $currentSite = Mockery::mock(CurrentSite::class);
+
+        $currentUser = Mockery::mock(CurrentUser::class);
+        $currentUser->shouldReceive("authAdmin")->andReturn();
+        $flashBag = Mockery::mock(FlashBag::class);
+        $flashBag->shouldReceive("add")
+            ->with("error", "Vous devez activer au moins une condition (montant ou quantité).")
+            ->andReturn();
+        $session = Mockery::mock(Session::class);
+        $session->shouldReceive("getFlashBag")
+            ->andReturn($flashBag);
+        $urlGenerator = Mockery::mock(UrlGenerator::class);
+        $urlGenerator->shouldReceive("generate")
+            ->with("special_offer_edit", ["id" => $offer->getId()])
+            ->andReturn("/special_offer_edit");
+
+        // when
+        $request->request->set("name", "Nouvelle offre");
+        $request->request->set("description", "Description de la nouvelle offre");
+        $request->request->set("start_date", "2021-01-01");
+        $request->request->set("end_date", "2021-01-31");
+        $request->request->set("free_article_id", "9999");
+        $response = $specialOfferController->updateAction(
+            $request,
+            $currentSite,
+            $currentUser,
+            $session,
+            $urlGenerator,
+            id: $offer->getId()
+        );
+
+        // then
+        $this->assertEquals(302, $response->getStatusCode());
+        $this->assertEquals("/special_offer_edit", $response->getTargetUrl());
+
+        $offer->reload();
+        $this->assertEquals("Super offre", $offer->getName(), "offer must not be updated");
     }
 }

--- a/tests/Biblys/Legacy/CartHelpersTest.php
+++ b/tests/Biblys/Legacy/CartHelpersTest.php
@@ -64,6 +64,7 @@ class CartHelpersTest extends TestCase
             $imageServices,
             $templateService,
             ModelFactory::createCart(),
+            0,
         );
 
         // then
@@ -99,6 +100,7 @@ class CartHelpersTest extends TestCase
             $imageServices,
             $templateService,
             ModelFactory::createCart(),
+            0,
         );
 
         // then
@@ -134,6 +136,7 @@ class CartHelpersTest extends TestCase
             $imageServices,
             $templateService,
             ModelFactory::createCart(),
+            0,
         );
 
         // then
@@ -173,13 +176,14 @@ class CartHelpersTest extends TestCase
             $imageServices,
             $templateService,
             $cart,
+            0,
         );
 
         // then
         $this->assertStringContainsString("Cékado", $notice);
-        $this->assertStringContainsString("Offert pour 2 titres de la", $notice);
         $this->assertStringContainsString("Collection cible", $notice);
-        $this->assertStringContainsString("Ajoutez encore 2 titres", $notice);
+        $this->assertStringContainsString('<li class="text-info">', $notice);
+        $this->assertStringContainsString("Ajoutez encore 2 titres de la collection", $notice);
         $this->assertStringContainsString(
             '<button class="btn btn-outline-secondary" disabled>Ajouter au panier</button>',
             $notice
@@ -227,6 +231,7 @@ class CartHelpersTest extends TestCase
             $imageServices,
             $templateService,
             $cart,
+            0,
         );
 
         // then
@@ -274,12 +279,15 @@ class CartHelpersTest extends TestCase
             $imageServices,
             $templateService,
             $cart,
+            0,
         );
 
         // then
         $this->assertStringContainsString("Cékado", $notice);
-        $this->assertStringContainsString("Offert pour 2 titres de la", $notice);
         $this->assertStringContainsString("Collection cible", $notice);
+        $this->assertStringContainsString('<li class="text-success">', $notice);
+        $this->assertStringContainsString("2 titres de la collection", $notice);
+        $this->assertStringContainsString("achetés", $notice);
         $this->assertStringContainsString("Vous pouvez bénéficier de l’offre.", $notice);
         $this->assertStringContainsString('<form method="post" action="/cart_url">', $notice);
         $this->assertStringContainsString(
@@ -326,10 +334,141 @@ class CartHelpersTest extends TestCase
             $imageServices,
             $templateService,
             $cart,
+            0,
         );
 
         // then
         $this->assertStringNotContainsString('Ajouter au panier', $notice);
         $this->assertStringContainsString('Vous bénéficiez de l’offre', $notice);
+    }
+
+    /**
+     * @throws PropelException
+     */
+    public function testGetSpecialOfferNoticeForAmountConditionWhenNotMet()
+    {
+        // given
+        $site = ModelFactory::createSite();
+        $freeArticle = ModelFactory::createArticle(title: "Cékado");
+        ModelFactory::createSpecialOffer(
+            targetCollection: null, targetQuantity: null, targetAmount: 3000,
+            freeArticle: $freeArticle,
+        );
+
+        $cart = ModelFactory::createCart();
+
+        $currentSite = Mockery::mock(CurrentSite::class);
+        $urlGenerator = Mockery::mock(UrlGenerator::class);
+        $imageServices = Mockery::mock(ImagesService::class);
+        $imageServices->expects("imageExistsFor")->andReturn(true);
+        $templateService = Mockery::mock(TemplateService::class);
+        $templateService->expects("render");
+
+        // when
+        $notice = CartHelpers::getSpecialOffersNotice(
+            $currentSite,
+            $urlGenerator,
+            $imageServices,
+            $templateService,
+            $cart,
+            1000,
+        );
+
+        // then
+        $this->assertStringContainsString("Cékado", $notice);
+        $this->assertStringContainsString('<li class="text-info">', $notice);
+        $this->assertStringContainsString("Ajoutez encore 20,00&nbsp;&euro; à votre panier", $notice);
+        $this->assertStringContainsString("minimum 30,00&nbsp;&euro;", $notice);
+        $this->assertStringContainsString(
+            '<button class="btn btn-outline-secondary" disabled>Ajouter au panier</button>',
+            $notice
+        );
+    }
+
+    /**
+     * @throws PropelException
+     */
+    public function testGetSpecialOfferNoticeForAmountConditionWhenMet()
+    {
+        // given
+        $site = ModelFactory::createSite();
+        $freeArticle = ModelFactory::createArticle(title: "Cékado");
+        ModelFactory::createSpecialOffer(
+            targetCollection: null, targetQuantity: null, targetAmount: 3000,
+            freeArticle: $freeArticle,
+        );
+
+        $cart = ModelFactory::createCart();
+
+        $currentSite = Mockery::mock(CurrentSite::class);
+        $urlGenerator = Mockery::mock(UrlGenerator::class);
+        $urlGenerator->shouldReceive("generate")
+            ->with("cart_add_article", ["articleId" => $freeArticle->getId()])
+            ->andReturn("/cart_url");
+        $imageServices = Mockery::mock(ImagesService::class);
+        $imageServices->expects("imageExistsFor")->andReturn(true);
+        $templateService = Mockery::mock(TemplateService::class);
+        $templateService->expects("render");
+
+        // when
+        $notice = CartHelpers::getSpecialOffersNotice(
+            $currentSite,
+            $urlGenerator,
+            $imageServices,
+            $templateService,
+            $cart,
+            3000,
+        );
+
+        // then
+        $this->assertStringContainsString('<li class="text-success">', $notice);
+        $this->assertStringContainsString("30,00&nbsp;&euro; d’achat atteints", $notice);
+        $this->assertStringContainsString("Vous pouvez bénéficier de l’offre.", $notice);
+        $this->assertStringContainsString('<form method="post" action="/cart_url">', $notice);
+    }
+
+    /**
+     * @throws PropelException
+     */
+    public function testGetSpecialOfferNoticeForBothConditionsWhenOnlyAmountIsMet()
+    {
+        // given
+        $site = ModelFactory::createSite();
+        $targetCollection = ModelFactory::createCollection(name: "Collection cible");
+        $freeArticle = ModelFactory::createArticle(title: "Cékado", collection: $targetCollection);
+        ModelFactory::createSpecialOffer(
+            targetCollection: $targetCollection, targetQuantity: 2, targetAmount: 1000,
+            freeArticle: $freeArticle,
+        );
+
+        $cart = ModelFactory::createCart();
+
+        $currentSite = Mockery::mock(CurrentSite::class);
+        $urlGenerator = Mockery::mock(UrlGenerator::class);
+        $urlGenerator->shouldReceive("generate");
+        $imageServices = Mockery::mock(ImagesService::class);
+        $imageServices->expects("imageExistsFor")->andReturn(true);
+        $templateService = Mockery::mock(TemplateService::class);
+        $templateService->expects("render");
+
+        // when
+        $notice = CartHelpers::getSpecialOffersNotice(
+            $currentSite,
+            $urlGenerator,
+            $imageServices,
+            $templateService,
+            $cart,
+            1000,
+        );
+
+        // then
+        $this->assertStringContainsString('<li class="text-success">', $notice, "amount condition is met");
+        $this->assertStringContainsString("10,00&nbsp;&euro; d’achat atteints", $notice);
+        $this->assertStringContainsString('<li class="text-info">', $notice, "quantity condition is not met");
+        $this->assertStringContainsString("Ajoutez encore 2 titres de la collection", $notice);
+        $this->assertStringContainsString(
+            '<button class="btn btn-outline-secondary" disabled>Ajouter au panier</button>',
+            $notice
+        );
     }
 }

--- a/tests/Biblys/Legacy/CartHelpersTest.php
+++ b/tests/Biblys/Legacy/CartHelpersTest.php
@@ -64,7 +64,6 @@ class CartHelpersTest extends TestCase
             $imageServices,
             $templateService,
             ModelFactory::createCart(),
-            0,
         );
 
         // then
@@ -100,7 +99,6 @@ class CartHelpersTest extends TestCase
             $imageServices,
             $templateService,
             ModelFactory::createCart(),
-            0,
         );
 
         // then
@@ -136,7 +134,6 @@ class CartHelpersTest extends TestCase
             $imageServices,
             $templateService,
             ModelFactory::createCart(),
-            0,
         );
 
         // then
@@ -176,7 +173,6 @@ class CartHelpersTest extends TestCase
             $imageServices,
             $templateService,
             $cart,
-            0,
         );
 
         // then
@@ -231,7 +227,6 @@ class CartHelpersTest extends TestCase
             $imageServices,
             $templateService,
             $cart,
-            0,
         );
 
         // then
@@ -279,7 +274,6 @@ class CartHelpersTest extends TestCase
             $imageServices,
             $templateService,
             $cart,
-            0,
         );
 
         // then
@@ -334,7 +328,6 @@ class CartHelpersTest extends TestCase
             $imageServices,
             $templateService,
             $cart,
-            0,
         );
 
         // then
@@ -356,6 +349,7 @@ class CartHelpersTest extends TestCase
         );
 
         $cart = ModelFactory::createCart();
+        ModelFactory::createStockItem(cart: $cart, sellingPrice: 1000);
 
         $currentSite = Mockery::mock(CurrentSite::class);
         $urlGenerator = Mockery::mock(UrlGenerator::class);
@@ -371,7 +365,6 @@ class CartHelpersTest extends TestCase
             $imageServices,
             $templateService,
             $cart,
-            1000,
         );
 
         // then
@@ -399,6 +392,7 @@ class CartHelpersTest extends TestCase
         );
 
         $cart = ModelFactory::createCart();
+        ModelFactory::createStockItem(cart: $cart, sellingPrice: 3000);
 
         $currentSite = Mockery::mock(CurrentSite::class);
         $urlGenerator = Mockery::mock(UrlGenerator::class);
@@ -417,7 +411,6 @@ class CartHelpersTest extends TestCase
             $imageServices,
             $templateService,
             $cart,
-            3000,
         );
 
         // then
@@ -442,6 +435,7 @@ class CartHelpersTest extends TestCase
         );
 
         $cart = ModelFactory::createCart();
+        ModelFactory::createStockItem(cart: $cart, sellingPrice: 1000);
 
         $currentSite = Mockery::mock(CurrentSite::class);
         $urlGenerator = Mockery::mock(UrlGenerator::class);
@@ -458,7 +452,6 @@ class CartHelpersTest extends TestCase
             $imageServices,
             $templateService,
             $cart,
-            1000,
         );
 
         // then

--- a/tests/Biblys/Legacy/OrderDeliveryHelpersTest.php
+++ b/tests/Biblys/Legacy/OrderDeliveryHelpersTest.php
@@ -1017,6 +1017,162 @@ class OrderDeliveryHelpersTest extends TestCase
      * @throws PropelException
      * @throws Exception
      */
+    public function testValidateCartContentWhenSpecialOfferAmountConditionIsNotMet()
+    {
+        // given
+        $site = ModelFactory::createSite();
+        $currentSite = new CurrentSite($site);
+        $cart = ModelFactory::createCart();
+
+        $freeArticle = ModelFactory::createArticle(
+            title: "Cékado",
+            availabilityDilicom: Article::AVAILABILITY_PRIVATELY_PRINTED,
+        );
+        ModelFactory::createStockItem(article: $freeArticle, cart: $cart);
+
+        ModelFactory::createSpecialOffer(
+            name: "Cado",
+            targetCollection: null,
+            targetQuantity: null,
+            targetAmount: 3000,
+            freeArticle: $freeArticle,
+        );
+
+        $article1 = ModelFactory::createArticle();
+        ModelFactory::createStockItem(article: $article1, cart: $cart, sellingPrice: 1000);
+
+        // when
+        $exception = Helpers::runAndCatchException(function() use($currentSite, $cart) {
+            OrderDeliveryHelpers::validateCartContent($currentSite, $cart);
+        });
+
+        // then
+        $this->assertInstanceOf(CartException::class, $exception);
+        $this->assertEquals(
+            "Votre panier ne remplit pas les conditions pour bénéficier de l'offre spéciale Cado.",
+            $exception->getMessage()
+        );
+    }
+
+    /**
+     * @throws PropelException
+     * @throws Exception
+     */
+    public function testValidateCartContentWhenSpecialOfferAmountConditionIsMet()
+    {
+        // given
+        $site = ModelFactory::createSite();
+        $currentSite = new CurrentSite($site);
+        $cart = ModelFactory::createCart();
+
+        $freeArticle = ModelFactory::createArticle(
+            title: "Cékado",
+            availabilityDilicom: Article::AVAILABILITY_PRIVATELY_PRINTED,
+        );
+        ModelFactory::createStockItem(article: $freeArticle, cart: $cart);
+
+        ModelFactory::createSpecialOffer(
+            name: "Cado",
+            targetCollection: null,
+            targetQuantity: null,
+            targetAmount: 3000,
+            freeArticle: $freeArticle,
+        );
+
+        $article1 = ModelFactory::createArticle();
+        ModelFactory::createStockItem(article: $article1, cart: $cart, sellingPrice: 3000);
+
+        // when
+        OrderDeliveryHelpers::validateCartContent($currentSite, $cart);
+
+        // then
+        $this->expectNotToPerformAssertions();
+    }
+
+    /**
+     * @throws PropelException
+     * @throws Exception
+     */
+    public function testValidateCartContentWhenSpecialOfferHasBothConditionsAndOnlyAmountIsMet()
+    {
+        // given
+        $site = ModelFactory::createSite();
+        $currentSite = new CurrentSite($site);
+        $cart = ModelFactory::createCart();
+
+        $targetCollection = ModelFactory::createCollection(name: "Collection cible");
+        $freeArticle = ModelFactory::createArticle(
+            title: "Cékado",
+            collection: $targetCollection,
+            availabilityDilicom: Article::AVAILABILITY_PRIVATELY_PRINTED,
+        );
+        ModelFactory::createStockItem(article: $freeArticle, cart: $cart);
+
+        ModelFactory::createSpecialOffer(
+            name: "Cado",
+            targetCollection: $targetCollection,
+            targetQuantity: 2,
+            targetAmount: 1000,
+            freeArticle: $freeArticle,
+        );
+
+        $article1 = ModelFactory::createArticle(collection: $targetCollection);
+        ModelFactory::createStockItem(article: $article1, cart: $cart, sellingPrice: 1000);
+
+        // when
+        $exception = Helpers::runAndCatchException(function() use($currentSite, $cart) {
+            OrderDeliveryHelpers::validateCartContent($currentSite, $cart);
+        });
+
+        // then
+        $this->assertInstanceOf(CartException::class, $exception);
+        $this->assertEquals(
+            "Votre panier ne remplit pas les conditions pour bénéficier de l'offre spéciale Cado.",
+            $exception->getMessage()
+        );
+    }
+
+    /**
+     * @throws PropelException
+     * @throws Exception
+     */
+    public function testValidateCartContentWhenSpecialOfferHasBothConditionsAndBothAreMet()
+    {
+        // given
+        $site = ModelFactory::createSite();
+        $currentSite = new CurrentSite($site);
+        $cart = ModelFactory::createCart();
+
+        $targetCollection = ModelFactory::createCollection(name: "Collection cible");
+        $freeArticle = ModelFactory::createArticle(
+            title: "Cékado",
+            collection: $targetCollection,
+            availabilityDilicom: Article::AVAILABILITY_PRIVATELY_PRINTED,
+        );
+        ModelFactory::createStockItem(article: $freeArticle, cart: $cart);
+
+        ModelFactory::createSpecialOffer(
+            name: "Cado",
+            targetCollection: $targetCollection,
+            targetQuantity: 1,
+            targetAmount: 1000,
+            freeArticle: $freeArticle,
+        );
+
+        $article1 = ModelFactory::createArticle(collection: $targetCollection);
+        ModelFactory::createStockItem(article: $article1, cart: $cart, sellingPrice: 1000);
+
+        // when
+        OrderDeliveryHelpers::validateCartContent($currentSite, $cart);
+
+        // then
+        $this->expectNotToPerformAssertions();
+    }
+
+    /**
+     * @throws PropelException
+     * @throws Exception
+     */
     public function testValidateCartContentWhenCartIsOk()
     {
         // given

--- a/tests/Biblys/Service/SpecialOffers/SpecialOfferEvaluatorTest.php
+++ b/tests/Biblys/Service/SpecialOffers/SpecialOfferEvaluatorTest.php
@@ -1,0 +1,186 @@
+<?php
+/*
+ * Copyright (C) 2026 Clément Latzarus
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+
+namespace Biblys\Service\SpecialOffers;
+
+use Biblys\Test\ModelFactory;
+use PHPUnit\Framework\TestCase;
+use Propel\Runtime\Exception\PropelException;
+
+require_once __DIR__ . "/../../../setUp.php";
+
+class SpecialOfferEvaluatorTest extends TestCase
+{
+    /**
+     * @throws PropelException
+     */
+    public function testEvaluateWithNoConditionsConfigured()
+    {
+        // given
+        $specialOffer = ModelFactory::createSpecialOffer(targetCollection: null, targetQuantity: null);
+        $cart = ModelFactory::createCart();
+
+        // when
+        $evaluation = SpecialOfferEvaluator::evaluate($specialOffer, $cart);
+
+        // then
+        $this->assertNull($evaluation->amount);
+        $this->assertNull($evaluation->quantity);
+        $this->assertTrue($evaluation->isMet());
+    }
+
+    /**
+     * @throws PropelException
+     */
+    public function testEvaluateAmountConditionNotMet()
+    {
+        // given
+        $specialOffer = ModelFactory::createSpecialOffer(
+            targetCollection: null, targetQuantity: null, targetAmount: 3000,
+        );
+        $cart = ModelFactory::createCart();
+        ModelFactory::createStockItem(cart: $cart, sellingPrice: 1000);
+
+        // when
+        $evaluation = SpecialOfferEvaluator::evaluate($specialOffer, $cart);
+
+        // then
+        $this->assertFalse($evaluation->amount->isMet);
+        $this->assertEquals(3000, $evaluation->amount->target);
+        $this->assertEquals(1000, $evaluation->amount->current);
+        $this->assertNull($evaluation->quantity);
+        $this->assertFalse($evaluation->isMet());
+    }
+
+    /**
+     * @throws PropelException
+     */
+    public function testEvaluateAmountConditionMet()
+    {
+        // given
+        $specialOffer = ModelFactory::createSpecialOffer(
+            targetCollection: null, targetQuantity: null, targetAmount: 3000,
+        );
+        $cart = ModelFactory::createCart();
+        ModelFactory::createStockItem(cart: $cart, sellingPrice: 3000);
+
+        // when
+        $evaluation = SpecialOfferEvaluator::evaluate($specialOffer, $cart);
+
+        // then
+        $this->assertTrue($evaluation->amount->isMet);
+        $this->assertTrue($evaluation->isMet());
+    }
+
+    /**
+     * @throws PropelException
+     */
+    public function testEvaluateQuantityConditionNotMet()
+    {
+        // given
+        $targetCollection = ModelFactory::createCollection();
+        $freeArticle = ModelFactory::createArticle(collection: $targetCollection);
+        $specialOffer = ModelFactory::createSpecialOffer(
+            targetCollection: $targetCollection, targetQuantity: 2, freeArticle: $freeArticle,
+        );
+        $cart = ModelFactory::createCart();
+        $article1 = ModelFactory::createArticle(collection: $targetCollection);
+        ModelFactory::createStockItem(article: $article1, cart: $cart);
+
+        // when
+        $evaluation = SpecialOfferEvaluator::evaluate($specialOffer, $cart);
+
+        // then
+        $this->assertFalse($evaluation->quantity->isMet);
+        $this->assertEquals(2, $evaluation->quantity->target);
+        $this->assertEquals(1, $evaluation->quantity->current);
+        $this->assertNull($evaluation->amount);
+        $this->assertFalse($evaluation->isMet());
+    }
+
+    /**
+     * @throws PropelException
+     */
+    public function testEvaluateQuantityConditionMet()
+    {
+        // given
+        $targetCollection = ModelFactory::createCollection();
+        $freeArticle = ModelFactory::createArticle(collection: $targetCollection);
+        $specialOffer = ModelFactory::createSpecialOffer(
+            targetCollection: $targetCollection, targetQuantity: 2, freeArticle: $freeArticle,
+        );
+        $cart = ModelFactory::createCart();
+        $article1 = ModelFactory::createArticle(collection: $targetCollection);
+        ModelFactory::createStockItem(article: $article1, cart: $cart);
+        $article2 = ModelFactory::createArticle(collection: $targetCollection);
+        ModelFactory::createStockItem(article: $article2, cart: $cart);
+
+        // when
+        $evaluation = SpecialOfferEvaluator::evaluate($specialOffer, $cart);
+
+        // then
+        $this->assertTrue($evaluation->quantity->isMet);
+        $this->assertEquals(2, $evaluation->quantity->current);
+        $this->assertTrue($evaluation->isMet());
+    }
+
+    /**
+     * @throws PropelException
+     */
+    public function testEvaluateQuantityConditionExcludesFreeArticleItselfFromCount()
+    {
+        // given
+        $targetCollection = ModelFactory::createCollection();
+        $freeArticle = ModelFactory::createArticle(collection: $targetCollection);
+        $specialOffer = ModelFactory::createSpecialOffer(
+            targetCollection: $targetCollection, targetQuantity: 1, freeArticle: $freeArticle,
+        );
+        $cart = ModelFactory::createCart();
+        ModelFactory::createStockItem(article: $freeArticle, cart: $cart);
+
+        // when
+        $evaluation = SpecialOfferEvaluator::evaluate($specialOffer, $cart);
+
+        // then
+        $this->assertEquals(0, $evaluation->quantity->current);
+        $this->assertFalse($evaluation->quantity->isMet);
+    }
+
+    /**
+     * @throws PropelException
+     */
+    public function testEvaluateWithBothConditionsAndOnlyOneMet()
+    {
+        // given
+        $targetCollection = ModelFactory::createCollection();
+        $freeArticle = ModelFactory::createArticle(collection: $targetCollection);
+        $specialOffer = ModelFactory::createSpecialOffer(
+            targetCollection: $targetCollection, targetQuantity: 2, targetAmount: 3000, freeArticle: $freeArticle,
+        );
+        $cart = ModelFactory::createCart();
+        ModelFactory::createStockItem(cart: $cart, sellingPrice: 3000);
+
+        // when
+        $evaluation = SpecialOfferEvaluator::evaluate($specialOffer, $cart);
+
+        // then
+        $this->assertTrue($evaluation->amount->isMet);
+        $this->assertFalse($evaluation->quantity->isMet);
+        $this->assertFalse($evaluation->isMet());
+    }
+}

--- a/tests/Model/CartTest.php
+++ b/tests/Model/CartTest.php
@@ -136,4 +136,36 @@ class CartTest extends TestCase
         // then
         $this->assertTrue($contains);
     }
+
+    /**
+     * @throws PropelException
+     */
+    public function testGetSubtotalSumsSellingPricesOfStocksInCart()
+    {
+        // given
+        $cart = ModelFactory::createCart();
+        ModelFactory::createStockItem(cart: $cart, sellingPrice: 1000);
+        ModelFactory::createStockItem(cart: $cart, sellingPrice: 500);
+
+        // when
+        $subtotal = $cart->getSubtotal();
+
+        // then
+        $this->assertEquals(1500, $subtotal);
+    }
+
+    /**
+     * @throws PropelException
+     */
+    public function testGetSubtotalReturnsZeroForEmptyCart()
+    {
+        // given
+        $cart = ModelFactory::createCart();
+
+        // when
+        $subtotal = $cart->getSubtotal();
+
+        // then
+        $this->assertEquals(0, $subtotal);
+    }
 }

--- a/tests/Model/SpecialOfferQueryTest.php
+++ b/tests/Model/SpecialOfferQueryTest.php
@@ -54,4 +54,24 @@ class SpecialOfferQueryTest extends TestCase
         $this->assertNotContains($offerStartingTomorrow, $activeOffers, "ignores future offers");
         $this->assertNotContains($offerEndedYesterday, $activeOffers, "ignores past offers");
     }
+
+    /**
+     * @throws PropelException
+     */
+    public function testTargetAmountIsPersistedAndReloaded()
+    {
+        // given
+        $site = ModelFactory::createSite();
+        $offer = ModelFactory::createSpecialOffer(
+            targetCollection: null, targetQuantity: null, targetAmount: 3000,
+        );
+
+        // when
+        $reloadedOffer = SpecialOfferQuery::create()->findPk($offer->getId());
+
+        // then
+        $this->assertEquals(3000, $reloadedOffer->getTargetAmount());
+        $this->assertNull($reloadedOffer->getTargetCollectionId());
+        $this->assertNull($reloadedOffer->getTargetQuantity());
+    }
 }


### PR DESCRIPTION
## Résumé
- Ajoute une condition « montant minimum de panier (hors frais de port) » aux offres spéciales, combinable en ET avec la condition existante de quantité minimum dans une collection ; au moins l'une des deux doit être activée.
- Le formulaire d'édition d'offre (admin) permet d'activer/désactiver chaque condition indépendamment, avec des phrases à trous plutôt qu'un formulaire classique label/champ.
- La notice affichée dans le panier montre chaque condition distinctement (statut rempli/non rempli), au lieu de les fondre dans une seule phrase.
- Ajoute un padding en bas des pages admin (`main` n'avait qu'une marge en haut).

## Test plan
- [x] `composer test` (suite complète, 1321 tests) au vert
- [x] Vérification visuelle en local (formulaire admin + panier) via navigateur
- [x] Migration Propel appliquée sur la base de test (jamais sur la base de dev)