### PR TITLE
Offres spéciales : simplifier l'affichage de la notice panier avec un template Twig

### DIFF
--- a/src/AppBundle/Resources/views/Cart/_special-offer-notice.html.twig
+++ b/src/AppBundle/Resources/views/Cart/_special-offer-notice.html.twig
@@ -1,0 +1,48 @@
+{#
+Copyright (C) 2026 Clément Latzarus
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, version 3.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#}
+
+<div class="SpecialOfferNotice">
+    <h2 class="SpecialOfferNotice-title">{{ specialOffer.name }}</h2>
+    <div class="SpecialOfferNotice-cover">
+        {{ cover|raw }}
+    </div>
+    <div class="SpecialOfferNotice-infos">
+        <p>
+            <a href="/{{ freeArticleEntity.url }}">{{ freeArticleEntity.title }}</a><br />
+            de {{ freeArticleAuthors|raw }}<br />
+            coll. {{ freeArticleEntity.collection.name }} {{ freeArticleNumero|raw }}<br />
+        </p>
+        <p>
+            <strong>Offert si :</strong>
+            <ul class="SpecialOfferNotice-conditions list-unstyled mb-2">
+                {% for item in conditionItems %}
+                    <li class="{{ item.met ? 'text-success' : 'text-info' }}">
+                        <span class="fa {{ item.met ? 'fa-check-circle' : 'fa-plus-circle' }}"></span> {{ item.label|raw }}
+                    </li>
+                {% endfor %}
+            </ul>
+            {{ amountConditionNote|raw }}
+            <small>{{ statusLine|raw }}</small>
+        </p>
+        {% if cartButtonUrl %}
+            <form method="post" action="{{ cartButtonUrl }}">
+                <button type="submit" class="btn btn-success">Ajouter au panier</button>
+            </form>
+        {% elseif not alreadyInCart %}
+            <button class="btn btn-outline-secondary" disabled>Ajouter au panier</button>
+        {% endif %}
+    </div>
+</div>

--- a/src/Biblys/Legacy/CartHelpers.php
+++ b/src/Biblys/Legacy/CartHelpers.php
@@ -291,32 +291,20 @@ class CartHelpers
         $am = new ArticleManager();
         $freeArticleEntity = $am->getById($freeArticle->getId());
 
-        $conditionsHtml = "";
-        foreach ($conditionItems as $conditionItem) {
-            $icon = $conditionItem["met"] ? "fa-check-circle" : "fa-plus-circle";
-            $class = $conditionItem["met"] ? "text-success" : "text-info";
-            $conditionsHtml .= '<li class="' . $class . '"><span class="fa ' . $icon . '"></span> ' .
-                $conditionItem["label"] . '</li>';
-        }
+        $freeArticleIsInCart = StockQuery::create()
+            ->filterByCart($cart)->findOneByArticleId($freeArticle->getId());
 
-        $statusLine = '';
-        $cartButton = '<button class="btn btn-outline-secondary" disabled>Ajouter au panier</button>';
-
-        if ($evaluation->isMet()) {
+        if ($freeArticleIsInCart) {
+            $statusLine = '<span class="text-success"><span class="fa fa-check-circle"></span> Vous bénéficiez de l’offre.</span>';
+            $cartButtonUrl = null;
+        } elseif ($evaluation->isMet()) {
             $statusLine = '<span class="text-success"><span class="fa fa-check-circle"></span> Vous pouvez bénéficier de l’offre.</span>';
             $cartButtonUrl = $urlGenerator->generate(
                 "cart_add_article", ["articleId" => $freeArticle->getId()]
             );
-            $cartButton = '<form method="post" action="' . $cartButtonUrl . '">';
-            $cartButton .= '<button type="submit" class="btn btn-success">Ajouter au panier</button>';
-            $cartButton .= '</form>';
-        }
-
-        $freeArticleIsInCart = StockQuery::create()
-            ->filterByCart($cart)->findOneByArticleId($freeArticle->getId());
-        if ($freeArticleIsInCart) {
-            $cartButton = "";
-            $statusLine = '<span class="text-success"><span class="fa fa-check-circle"></span> Vous bénéficiez de l’offre.</span>';
+        } else {
+            $statusLine = '';
+            $cartButtonUrl = null;
         }
 
         $cover = null;
@@ -330,28 +318,17 @@ class CartHelpers
             );
         }
 
