### PR TITLE
Correctif 3.16.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Historique des modifications
 
+## 3.16.3 (11 septembre 2026)
+
+### Corrections
+
+- La meta description générée dynamiquement par page (article, billet de
+  blog, campagne...) est désormais rendue avec la syntaxe HTML attendue par
+  les moteurs de recherche (`<meta name="description">` au lieu de
+  `<meta property="description">`), qui l'ignoraient jusqu'ici.
+
 ## 3.16.2 (9 septembre 2026)
 
 ### Corrections

--- a/inc/constants.php
+++ b/inc/constants.php
@@ -15,4 +15,4 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-const BIBLYS_VERSION = "3.16.2";
+const BIBLYS_VERSION = "3.16.3";

--- a/src/Biblys/Service/MetaTagsService.php
+++ b/src/Biblys/Service/MetaTagsService.php
@@ -41,7 +41,7 @@ class MetaTagsService
     public function setDescription(string $description): void
     {
         $this->writer->append(Opengraph::OG_DESCRIPTION, $description);
-        $this->writer->append("description", $description);
+        MetaTagsService::$tags[] = "<meta name=\"description\" content=\"$description\" />";
     }
 
     public function setImage(string $url): void

--- a/tests/Biblys/Service/MetaTagsServiceTest.php
+++ b/tests/Biblys/Service/MetaTagsServiceTest.php
@@ -19,7 +19,6 @@
 namespace Biblys\Service;
 
 use Biblys\Test\ModelFactory;
-use Mockery;
 use Opengraph\Writer;
 use PHPUnit\Framework\MockObject\Exception;
 use PHPUnit\Framework\TestCase;
@@ -83,16 +82,21 @@ class MetaTagsServiceTest extends TestCase
         $site = ModelFactory::createSite(domain: "example.org");
         $currentSite = new CurrentSite($site);
 
-        $writer = Mockery::mock(Writer::class);
-        $writer->shouldReceive("append")->with("og:description", "This is a description");
-        $writer->shouldReceive("append")->with("description", "This is a description");
+        $writer = $this->createMock(Writer::class);
+        $writer->expects($this->once())
+            ->method("append")
+            ->with($this->equalTo("og:description"), $this->equalTo("This is a description"));
+        $writer->method("render")->willReturn("");
         $metaTagsService = new MetaTagsService($writer, $currentSite);
 
         // when
         $metaTagsService->setDescription("This is a description");
 
         // then
-        $this->assertTrue(true);
+        $this->assertStringContainsString(
+            '<meta name="description" content="This is a description" />',
+            $metaTagsService->dump()
+        );
     }
 
     /**


### PR DESCRIPTION
## Résumé

- Corrige `MetaTagsService::setDescription()` qui rendait `<meta property="description">` au lieu de `<meta name="description">`, syntaxe non lue par les moteurs de recherche pour l'extrait de résultat.
- Ferme #688.

## Plan de test

- [x] `composer test:path tests/Biblys/Service/MetaTagsServiceTest.php`
- [x] `composer test` (suite complète, 1307 tests, OK)
- [x] Vérifié en prod sur `librairieduvoyageur.com` avant/après déploiement du thème que la balise `og:description` reste correcte