-        return '
-            <div class="SpecialOfferNotice">
-                <h2 class="SpecialOfferNotice-title">' . $specialOffer->getName() . '</h2>
-                <div class="SpecialOfferNotice-cover">
-                    ' . $cover . '
-                </div>
-                <div class="SpecialOfferNotice-infos">
-                    <p>
-
-                        <a href="/' . $freeArticleEntity->get('url') . '">' . $freeArticleEntity->get('title') . '</a><br />
-                        de ' . authors($freeArticleEntity->get('authors')) . '<br />
-                        coll. ' . $freeArticleEntity->get('collection')->get('name') . ' ' . numero($freeArticleEntity->get('number')) . '<br />
-                    </p>
-                    <p>
-                        <strong>Offert si :</strong>
-                        <ul class="SpecialOfferNotice-conditions list-unstyled mb-2">' . $conditionsHtml . '</ul>
-                        ' . $amountConditionNote . '
-                        <small>' . $statusLine . '</small>
-                    </p>
-                    ' . $cartButton . '
-                </div>
-            </div>
-        ';
+        return $templateService->render("AppBundle:Cart:_special-offer-notice.html.twig", [
+            "specialOffer" => $specialOffer,
+            "freeArticleEntity" => $freeArticleEntity,
+            "freeArticleAuthors" => authors($freeArticleEntity->get('authors')),
+            "freeArticleNumero" => numero($freeArticleEntity->get('number')),
+            "conditionItems" => $conditionItems,
+            "amountConditionNote" => $amountConditionNote,
+            "cover" => $cover,
+            "statusLine" => $statusLine,
+            "cartButtonUrl" => $cartButtonUrl,
+            "alreadyInCart" => (bool) $freeArticleIsInCart,
+        ]);
     }
 }

--- a/tests/Biblys/Legacy/CartHelpersTest.php
+++ b/tests/Biblys/Legacy/CartHelpersTest.php
@@ -20,7 +20,7 @@ namespace Biblys\Legacy;
 
 use Biblys\Service\CurrentSite;
 use Biblys\Service\Images\ImagesService;
-use Biblys\Service\TemplateService;
+use Biblys\Test\Helpers;
 use Biblys\Test\ModelFactory;
 use DateTime;
 use Mockery;
@@ -54,8 +54,7 @@ class CartHelpersTest extends TestCase
         $urlGenerator = Mockery::mock(UrlGenerator::class);
         $imageServices = Mockery::mock(ImagesService::class);
         $imageServices->expects("imageExistsFor")->andReturn(true);
-        $templateService = Mockery::mock(TemplateService::class);
-        $templateService->expects("render");
+        $templateService = Helpers::getTemplateService();
 
         // when
         $notice = CartHelpers::getSpecialOffersNotice(
@@ -89,8 +88,7 @@ class CartHelpersTest extends TestCase
         $urlGenerator = Mockery::mock(UrlGenerator::class);
         $imageServices = Mockery::mock(ImagesService::class);
         $imageServices->expects("imageExistsFor")->andReturn(true);
-        $templateService = Mockery::mock(TemplateService::class);
-        $templateService->expects("render");
+        $templateService = Helpers::getTemplateService();
 
         // when
         $notice = CartHelpers::getSpecialOffersNotice(
@@ -124,8 +122,7 @@ class CartHelpersTest extends TestCase
         $urlGenerator = Mockery::mock(UrlGenerator::class);
         $imageServices = Mockery::mock(ImagesService::class);
         $imageServices->expects("imageExistsFor")->andReturn(true);
-        $templateService = Mockery::mock(TemplateService::class);
-        $templateService->expects("render");
+        $templateService = Helpers::getTemplateService();
 
         // when
         $notice = CartHelpers::getSpecialOffersNotice(
@@ -163,8 +160,7 @@ class CartHelpersTest extends TestCase
         $imageServices = Mockery::mock(ImagesService::class);
         $imageServices->expects("imageExistsFor")->andReturn(true);
         $imageServices->expects("imageExistsFor")->andReturn(true);
-        $templateService = Mockery::mock(TemplateService::class);
-        $templateService->expects("render");
+        $templateService = Helpers::getTemplateService();
 
         // when
         $notice = CartHelpers::getSpecialOffersNotice(
@@ -217,8 +213,7 @@ class CartHelpersTest extends TestCase
         $urlGenerator->shouldReceive("generate");
         $imageServices = Mockery::mock(ImagesService::class);
         $imageServices->expects("imageExistsFor")->andReturn(true);
-        $templateService = Mockery::mock(TemplateService::class);
-        $templateService->expects("render");
+        $templateService = Helpers::getTemplateService();
 
         // when
         $notice = CartHelpers::getSpecialOffersNotice(
@@ -264,8 +259,7 @@ class CartHelpersTest extends TestCase
             ->andReturn("/cart_url");
         $imageServices = Mockery::mock(ImagesService::class);
         $imageServices->expects("imageExistsFor")->andReturn(true);
-        $templateService = Mockery::mock(TemplateService::class);
-        $templateService->expects("render");
+        $templateService = Helpers::getTemplateService();
 
         // when
         $notice = CartHelpers::getSpecialOffersNotice(
@@ -318,8 +312,7 @@ class CartHelpersTest extends TestCase
             ->andReturn("/cart_url");
         $imageServices = Mockery::mock(ImagesService::class);
         $imageServices->expects("imageExistsFor")->andReturn(true);
-        $templateService = Mockery::mock(TemplateService::class);
-        $templateService->expects("render");
+        $templateService = Helpers::getTemplateService();
 
         // when
         $notice = CartHelpers::getSpecialOffersNotice(
@@ -355,8 +348,7 @@ class CartHelpersTest extends TestCase
         $urlGenerator = Mockery::mock(UrlGenerator::class);
         $imageServices = Mockery::mock(ImagesService::class);
         $imageServices->expects("imageExistsFor")->andReturn(true);
-        $templateService = Mockery::mock(TemplateService::class);
-        $templateService->expects("render");
+        $templateService = Helpers::getTemplateService();
 
         // when
         $notice = CartHelpers::getSpecialOffersNotice(
@@ -405,8 +397,7 @@ class CartHelpersTest extends TestCase
             ->andReturn("/cart_url");
         $imageServices = Mockery::mock(ImagesService::class);
         $imageServices->expects("imageExistsFor")->andReturn(true);
-        $templateService = Mockery::mock(TemplateService::class);
-        $templateService->expects("render");
+        $templateService = Helpers::getTemplateService();
 
         // when
         $notice = CartHelpers::getSpecialOffersNotice(
@@ -446,8 +437,7 @@ class CartHelpersTest extends TestCase
         $urlGenerator->shouldReceive("generate");
         $imageServices = Mockery::mock(ImagesService::class);
         $imageServices->expects("imageExistsFor")->andReturn(true);
-        $templateService = Mockery::mock(TemplateService::class);
-        $templateService->expects("render");
+        $templateService = Helpers::getTemplateService();
 
         // when
         $notice = CartHelpers::getSpecialOffersNotice(


### PR DESCRIPTION
## Changes

- La notice d'offre spéciale affichée sur la page panier est désormais rendue via un template Twig (`_special-offer-notice.html.twig`) au lieu d'une construction de chaîne HTML en PHP dans `CartHelpers::_buildSpecialOfferNotice()`
- La logique de décision (évaluation des conditions, libellés, statut, URL du bouton) reste en PHP ; seule la structure HTML de la notice est déplacée dans le template

## Test plan

- [x] Le rendu Twig de la notice produit un HTML équivalent à l'ancienne implémentation (mêmes assertions de test qu'avant le refactoring)
- [x] Suite de tests complète verte (1334 tests)